### PR TITLE
Emit error and readiness transition and quorum changes events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,6 @@ on:
     branches: [ main ]
 env:
   kind-version: 'v0.29.0'
-
 permissions:
   contents: read
   statuses: write
@@ -195,6 +194,7 @@ jobs:
   e2e-test:
     needs: [ lint, bundle, build_and_test, helm-validate, helm-test ]
     strategy:
+      fail-fast: false
       matrix:
         scope: [ test-keeper-e2e, test-clickhouse-e2e ]
     runs-on: [self-hosted, func-tester]

--- a/Makefile
+++ b/Makefile
@@ -132,15 +132,15 @@ test-ci: manifests generate fmt vet envtest ## Run tests in CI env.
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e: ## Run all e2e tests.
-	go test ./test/e2e/ -test.timeout 30m
+	go test ./test/e2e/ -test.timeout 30m --ginkgo.v
 
 .PHONY: test-keeper-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-keeper-e2e: ## Run keeper e2e tests.
-	go test ./test/e2e/ --ginkgo.label-filter keeper -test.timeout 30m --ginkgo.junit-report=report/junit-report.xml
+	go test ./test/e2e/ --ginkgo.label-filter keeper -test.timeout 30m --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
 .PHONY: test-clickhouse-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-clickhouse-e2e: ## Run clickhouse e2e tests.
-	go test ./test/e2e/ --ginkgo.label-filter clickhouse -test.timeout 30m --ginkgo.junit-report=report/junit-report.xml
+	go test ./test/e2e/ --ginkgo.label-filter clickhouse -test.timeout 30m --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -265,6 +265,10 @@ func (v *ClickHouseCluster) NamespacedName() types.NamespacedName {
 	}
 }
 
+func (v *ClickHouseCluster) GetStatus() *ClickHouseClusterStatus {
+	return &v.Status
+}
+
 func (v *ClickHouseCluster) Conditions() *[]metav1.Condition {
 	return &v.Status.Conditions
 }

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -46,6 +46,7 @@ const (
 	KeeperConditionReasonNotEnoughFollowers ConditionReason = "NotEnoughFollowers"
 )
 
