### PR TITLE
Add test reports to the CI. Use ginkgo in all suites for consistency.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,12 @@ on:
 env:
   kind-version: 'v0.29.0'
 
+permissions:
+  contents: read
+  statuses: write
+  checks: write
+  pull-requests: write
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -90,6 +96,14 @@ jobs:
           go list ./... | grep -v /e2e
           make test-ci
 
+      - name: Test Report
+        uses: dorny/test-reporter@v2
+        if: ${{ !cancelled() }}
+        with:
+          name: Unit tests
+          badge-title: Unit tests
+          path: "**/report/*.xml"
+          reporter: java-junit
 
   helm-validate:
     runs-on: ubuntu-latest
@@ -209,3 +223,12 @@ jobs:
       - name: Run e2e tests
         run: |
           make ${{ matrix.scope }}
+
+      - name: Test Report
+        uses: dorny/test-reporter@v2
+        if: ${{ !cancelled() }}
+        with:
+          name: ${{ matrix.scope }}
+          badge-title: ${{ matrix.scope }}
+          path: "**/report/*.xml"
+          reporter: java-junit

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ bundle
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+# Test reports
+**/report/*
 
 # Go workspace file
 go.work

--- a/Makefile
+++ b/Makefile
@@ -121,25 +121,26 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e)
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) \
+	--ginkgo.v
 
 .PHONY: test-ci
 test-ci: manifests generate fmt vet envtest ## Run tests in CI env.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -v -count=1 -race -coverprofile cover.out
-
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) \
+	-v -count=1 -race -coverprofile cover.out --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e: ## Run all e2e tests.
-	go test ./test/e2e/ -v -ginkgo.v -test.timeout 30m
+	go test ./test/e2e/ -test.timeout 30m
 
 .PHONY: test-keeper-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-keeper-e2e: ## Run keeper e2e tests.
-	go test ./test/e2e/ -v -ginkgo.v --ginkgo.label-filter keeper -test.timeout 30m
+	go test ./test/e2e/ --ginkgo.label-filter keeper -test.timeout 30m --ginkgo.junit-report=report/junit-report.xml
 
 .PHONY: test-clickhouse-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-clickhouse-e2e: ## Run clickhouse e2e tests.
-	go test ./test/e2e/ -v -ginkgo.v --ginkgo.label-filter clickhouse -test.timeout 30m
+	go test ./test/e2e/ --ginkgo.label-filter clickhouse -test.timeout 30m --ginkgo.junit-report=report/junit-report.xml
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/internal/controller/clickhouse/config_test.go
+++ b/internal/controller/clickhouse/config_test.go
@@ -1,10 +1,9 @@
 package clickhouse
 
 import (
-	"testing"
-
 	v1 "github.com/clickhouse-operator/api/v1alpha1"
 	"github.com/clickhouse-operator/internal/controller"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,10 +11,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func TestConfigGeneratorValidYAML(t *testing.T) {
-	g := NewWithT(t)
-	RegisterFailHandler(g.Fail)
-
+var _ = Describe("ConfigGenerator", func() {
 	ctx := reconcileContext{
 		ReconcileContextBase: controller.ReconcileContextBase[*v1.ClickHouseCluster, v1.ClickHouseReplicaID, replicaState]{
 			Cluster: &v1.ClickHouseCluster{
@@ -45,7 +41,7 @@ func TestConfigGeneratorValidYAML(t *testing.T) {
 	}
 
 	for _, generator := range generators {
-		t.Run(generator.Filename(), func(t *testing.T) {
+		It("should generate config: "+generator.Filename(), func() {
 			Expect(generator.Exists(&ctx)).To(BeTrue())
 			data, err := generator.Generate(&ctx, v1.ClickHouseReplicaID{})
 			Expect(err).ToNot(HaveOccurred())
@@ -53,4 +49,4 @@ func TestConfigGeneratorValidYAML(t *testing.T) {
 			Expect(yaml.Unmarshal([]byte(data), &obj)).To(Succeed())
 		})
 	}
-}
+})

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -21,38 +21,23 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var suite testutil.TestSuit
-var reconciler *ClusterReconciler
-
 func TestControllers(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "Controller Suite")
+	RunSpecs(t, "ClickHouse Controller Suite")
 }
 
-var _ = BeforeSuite(func() {
-	suite = testutil.SetupEnvironment(v1.AddToScheme)
-	reconciler = &ClusterReconciler{
-		Client: suite.Client,
-		Scheme: scheme.Scheme,
-
-		Reader:   suite.Client,
-		Logger:   suite.Log.Named("clickhouse"),
-		Recorder: record.NewFakeRecorder(128),
-	}
-})
-
-var _ = AfterSuite(func() {
-	By("tearing down the test environment")
-	suite.Cancel()
-	err := suite.TestEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
-})
-
-var _ = Describe("ClickHouseCluster Controller", func() {
-	Context("When reconciling a resource", Ordered, func() {
-		keeperName := "keeper"
-		cr := &v1.ClickHouseCluster{
+var _ = When("reconciling ClickHouseCluster", Ordered, func() {
+	var (
+		suite        testutil.TestSuit
+		reconciler   *ClusterReconciler
+		keeperName   = "keeper"
+		services     corev1.ServiceList
+		pdbs         policyv1.PodDisruptionBudgetList
+		secrets      corev1.SecretList
+		configs      corev1.ConfigMapList
+		statefulsets appsv1.StatefulSetList
+		cr           = &v1.ClickHouseCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standalone",
 				Namespace: "default",
@@ -69,183 +54,194 @@ var _ = Describe("ClickHouseCluster Controller", func() {
 				},
 			},
 		}
+	)
 
-		var services corev1.ServiceList
-		var pdbs policyv1.PodDisruptionBudgetList
-		var secrets corev1.SecretList
-		var configs corev1.ConfigMapList
-		var statefulsets appsv1.StatefulSetList
+	BeforeAll(func() {
+		suite = testutil.SetupEnvironment(v1.AddToScheme)
+		reconciler = &ClusterReconciler{
+			Client: suite.Client,
+			Scheme: scheme.Scheme,
 
-		BeforeAll(func() {
-			keeper := &v1.KeeperCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      keeperName,
-					Namespace: "default",
-				},
-			}
-			Expect(suite.Client.Create(suite.Context, keeper)).To(Succeed())
-			Expect(suite.Client.Get(suite.Context, keeper.NamespacedName(), keeper)).To(Succeed())
-			meta.SetStatusCondition(&keeper.Status.Conditions, metav1.Condition{
-				Type:   string(v1.ConditionTypeReady),
-				Status: metav1.ConditionTrue,
-				Reason: string(v1.KeeperConditionReasonStandaloneReady),
-			})
-			Expect(suite.Client.Status().Update(suite.Context, keeper)).To(Succeed())
+			Reader:   suite.Client,
+			Logger:   suite.Log.Named("clickhouse"),
+			Recorder: record.NewFakeRecorder(128),
+		}
+
+		keeper := &v1.KeeperCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      keeperName,
+				Namespace: "default",
+			},
+		}
+		Expect(suite.Client.Create(suite.Context, keeper)).To(Succeed())
+		Expect(suite.Client.Get(suite.Context, keeper.NamespacedName(), keeper)).To(Succeed())
+		meta.SetStatusCondition(&keeper.Status.Conditions, metav1.Condition{
+			Type:   string(v1.ConditionTypeReady),
+			Status: metav1.ConditionTrue,
+			Reason: string(v1.KeeperConditionReasonStandaloneReady),
 		})
+		Expect(suite.Client.Status().Update(suite.Context, keeper)).To(Succeed())
+	})
 
-		AfterEach(func() {
-			testutil.EnsureNoEvents(reconciler.Recorder.(*record.FakeRecorder).Events)
-		})
+	AfterAll(func() {
+		By("tearing down the test environment")
+		suite.Cancel()
+		err := suite.TestEnv.Stop()
+		Expect(err).NotTo(HaveOccurred())
+	})
 
-		It("should create ClickHouse cluster", func() {
-			By("by creating standalone resource CR")
-			Expect(suite.Client.Create(suite.Context, cr)).To(Succeed())
-			Expect(suite.Client.Get(suite.Context, cr.NamespacedName(), cr)).To(Succeed())
-		})
+	AfterEach(func() {
+		testutil.EnsureNoEvents(reconciler.Recorder.(*record.FakeRecorder).Events)
+	})
 
-		It("should successfully create all resources of the new cluster", func() {
-			By("reconciling the created resource once")
-			_, err := reconciler.Reconcile(suite.Context, ctrl.Request{NamespacedName: cr.NamespacedName()})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(suite.Client.Get(suite.Context, cr.NamespacedName(), cr)).To(Succeed())
+	It("should create ClickHouse cluster", func() {
+		By("by creating standalone resource CR")
+		Expect(suite.Client.Create(suite.Context, cr)).To(Succeed())
+		Expect(suite.Client.Get(suite.Context, cr.NamespacedName(), cr)).To(Succeed())
+	})
 
-			listOpts := util.AppRequirements(cr.Namespace, cr.SpecificName())
+	It("should successfully create all resources of the new cluster", func() {
+		By("reconciling the created resource once")
+		_, err := reconciler.Reconcile(suite.Context, ctrl.Request{NamespacedName: cr.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(suite.Client.Get(suite.Context, cr.NamespacedName(), cr)).To(Succeed())
 
-			Expect(suite.Client.List(suite.Context, &services, listOpts)).To(Succeed())
-			Expect(services.Items).To(HaveLen(1))
+		listOpts := util.AppRequirements(cr.Namespace, cr.SpecificName())
 
-			Expect(suite.Client.List(suite.Context, &pdbs, listOpts)).To(Succeed())
-			Expect(pdbs.Items).To(HaveLen(2))
+		Expect(suite.Client.List(suite.Context, &services, listOpts)).To(Succeed())
+		Expect(services.Items).To(HaveLen(1))
 
-			Expect(suite.Client.List(suite.Context, &secrets, listOpts)).To(Succeed())
-			Expect(secrets.Items).To(HaveLen(1))
+		Expect(suite.Client.List(suite.Context, &pdbs, listOpts)).To(Succeed())
+		Expect(pdbs.Items).To(HaveLen(2))
 
-			Expect(suite.Client.List(suite.Context, &configs, listOpts)).To(Succeed())
-			Expect(configs.Items).To(HaveLen(4))
+		Expect(suite.Client.List(suite.Context, &secrets, listOpts)).To(Succeed())
+		Expect(secrets.Items).To(HaveLen(1))
 
-			Expect(suite.Client.List(suite.Context, &statefulsets, listOpts)).To(Succeed())
-			Expect(statefulsets.Items).To(HaveLen(4))
-		})
+		Expect(suite.Client.List(suite.Context, &configs, listOpts)).To(Succeed())
+		Expect(configs.Items).To(HaveLen(4))
 
-		It("should propagate meta attributes for every resource", func() {
-			expectedOwnerRef := metav1.OwnerReference{
-				Kind:               "ClickHouseCluster",
-				APIVersion:         "clickhouse.com/v1alpha1",
-				UID:                cr.UID,
-				Name:               cr.Name,
-				Controller:         ptr.To(true),
-				BlockOwnerDeletion: ptr.To(true),
+		Expect(suite.Client.List(suite.Context, &statefulsets, listOpts)).To(Succeed())
+		Expect(statefulsets.Items).To(HaveLen(4))
+	})
+
+	It("should propagate meta attributes for every resource", func() {
+		expectedOwnerRef := metav1.OwnerReference{
+			Kind:               "ClickHouseCluster",
+			APIVersion:         "clickhouse.com/v1alpha1",
+			UID:                cr.UID,
+			Name:               cr.Name,
+			Controller:         ptr.To(true),
+			BlockOwnerDeletion: ptr.To(true),
+		}
+
+		By("setting meta attributes for service")
+		for _, service := range services.Items {
+			Expect(service.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
+			for k, v := range cr.Spec.Labels {
+				Expect(service.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
 			}
-
-			By("setting meta attributes for service")
-			for _, service := range services.Items {
-				Expect(service.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
-				for k, v := range cr.Spec.Labels {
-					Expect(service.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
-				}
-				for k, v := range cr.Spec.Annotations {
-					Expect(service.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
-				}
+			for k, v := range cr.Spec.Annotations {
+				Expect(service.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
 			}
+		}
 
-			By("setting meta attributes for pod disruption budget")
-			for _, pdb := range pdbs.Items {
-				Expect(pdb.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
-				for k, v := range cr.Spec.Labels {
-					Expect(pdb.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
-				}
-				for k, v := range cr.Spec.Annotations {
-					Expect(pdb.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
-				}
+		By("setting meta attributes for pod disruption budget")
+		for _, pdb := range pdbs.Items {
+			Expect(pdb.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
+			for k, v := range cr.Spec.Labels {
+				Expect(pdb.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
 			}
-
-			By("setting meta attributes for secrets")
-			for _, secret := range secrets.Items {
-				Expect(secret.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
-				for k, v := range cr.Spec.Labels {
-					Expect(secret.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
-				}
-				for k, v := range cr.Spec.Annotations {
-					Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
-				}
+			for k, v := range cr.Spec.Annotations {
+				Expect(pdb.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
 			}
+		}
 
-			By("setting meta attributes for configs")
-			for _, config := range configs.Items {
-				Expect(config.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
-				for k, v := range cr.Spec.Labels {
-					Expect(config.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
-				}
-				for k, v := range cr.Spec.Annotations {
-					Expect(config.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
-				}
+		By("setting meta attributes for secrets")
+		for _, secret := range secrets.Items {
+			Expect(secret.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
+			for k, v := range cr.Spec.Labels {
+				Expect(secret.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
 			}
-
-			By("setting meta attributes for statefulsets")
-			for _, sts := range statefulsets.Items {
-				Expect(sts.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
-				for k, v := range cr.Spec.Labels {
-					Expect(sts.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
-					Expect(sts.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
-				}
-				for k, v := range cr.Spec.Annotations {
-					Expect(sts.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
-					Expect(sts.Spec.Template.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
-				}
+			for k, v := range cr.Spec.Annotations {
+				Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
 			}
-		})
+		}
 
-		It("should generate all secret values", func() {
-			for key := range SecretsToGenerate {
-				Expect(secrets.Items[0].Data).To(HaveKey(key))
-				Expect(secrets.Items[0].Data[key]).To(Not(BeEmpty()))
+		By("setting meta attributes for configs")
+		for _, config := range configs.Items {
+			Expect(config.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
+			for k, v := range cr.Spec.Labels {
+				Expect(config.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
 			}
-		})
-
-		It("should generate a valid YAML objects as config files", func() {
-			var unused map[string]any
-			for _, config := range configs.Items {
-				for filename, data := range config.Data {
-					Expect(yaml.Unmarshal([]byte(data), &unused)).To(Succeed(), filename, data)
-				}
+			for k, v := range cr.Spec.Annotations {
+				Expect(config.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
 			}
-		})
+		}
 
-		It("should delete unneeded secrets and generate missing", func() {
-			secret := secrets.Items[0]
-			secret.Data["invalid-key"] = []byte("invalid-value")
-			delete(secrets.Items[0].Data, SecretKeyManagementPassword)
-			By("Changing secret data")
-			Expect(suite.Client.Update(suite.Context, &secret)).To(Succeed())
+		By("setting meta attributes for statefulsets")
+		for _, sts := range statefulsets.Items {
+			Expect(sts.ObjectMeta.OwnerReferences).To(ContainElement(expectedOwnerRef))
+			for k, v := range cr.Spec.Labels {
+				Expect(sts.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
+				Expect(sts.Spec.Template.ObjectMeta.Labels).To(HaveKeyWithValue(k, v))
+			}
+			for k, v := range cr.Spec.Annotations {
+				Expect(sts.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
+				Expect(sts.Spec.Template.ObjectMeta.Annotations).To(HaveKeyWithValue(k, v))
+			}
+		}
+	})
 
-			By("reconciling the cluster")
-			_, err := reconciler.Reconcile(suite.Context, ctrl.Request{NamespacedName: cr.NamespacedName()})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(suite.Client.Get(suite.Context, cr.NamespacedName(), cr)).To(Succeed())
+	It("should generate all secret values", func() {
+		for key := range SecretsToGenerate {
+			Expect(secrets.Items[0].Data).To(HaveKey(key))
+			Expect(secrets.Items[0].Data[key]).To(Not(BeEmpty()))
+		}
+	})
 
-			By("checking that secret is updated")
-			Expect(suite.Client.Get(suite.Context, types.NamespacedName{
-				Name:      secret.Name,
-				Namespace: secret.Namespace,
-			}, &secret)).To(Succeed())
+	It("should generate a valid YAML objects as config files", func() {
+		var unused map[string]any
+		for _, config := range configs.Items {
+			for filename, data := range config.Data {
+				Expect(yaml.Unmarshal([]byte(data), &unused)).To(Succeed(), filename, data)
+			}
+		}
+	})
 
-			Expect(secret.Data).NotTo(HaveKey("invalid-key"))
-			Expect(secret.Data).To(HaveKey(SecretKeyManagementPassword))
-			Expect(secret.Data[SecretKeyManagementPassword]).NotTo(BeEmpty())
-		})
+	It("should delete unneeded secrets and generate missing", func() {
+		secret := secrets.Items[0]
+		secret.Data["invalid-key"] = []byte("invalid-value")
+		delete(secrets.Items[0].Data, SecretKeyManagementPassword)
+		By("Changing secret data")
+		Expect(suite.Client.Update(suite.Context, &secret)).To(Succeed())
 
-		It("should reflect configuration changes in revisions", func() {
-			updatedCR := cr.DeepCopy()
-			updatedCR.Spec.Settings.Logger.Level = "warning"
-			Expect(suite.Client.Update(suite.Context, updatedCR)).To(Succeed())
-			_, err := reconciler.Reconcile(suite.Context, ctrl.Request{NamespacedName: cr.NamespacedName()})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(suite.Client.Get(suite.Context, cr.NamespacedName(), updatedCR)).To(Succeed())
+		By("reconciling the cluster")
+		_, err := reconciler.Reconcile(suite.Context, ctrl.Request{NamespacedName: cr.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(suite.Client.Get(suite.Context, cr.NamespacedName(), cr)).To(Succeed())
 
-			Expect(updatedCR.Status.ObservedGeneration).To(Equal(updatedCR.Generation))
-			Expect(updatedCR.Status.UpdateRevision).NotTo(Equal(updatedCR.Status.CurrentRevision))
-			Expect(updatedCR.Status.ConfigurationRevision).NotTo(Equal(cr.Status.ConfigurationRevision))
-			Expect(updatedCR.Status.StatefulSetRevision).To(Equal(cr.Status.StatefulSetRevision))
-		})
+		By("checking that secret is updated")
+		Expect(suite.Client.Get(suite.Context, types.NamespacedName{
+			Name:      secret.Name,
+			Namespace: secret.Namespace,
+		}, &secret)).To(Succeed())
+
+		Expect(secret.Data).NotTo(HaveKey("invalid-key"))
+		Expect(secret.Data).To(HaveKey(SecretKeyManagementPassword))
+		Expect(secret.Data[SecretKeyManagementPassword]).NotTo(BeEmpty())
+	})
+
+	It("should reflect configuration changes in revisions", func() {
+		updatedCR := cr.DeepCopy()
+		updatedCR.Spec.Settings.Logger.Level = "warning"
+		Expect(suite.Client.Update(suite.Context, updatedCR)).To(Succeed())
+		_, err := reconciler.Reconcile(suite.Context, ctrl.Request{NamespacedName: cr.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(suite.Client.Get(suite.Context, cr.NamespacedName(), updatedCR)).To(Succeed())
+
+		Expect(updatedCR.Status.ObservedGeneration).To(Equal(updatedCR.Generation))
+		Expect(updatedCR.Status.UpdateRevision).NotTo(Equal(updatedCR.Status.CurrentRevision))
+		Expect(updatedCR.Status.ConfigurationRevision).NotTo(Equal(cr.Status.ConfigurationRevision))
+		Expect(updatedCR.Status.StatefulSetRevision).To(Equal(cr.Status.StatefulSetRevision))
 	})
 })

--- a/internal/controller/keeper/templates_test.go
+++ b/internal/controller/keeper/templates_test.go
@@ -1,10 +1,9 @@
 package keeper
 
 import (
-	"testing"
-
 	v1 "github.com/clickhouse-operator/api/v1alpha1"
 	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,9 +12,8 @@ import (
 
 type confMap map[any]any
 
-func TestServerRevision(t *testing.T) {
-	RegisterFailHandler(NewWithT(t).Fail)
-	cr := &v1.KeeperCluster{
+var _ = Describe("ServerRevision", func() {
+	baseCR := &v1.KeeperCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 		},
@@ -24,56 +22,62 @@ func TestServerRevision(t *testing.T) {
 		},
 	}
 
-	cfgRevision, err := GetConfigurationRevision(cr, nil)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(cfgRevision).ToNot(BeEmpty())
+	var baseCfgRevision string
+	var baseStsRevision string
 
-	stsRevision, err := GetStatefulSetRevision(cr)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(stsRevision).ToNot(BeEmpty())
+	BeforeEach(func() {
+		var err error
+		baseCfgRevision, err = GetConfigurationRevision(baseCR, nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(baseCfgRevision).ToNot(BeEmpty())
 
-	t.Run("config revision not changed by replica count", func(t *testing.T) {
-		RegisterFailHandler(NewWithT(t).Fail)
-		cr := cr.DeepCopy()
+		baseStsRevision, err = GetStatefulSetRevision(baseCR)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(baseStsRevision).ToNot(BeEmpty())
+	})
+
+	It("should not change config revision if only replica count changes", func() {
+		cr := baseCR.DeepCopy()
 		cr.Spec.Replicas = ptr.To[int32](3)
 		cfgRevisionUpdated, err := GetConfigurationRevision(cr, nil)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(cfgRevision).ToNot(BeEmpty())
-		Expect(cfgRevisionUpdated).To(Equal(cfgRevision), "server config revision shouldn't depend on replica count")
+		Expect(baseCfgRevision).ToNot(BeEmpty())
+		Expect(cfgRevisionUpdated).To(Equal(baseCfgRevision), "server config revision shouldn't depend on replica count")
 
 		stsRevisionUpdated, err := GetStatefulSetRevision(cr)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stsRevisionUpdated).ToNot(BeEmpty())
-		Expect(stsRevisionUpdated).To(Equal(stsRevision), "StatefulSet config revision shouldn't depend on replica count")
+		Expect(stsRevisionUpdated).To(Equal(baseStsRevision), "StatefulSet config revision shouldn't depend on replica count")
 	})
 
-	t.Run("sts revision not changed by config", func(t *testing.T) {
-		RegisterFailHandler(NewWithT(t).Fail)
-		cr := cr.DeepCopy()
+	It("should not change sts revision if only config changes", func() {
+		cr := baseCR.DeepCopy()
 		cr.Spec.Settings.Logger.Level = "warning"
 		cfgRevisionUpdated, err := GetConfigurationRevision(cr, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cfgRevisionUpdated).ToNot(BeEmpty())
-		Expect(cfgRevisionUpdated).ToNot(Equal(cfgRevision), "configuration change should update config revision")
+		Expect(cfgRevisionUpdated).ToNot(Equal(baseCfgRevision), "configuration change should update config revision")
 
 		stsRevisionUpdated, err := GetStatefulSetRevision(cr)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stsRevisionUpdated).ToNot(BeEmpty())
-		Expect(stsRevisionUpdated).To(Equal(stsRevision), "StatefulSet config revision shouldn't change with config")
+		Expect(stsRevisionUpdated).To(Equal(baseStsRevision), "StatefulSet config revision shouldn't change with config")
 	})
-}
+})
 
-func TestExtraConfig(t *testing.T) {
-	RegisterFailHandler(NewWithT(t).Fail)
+var _ = Describe("ExtraConfig", func() {
 	cr := &v1.KeeperCluster{}
-
-	baseConfigYAML, err := generateConfigForSingleReplica(cr, nil, 1)
-	Expect(err).NotTo(HaveOccurred())
+	var baseConfigYAML string
 	var baseConfig confMap
-	Expect(yaml.Unmarshal([]byte(baseConfigYAML), &baseConfig)).To(Succeed())
 
-	t.Run("add new setting", func(t *testing.T) {
-		RegisterFailHandler(NewWithT(t).Fail)
+	BeforeEach(func() {
+		var err error
+		baseConfigYAML, err = generateConfigForSingleReplica(cr, nil, 1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(yaml.Unmarshal([]byte(baseConfigYAML), &baseConfig)).To(Succeed())
+	})
+
+	It("should reflect config changes in generated config", func() {
 		configYAML, err := generateConfigForSingleReplica(cr, map[string]any{
 			"keeper_server": confMap{
 				"coordination_settings": confMap{
@@ -88,8 +92,7 @@ func TestExtraConfig(t *testing.T) {
 		Expect(config["keeper_server"].(confMap)["coordination_settings"].(confMap)["quorum_reads"]).To(BeTrue())
 	})
 
-	t.Run("override existing setting", func(t *testing.T) {
-		RegisterFailHandler(NewWithT(t).Fail)
+	It("should override existing setting by extra config", func() {
 		configYAML, err := generateConfigForSingleReplica(cr, map[string]any{
 			"keeper_server": confMap{
 				"coordination_settings": confMap{
@@ -105,4 +108,4 @@ func TestExtraConfig(t *testing.T) {
 		Expect(config).ToNot(Equal(baseConfig), cmp.Diff(config, baseConfig))
 		Expect(config["keeper_server"].(confMap)["coordination_settings"].(confMap)["compress_logs"]).To(BeTrue())
 	})
-}
+})


### PR DESCRIPTION
## Why

- E2E tests can output a lot of logs, and it's hard find what has failed.
- `go test --json` generates a result for only the topmost Ginkgo suite.
- `--ginkgo.gojson-report` breaks regular test runs
- So it's easier to stick to a single approach

## What

- Added generation of test reports in the CI
- Adapted all tests to Ginkgo