+// ClickHouseCluster specific condition types and reasons.
 const (
 	// ClickHouseConditionTypeSchemaInSync indicates that databases were created on all new replicas and deleted
 	// replicas metadata was removed. This condition indicates that newly created replicas are ready to use or cluster
@@ -56,6 +57,18 @@ const (
 	ClickHouseConditionReplicasInSync       ConditionReason = "ReplicasInSync"
 	ClickHouseConditionDatabasesNotCreated  ConditionReason = "DatabasesNotCreated"
 	ClickHouseConditionReplicasNotCleanedUp ConditionReason = "ReplicasNotCleanedUp"
+)
+
+// KeeperCluster specific condition types and reasons.
+const (
+	// KeeperConditionTypeScaleAllowed indicates that cluster is ready to change quorum size.
+	KeeperConditionTypeScaleAllowed ConditionType = "ScaleAllowed"
+
+	KeeperConditionReasonReplicaHasPendingChanges ConditionReason = "ReplicaHasPendingChanges"
+	KeeperConditionReasonReplicaNotReady          ConditionReason = "ReplicaNotReady"
+	KeeperConditionReasonNoQuorum                 ConditionReason = "NoQuorum"
+	KeeperConditionReasonWaitingFollowers         ConditionReason = "WaitingFollowers"
+	KeeperConditionReasonReadyToScale             ConditionReason = "ReadyToScale"
 )
 
 var (

--- a/api/v1alpha1/events.go
+++ b/api/v1alpha1/events.go
@@ -4,8 +4,22 @@ type EventReason = string
 
 // Event reasons for owned resources lifecycle events.
 const (
-	EventReasonFailedCreate     EventReason = "FailedCreate"
-	EventReasonFailedUpdate     EventReason = "FailedUpdate"
-	EventReasonSuccessfulDelete EventReason = "SuccessfulDelete"
-	EventReasonFailedDelete     EventReason = "FailedDelete"
+	EventReasonFailedCreate EventReason = "FailedCreate"
+	EventReasonFailedUpdate EventReason = "FailedUpdate"
+	EventReasonFailedDelete EventReason = "FailedDelete"
+)
+
+// Event reasons for horizontal scaling events.
+const (
+	EventReasonReplicaCreated           EventReason = "ReplicaCreated"
+	EventReasonReplicaDeleted           EventReason = "ReplicaDeleted"
+	EventReasonHorizontalScaleBlocked   EventReason = "HorizontalScaleBlocked"
+	EventReasonHorizontalScaleStarted   EventReason = "HorizontalScaleStarted"
+	EventReasonHorizontalScaleCompleted EventReason = "HorizontalScaleCompleted"
+)
+
+// Event reasons for cluster health transitions.
+const (
+	EventReasonClusterReady    EventReason = "ClusterReady"
+	EventReasonClusterNotReady EventReason = "ClusterNotReady"
 )

--- a/api/v1alpha1/keepercluster_types.go
+++ b/api/v1alpha1/keepercluster_types.go
@@ -178,6 +178,10 @@ func (v *KeeperCluster) NamespacedName() types.NamespacedName {
 	}
 }
 
+func (v *KeeperCluster) GetStatus() *KeeperClusterStatus {
+	return &v.Status
+}
+
 func (v *KeeperCluster) Conditions() *[]metav1.Condition {
 	return &v.Status.Conditions
 }

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -419,3 +419,4 @@ defaultUserPassword:
 | `ClusterSizeAligned`      | Cluster have the same amount of replicas as requested.                                         |
 | `ConfigurationInSync`     | Represents Configuration deployment state                                                      |
 | `Ready`                   | KeeperCluster is ready to serve client requests. Leader elected.                               |
+| `ScaleAllowed`            | Represents the operator's ability to add/remove a node in the quorum.                          |

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-zookeeper/zk v1.0.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/onsi/ginkgo/v2 v2.27.3
+	github.com/onsi/ginkgo/v2 v2.27.5
 	github.com/onsi/gomega v1.38.3
 	go.uber.org/zap v1.27.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/onsi/ginkgo/v2 v2.27.3 h1:ICsZJ8JoYafeXFFlFAG75a7CxMsJHwgKwtO+82SE9L8=
-github.com/onsi/ginkgo/v2 v2.27.3/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
+github.com/onsi/ginkgo/v2 v2.27.5 h1:ZeVgZMx2PDMdJm/+w5fE/OyG6ILo1Y3e+QX4zSR0zTE=
+github.com/onsi/ginkgo/v2 v2.27.5/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.3 h1:eTX+W6dobAYfFeGC2PV6RwXRu/MyT+cQguijutvkpSM=
 github.com/onsi/gomega v1.38.3/go.mod h1:ZCU1pkQcXDO5Sl9/VVEGlDyp+zm0m1cmeG5TOzLgdh4=
 github.com/paulmach/orb v0.12.0 h1:z+zOwjmG3MyEEqzv92UN49Lg1JFYx0L9GpGKNVDKk1s=

--- a/internal/controller/clickhouse/config.go
+++ b/internal/controller/clickhouse/config.go
@@ -156,8 +156,6 @@ type baseConfigParams struct {
 
 	KeeperNodes               []keeperNode
 	KeeperIdentityEnv         string
-	ClusterDiscoveryPath      string
-	ShardID                   int32
 	DistributedDDLPath        string
 	DistributedDDLProfileName string
 	UsersXMLPath              string
@@ -225,8 +223,6 @@ func baseConfigGenerator(tmpl *template.Template, ctx *reconcileContext, id v1.C
 
 		KeeperNodes:               keeperNodes,
 		KeeperIdentityEnv:         EnvKeeperIdentity,
-		ClusterDiscoveryPath:      KeeperPathDiscovery,
-		ShardID:                   id.ShardID,
 		DistributedDDLPath:        KeeperPathDistributedDDL,
 		DistributedDDLProfileName: DefaultProfileName,
 		UsersXMLPath:              UsersFileName,

--- a/internal/controller/clickhouse/config_test.go
+++ b/internal/controller/clickhouse/config_test.go
@@ -2,7 +2,6 @@ package clickhouse
 
 import (
 	v1 "github.com/clickhouse-operator/api/v1alpha1"
-	"github.com/clickhouse-operator/internal/controller"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
@@ -13,7 +12,7 @@ import (
 
 var _ = Describe("ConfigGenerator", func() {
 	ctx := reconcileContext{
-		ReconcileContextBase: controller.ReconcileContextBase[*v1.ClickHouseCluster, v1.ClickHouseReplicaID, replicaState]{
+		ReconcileContextBase: ReconcileContextBase{
 			Cluster: &v1.ClickHouseCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",

--- a/internal/controller/clickhouse/constants.go
+++ b/internal/controller/clickhouse/constants.go
@@ -40,7 +40,6 @@ const (
 
 	DefaultClusterName       = "default"
 	KeeperPathUsers          = "/clickhouse/access"
-	KeeperPathDiscovery      = "/clickhouse/discovery/default"
 	KeeperPathUDF            = "/clickhouse/user_defined"
 	KeeperPathDistributedDDL = "/clickhouse/task_queue/ddl"
 

--- a/internal/controller/clickhouse/controller.go
+++ b/internal/controller/clickhouse/controller.go
@@ -34,7 +34,6 @@ type ClusterReconciler struct {
 	Scheme *runtime.Scheme
 
 	Recorder record.EventRecorder
-	Reader   client.Reader // Used to bypass the cache.
 	Logger   util.Logger
 }
 
@@ -112,7 +111,6 @@ func SetupWithManager(mgr ctrl.Manager, log util.Logger) error {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("clickhouse-controller"),
-		Reader:   mgr.GetAPIReader(),
 		Logger:   namedLogger,
 	}
 

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -59,10 +59,8 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 	BeforeAll(func() {
 		suite = testutil.SetupEnvironment(v1.AddToScheme)
 		reconciler = &ClusterReconciler{
-			Client: suite.Client,
-			Scheme: scheme.Scheme,
-
-			Reader:   suite.Client,
+			Client:   suite.Client,
+			Scheme:   scheme.Scheme,
 			Logger:   suite.Log.Named("clickhouse"),
 			Recorder: record.NewFakeRecorder(128),
 		}
@@ -122,6 +120,10 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 
 		Expect(suite.Client.List(suite.Context, &statefulsets, listOpts)).To(Succeed())
 		Expect(statefulsets.Items).To(HaveLen(4))
+
+		testutil.AssertEvents(reconciler.Recorder.(*record.FakeRecorder).Events, map[string]int{
+			"ClusterNotReady": 1,
+		})
 	})
 
 	It("should propagate meta attributes for every resource", func() {

--- a/internal/controller/clickhouse/templates/base.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/base.yaml.tmpl
@@ -19,11 +19,6 @@ zookeeper:
   identity:
     "@from_env": {{ .KeeperIdentityEnv }}
 
-remote_servers:
-  default:
-    discovery:
-      path: {{ .ClusterDiscoveryPath }}
-      shard: {{ .ShardID}}
 distributed_ddl:
   path: {{ .DistributedDDLPath }}
   profile: {{ .DistributedDDLProfileName }}
@@ -39,5 +34,4 @@ openSSL:
 {{ yaml .OpenSSL | indent 2 }}
 
 {{- /* Special settings, required for default config */}}
-allow_experimental_cluster_discovery: true
 display_secrets_in_show_and_select: true

--- a/internal/controller/context.go
+++ b/internal/controller/context.go
@@ -2,21 +2,29 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"reflect"
+	"time"
 
 	v1 "github.com/clickhouse-operator/api/v1alpha1"
 	"github.com/clickhouse-operator/internal/util"
+	gcmp "github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type ClusterObject interface {
-	runtime.Object
+type ClusterObject[Status any] interface {
+	client.Object
 	GetGeneration() int64
 	Conditions() *[]metav1.Condition
+	NamespacedName() types.NamespacedName
+	GetStatus() *Status
 }
 
-type ReconcileContextBase[T ClusterObject, ReplicaKey comparable, ReplicaState any] struct {
+type ReconcileContextBase[S any, T ClusterObject[S], ReplicaKey comparable, ReplicaState any] struct {
 	Cluster T
 	Context context.Context
 
@@ -24,17 +32,17 @@ type ReconcileContextBase[T ClusterObject, ReplicaKey comparable, ReplicaState a
 	ReplicaState map[ReplicaKey]ReplicaState
 }
 
-func (c *ReconcileContextBase[T, K, S]) Replica(key K) S {
+func (c *ReconcileContextBase[Status, T, K, S]) Replica(key K) S {
 	return c.ReplicaState[key]
 }
 
-func (c *ReconcileContextBase[T, K, S]) SetReplica(key K, state S) bool {
+func (c *ReconcileContextBase[Status, T, K, S]) SetReplica(key K, state S) bool {
 	_, exists := c.ReplicaState[key]
 	c.ReplicaState[key] = state
 	return exists
 }
 
-func (c *ReconcileContextBase[T, K, S]) NewCondition(
+func (c *ReconcileContextBase[Status, T, K, S]) NewCondition(
 	condType v1.ConditionType,
 	status metav1.ConditionStatus,
 	reason v1.ConditionReason,
@@ -49,28 +57,127 @@ func (c *ReconcileContextBase[T, K, S]) NewCondition(
 	}
 }
 
-func (c *ReconcileContextBase[T, K, S]) SetConditions(
+func (c *ReconcileContextBase[Status, T, K, S]) SetConditions(
 	log util.Logger,
 	conditions []metav1.Condition,
-) {
+) bool {
 	clusterCond := c.Cluster.Conditions()
 	if *clusterCond == nil {
 		*clusterCond = make([]metav1.Condition, 0, len(conditions))
 	}
 
+	hasChanges := false
 	for _, condition := range conditions {
-		if meta.SetStatusCondition(clusterCond, condition) {
+		if setStatusCondition(clusterCond, condition) {
 			log.Debug("condition changed", "condition", condition.Type, "condition_value", condition.Status)
+			hasChanges = true
 		}
 	}
+
+	return hasChanges
 }
 
-func (c *ReconcileContextBase[T, K, S]) SetCondition(
+func (c *ReconcileContextBase[Status, T, K, S]) SetCondition(
 	log util.Logger,
 	condType v1.ConditionType,
 	status metav1.ConditionStatus,
 	reason v1.ConditionReason,
 	message string,
-) {
-	c.SetConditions(log, []metav1.Condition{c.NewCondition(condType, status, reason, message)})
+) bool {
+	return c.SetConditions(log, []metav1.Condition{c.NewCondition(condType, status, reason, message)})
+}
+
+// UpsertCondition upserts the given condition into the CRD status conditions.
+// Returns true if the condition was changed. Useful to precise detect if condition transition happened.
+func (c *ReconcileContextBase[Status, T, K, S]) UpsertCondition(
+	controller Controller,
+	log util.Logger,
+	condition metav1.Condition,
+) (bool, error) {
+	changed := false
+	crdInstance := c.Cluster.DeepCopyObject().(ClusterObject[Status])
+	setStatusCondition(c.Cluster.Conditions(), condition)
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		cli := controller.GetClient()
+		if err := cli.Get(c.Context, c.Cluster.NamespacedName(), crdInstance); err != nil {
+			return err
+		}
+
+		if changed = setStatusCondition(crdInstance.Conditions(), condition); !changed {
+			log.Debug("condition is up to date", "condition", condition.Type, "condition_value", condition.Status)
+			return nil
+		}
+
+		return cli.Status().Update(c.Context, crdInstance)
+	})
+
+	return changed, err
+}
+
+// UpsertConditionAndSendEvent upserts the given condition into the CRD status conditions.
+// Sends an event if the condition was changed.
+func (c *ReconcileContextBase[Status, T, K, S]) UpsertConditionAndSendEvent(
+	controller Controller,
+	log util.Logger,
+	condition metav1.Condition,
+	eventType string,
+	eventReason v1.EventReason,
+	eventMessageFormat string,
+	eventMessageArgs ...any,
+) (bool, error) {
+	changed, err := c.UpsertCondition(controller, log, condition)
+	if err != nil {
+		return false, err
+	}
+
+	if changed {
+		controller.GetRecorder().Eventf(c.Cluster, eventType, eventReason, eventMessageFormat, eventMessageArgs...)
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *ReconcileContextBase[Status, T, K, S]) UpsertStatus(controller Controller, log util.Logger) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		cli := controller.GetClient()
+		crdInstance := c.Cluster.DeepCopyObject().(ClusterObject[Status])
+		if err := cli.Get(c.Context, c.Cluster.NamespacedName(), crdInstance); err != nil {
+			return err
+		}
+		preStatus := crdInstance.GetStatus()
+
+		if reflect.DeepEqual(*preStatus, *c.Cluster.GetStatus()) {
+			log.Info("statuses are equal, nothing to do")
+			return nil
+		}
+		log.Debug(fmt.Sprintf("status difference:\n%s", gcmp.Diff(*preStatus, *c.Cluster.GetStatus())))
+		*crdInstance.GetStatus() = *c.Cluster.GetStatus()
+		return cli.Status().Update(c.Context, crdInstance)
+	})
+}
+
+// SetStatusCondition sets the given condition in conditions and returns true if the condition was changed.
+// Differs from meta.SetStatusCondition as it checks only Status changes.
+func setStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Condition) bool {
+	if conditions == nil {
+		return false
+	}
+	existingCondition := meta.FindStatusCondition(*conditions, newCondition.Type)
+	if existingCondition == nil {
+		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		*conditions = append(*conditions, newCondition)
+		return true
+	}
+
+	changed := existingCondition.Status != newCondition.Status
+	if changed {
+		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+	} else {
+		newCondition.LastTransitionTime = existingCondition.LastTransitionTime
+	}
+
+	*existingCondition = newCondition
+	return changed
 }

--- a/internal/controller/keeper/controller.go
+++ b/internal/controller/keeper/controller.go
@@ -30,7 +30,6 @@ type ClusterReconciler struct {
 	Scheme *runtime.Scheme
 
 	Recorder record.EventRecorder
-	Reader   client.Reader // Used to bypass the cache.
 	Logger   util.Logger
 }
 
@@ -112,7 +111,6 @@ func SetupWithManager(mgr ctrl.Manager, log util.Logger) error {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("keeper-controller"),
-		Reader:   mgr.GetAPIReader(),
 		Logger:   namedLogger,
 	}
 


### PR DESCRIPTION
## Why

Improve usability by sending events about operator decisions

## What
- Unified status update logic.
- Added Readiness transition events.
- Added keeper quorum membership changes events, and ScaleAllowed condition
- Remove uncached k8s client usage
- Remove cluster discrover as the `default` database provides the same cluster with the same same


