### PR TITLE
Refactor controllers to use shared base reconciler pattern, keeping most dependencies

### DIFF
--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -230,6 +230,14 @@ func ClickHouseIDFromLabels(labels map[string]string) (ClickHouseReplicaID, erro
 	}, nil
 }
 
+// Labels returns labels that should be set for every resource related to the specified replica.
+func (id ClickHouseReplicaID) Labels() map[string]string {
+	return map[string]string{
+		controllerutil.LabelClickHouseShardID:   strconv.Itoa(int(id.ShardID)),
+		controllerutil.LabelClickHouseReplicaID: strconv.Itoa(int(id.Index)),
+	}
+}
+
 // IDFromHostname extracts ClickHouseReplicaID from given hostname.
 func IDFromHostname(v *ClickHouseCluster, hostname string) (ClickHouseReplicaID, error) {
 	if !strings.HasPrefix(hostname, v.SpecificName()+"-") || !strings.HasSuffix(hostname, "-0") {

--- a/api/v1alpha1/keepercluster_types.go
+++ b/api/v1alpha1/keepercluster_types.go
@@ -176,6 +176,13 @@ func KeeperReplicaIDFromLabels(labels map[string]string) (KeeperReplicaID, error
 	return KeeperReplicaID(id), nil
 }
 
+// Labels returns labels that should be set for every resource related to the specified replica.
+func (id KeeperReplicaID) Labels() map[string]string {
+	return map[string]string{
+		controllerutil.LabelKeeperReplicaID: strconv.FormatInt(int64(id), 10),
+	}
+}
+
 // NamespacedName returns NamespacedName for the KeeperCluster.
 func (v *KeeperCluster) NamespacedName() types.NamespacedName {
 	return types.NamespacedName{

--- a/ci/kind-cluster.config
+++ b/ci/kind-cluster.config
@@ -5,12 +5,9 @@ nodes:
   - role: worker
     labels:
       topology.kubernetes.io/zone: zone-a
-      kubernetes.io/hostname: worker-a
   - role: worker
     labels:
       topology.kubernetes.io/zone: zone-b
-      kubernetes.io/hostname: worker-b
   - role: worker
     labels:
       topology.kubernetes.io/zone: zone-c
-      kubernetes.io/hostname: worker-c

--- a/internal/controller/clickhouse/config_test.go
+++ b/internal/controller/clickhouse/config_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 var _ = Describe("ConfigGenerator", func() {
-	ctx := reconcileContext{
-		reconcileContextBase: reconcileContextBase{
+	ctx := clickhouseReconciler{
+		reconcilerBase: reconcilerBase{
 			Cluster: &v1.ClickHouseCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",

--- a/internal/controller/clickhouse/templates_test.go
+++ b/internal/controller/clickhouse/templates_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("BuildVolumes", func() {
-	ctx := reconcileContext{}
+	ctx := clickhouseReconciler{}
 
 	It("should generate default volumes", func() {
 		ctx.Cluster = &v1.ClickHouseCluster{

--- a/internal/controller/reconcilerbase.go
+++ b/internal/controller/reconcilerbase.go
@@ -1,0 +1,71 @@
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type clusterObject[Status any] interface {
+	client.Object
+	GetGeneration() int64
+	Conditions() *[]metav1.Condition
+	NamespacedName() types.NamespacedName
+	GetStatus() *Status
+	SpecificName() string
+}
+
+type replicaID interface {
+	comparable
+	Labels() map[string]string
+}
+
+type controller interface {
+	GetClient() client.Client
+	GetScheme() *k8sruntime.Scheme
+	GetRecorder() record.EventRecorder
+}
+
+// ResourceReconcilerBase provides a base class for cluster reconcilers.
+// It is expected to be embedded in specific reconcilers that hold reconciliation logic and state.
+// It contains common methods for managing Cluster status and resources.
+type ResourceReconcilerBase[
+	ClusterStatus any,
+	Cluster clusterObject[ClusterStatus],
+	ReplicaID replicaID,
+	ReplicaState any,
+] struct {
+	controller
+
+	Cluster Cluster
+	// Should be populated by reconcileActiveReplicaStatus.
+	ReplicaState map[ReplicaID]ReplicaState
+}
+
+// NewReconcilerBase creates a new ResourceReconcilerBase instance.
+func NewReconcilerBase[
+	ClusterStatus any,
+	Cluster clusterObject[ClusterStatus],
+	ReplicaID replicaID,
+	ReplicaState any,
+](ctrl controller, cluster Cluster) ResourceReconcilerBase[ClusterStatus, Cluster, ReplicaID, ReplicaState] {
+	return ResourceReconcilerBase[ClusterStatus, Cluster, ReplicaID, ReplicaState]{
+		controller:   ctrl,
+		Cluster:      cluster,
+		ReplicaState: map[ReplicaID]ReplicaState{},
+	}
+}
+
+// Replica returns the state of the replica with the given ID.
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) Replica(id ReplicaID) S {
+	return r.ReplicaState[id]
+}
+
+// SetReplica sets the state of the replica with the given ID.
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) SetReplica(id ReplicaID, state S) bool {
+	_, exists := r.ReplicaState[id]
+	r.ReplicaState[id] = state
+	return exists
+}

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -6,19 +6,19 @@ import (
 	"reflect"
 	"slices"
 
-	"github.com/google/go-cmp/cmp"
+	gcmp "github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/clickhouse-operator/api/v1alpha1"
-	"github.com/clickhouse-operator/internal/controllerutil"
+	util "github.com/clickhouse-operator/internal/controllerutil"
 )
 
 // ReplicaUpdateStage represents the stage of updating a ClickHouse replica. Used in reconciliation process.
@@ -51,7 +51,7 @@ func (s ReplicaUpdateStage) String() string {
 var podErrorStatuses = []string{"ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff"}
 
 // CheckPodError checks if the pod of the given StatefulSet have permanent errors preventing it from starting.
-func CheckPodError(ctx context.Context, log controllerutil.Logger, client client.Client, sts *appsv1.StatefulSet) (bool, error) {
+func CheckPodError(ctx context.Context, log util.Logger, client client.Client, sts *appsv1.StatefulSet) (bool, error) {
 	var pod corev1.Pod
 
 	podName := sts.Name + "-0"
@@ -82,11 +82,11 @@ func CheckPodError(ctx context.Context, log controllerutil.Logger, client client
 	return isError, nil
 }
 
-func diffFilter(specFields []string) cmp.Option {
-	return cmp.FilterPath(func(path cmp.Path) bool {
+func diffFilter(specFields []string) gcmp.Option {
+	return gcmp.FilterPath(func(path gcmp.Path) bool {
 		inMeta := false
 		for _, s := range path {
-			if f, ok := s.(cmp.StructField); ok {
+			if f, ok := s.(gcmp.StructField); ok {
 				switch {
 				case inMeta:
 					return !slices.Contains([]string{"Labels", "Annotations"}, f.Name())
@@ -99,41 +99,33 @@ func diffFilter(specFields []string) cmp.Option {
 		}
 
 		return false
-	}, cmp.Ignore())
+	}, gcmp.Ignore())
 }
 
-type controller interface {
-	GetClient() client.Client
-	GetScheme() *k8sruntime.Scheme
-	GetRecorder() record.EventRecorder
-}
-
-func reconcileResource(
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) reconcileResource(
 	ctx context.Context,
-	log controllerutil.Logger,
-	ctrl controller,
-	owner client.Object,
+	log util.Logger,
 	resource client.Object,
 	specFields []string,
 ) (bool, error) {
-	cli := ctrl.GetClient()
+	cli := r.GetClient()
 	kind := resource.GetObjectKind().GroupVersionKind().Kind
 	log = log.With(kind, resource.GetName())
 
-	if err := ctrlruntime.SetControllerReference(owner, resource, ctrl.GetScheme()); err != nil {
-		return false, fmt.Errorf("set %s/%s ctrl reference: %w", kind, resource.GetName(), err)
+	if err := ctrlruntime.SetControllerReference(r.Cluster, resource, r.GetScheme()); err != nil {
+		return false, fmt.Errorf("set %s/%s Ctrl reference: %w", kind, resource.GetName(), err)
 	}
 
 	if len(specFields) == 0 {
 		return false, fmt.Errorf("%s specFields is empty", kind)
 	}
 
-	resourceHash, err := controllerutil.DeepHashResource(resource, specFields)
+	resourceHash, err := util.DeepHashResource(resource, specFields)
 	if err != nil {
 		return false, fmt.Errorf("deep hash %s/%s: %w", kind, resource.GetName(), err)
 	}
 
-	controllerutil.AddHashWithKeyToAnnotations(resource, controllerutil.AnnotationSpecHash, resourceHash)
+	util.AddHashWithKeyToAnnotations(resource, util.AnnotationSpecHash, resourceHash)
 
 	foundResource := resource.DeepCopyObject().(client.Object) //nolint:forcetypeassert // safe cast
 
@@ -148,15 +140,15 @@ func reconcileResource(
 
 		log.Info("resource not found, creating")
 
-		return true, Create(ctx, ctrl, owner, resource)
+		return true, r.Create(ctx, resource)
 	}
 
-	if controllerutil.GetSpecHashFromObject(foundResource) == resourceHash {
+	if util.GetSpecHashFromObject(foundResource) == resourceHash {
 		log.Debug("resource is up to date")
 		return false, nil
 	}
 
-	log.Debug("resource changed, diff: " + cmp.Diff(foundResource, resource, diffFilter(specFields)))
+	log.Debug("resource changed, diff: " + gcmp.Diff(foundResource, resource, diffFilter(specFields)))
 
 	foundResource.SetAnnotations(resource.GetAnnotations())
 	foundResource.SetLabels(resource.GetLabels())
@@ -170,50 +162,44 @@ func reconcileResource(
 		field.Set(reflect.ValueOf(resource).Elem().FieldByName(fieldName))
 	}
 
-	return true, Update(ctx, ctrl, owner, foundResource)
+	return true, r.Update(ctx, foundResource)
 }
 
 // ReconcileService reconciles a Kubernetes Service resource.
-func ReconcileService(
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) ReconcileService(
 	ctx context.Context,
-	log controllerutil.Logger,
-	ctrl controller,
-	owner client.Object,
+	log util.Logger,
 	service *corev1.Service,
 ) (bool, error) {
-	return reconcileResource(ctx, log, ctrl, owner, service, []string{"Spec"})
+	return r.reconcileResource(ctx, log, service, []string{"Spec"})
 }
 
 // ReconcilePodDisruptionBudget reconciles a Kubernetes PodDisruptionBudget resource.
-func ReconcilePodDisruptionBudget(
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) ReconcilePodDisruptionBudget(
 	ctx context.Context,
-	log controllerutil.Logger,
-	ctrl controller,
-	owner client.Object,
+	log util.Logger,
 	pdb *policyv1.PodDisruptionBudget,
 ) (bool, error) {
-	return reconcileResource(ctx, log, ctrl, owner, pdb, []string{"Spec"})
+	return r.reconcileResource(ctx, log, pdb, []string{"Spec"})
 }
 
 // ReconcileConfigMap reconciles a Kubernetes ConfigMap resource.
-func ReconcileConfigMap(
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) ReconcileConfigMap(
 	ctx context.Context,
-	log controllerutil.Logger,
-	ctrl controller,
-	owner client.Object,
+	log util.Logger,
 	configMap *corev1.ConfigMap,
 ) (bool, error) {
-	return reconcileResource(ctx, log, ctrl, owner, configMap, []string{"Data", "BinaryData"})
+	return r.reconcileResource(ctx, log, configMap, []string{"Data", "BinaryData"})
 }
 
 // Create creates the given Kubernetes resource and emits events on failure.
-func Create(ctx context.Context, ctrl controller, owner client.Object, resource client.Object) error {
-	recorder := ctrl.GetRecorder()
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) Create(ctx context.Context, resource client.Object) error {
+	recorder := r.GetRecorder()
 	kind := resource.GetObjectKind().GroupVersionKind().Kind
 
-	if err := ctrl.GetClient().Create(ctx, resource); err != nil {
-		if controllerutil.ShouldEmitEvent(err) {
-			recorder.Eventf(owner, corev1.EventTypeWarning, v1.EventReasonFailedCreate,
+	if err := r.GetClient().Create(ctx, resource); err != nil {
+		if util.ShouldEmitEvent(err) {
+			recorder.Eventf(r.Cluster, corev1.EventTypeWarning, v1.EventReasonFailedCreate,
 				"Create %s %s failed: %s", kind, resource.GetName(), err.Error())
 		}
 
@@ -224,13 +210,13 @@ func Create(ctx context.Context, ctrl controller, owner client.Object, resource 
 }
 
 // Update updates the given Kubernetes resource and emits events on failure.
-func Update(ctx context.Context, ctrl controller, owner client.Object, resource client.Object) error {
-	recorder := ctrl.GetRecorder()
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) Update(ctx context.Context, resource client.Object) error {
+	recorder := r.GetRecorder()
 	kind := resource.GetObjectKind().GroupVersionKind().Kind
 
-	if err := ctrl.GetClient().Update(ctx, resource); err != nil {
-		if controllerutil.ShouldEmitEvent(err) {
-			recorder.Eventf(owner, corev1.EventTypeWarning, v1.EventReasonFailedUpdate,
+	if err := r.GetClient().Update(ctx, resource); err != nil {
+		if util.ShouldEmitEvent(err) {
+			recorder.Eventf(r.Cluster, corev1.EventTypeWarning, v1.EventReasonFailedUpdate,
 				"Update %s %s failed: %s", kind, resource.GetName(), err.Error())
 		}
 
@@ -241,21 +227,78 @@ func Update(ctx context.Context, ctrl controller, owner client.Object, resource 
 }
 
 // Delete deletes the given Kubernetes resource and emits events on failure.
-func Delete(ctx context.Context, ctrl controller, owner client.Object, resource client.Object) error {
-	recorder := ctrl.GetRecorder()
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) Delete(ctx context.Context, resource client.Object) error {
+	recorder := r.GetRecorder()
 	kind := resource.GetObjectKind().GroupVersionKind().Kind
 
-	if err := ctrl.GetClient().Delete(ctx, resource); err != nil {
+	if err := r.GetClient().Delete(ctx, resource); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 
-		if controllerutil.ShouldEmitEvent(err) {
-			recorder.Eventf(owner, corev1.EventTypeWarning, v1.EventReasonFailedDelete,
+		if util.ShouldEmitEvent(err) {
+			recorder.Eventf(r.Cluster, corev1.EventTypeWarning, v1.EventReasonFailedDelete,
 				"Delete %s %s failed: %s", kind, resource.GetName(), err.Error())
 		}
 
 		return fmt.Errorf("delete %s/%s: %w", kind, resource.GetName(), err)
+	}
+
+	return nil
+}
+
+// UpdatePVC updates the PersistentVolumeClaim for the given replica ID if it exists and differs from the provided spec.
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) UpdatePVC(
+	ctx context.Context,
+	log util.Logger,
+	id ReplicaID,
+	volumeSpec corev1.PersistentVolumeClaimSpec,
+) error {
+	cli := r.GetClient()
+
+	var pvcs corev1.PersistentVolumeClaimList
+
+	req := util.AppRequirements(r.Cluster.GetNamespace(), r.Cluster.SpecificName())
+	for k, v := range id.Labels() {
+		idReq, _ := labels.NewRequirement(k, selection.Equals, []string{v})
+		req.LabelSelector = req.LabelSelector.Add(*idReq)
+	}
+
+	log.Debug("listing replica PVCs", "replica_id", id, "selector", req.LabelSelector.String())
+
+	if err := cli.List(ctx, &pvcs, req); err != nil {
+		return fmt.Errorf("list replica %v PVCs: %w", id, err)
+	}
+
+	if len(pvcs.Items) == 0 {
+		log.Info("no PVCs found for replica, skipping update", "replica_id", id)
+		return nil
+	}
+
+	if len(pvcs.Items) > 1 {
+		pvcNames := make([]string, len(pvcs.Items))
+		for i, pvc := range pvcs.Items {
+			pvcNames[i] = pvc.Name
+		}
+
+		return fmt.Errorf("found multiple PVCs for replica %v: %v", id, pvcNames)
+	}
+
+	if gcmp.Equal(pvcs.Items[0].Spec, volumeSpec) {
+		log.Debug("replica PVC is up to date", "pvc", pvcs.Items[0].Name)
+		return nil
+	}
+
+	targetSpec := volumeSpec.DeepCopy()
+	if err := util.ApplyDefault(targetSpec, pvcs.Items[0].Spec); err != nil {
+		return fmt.Errorf("apply patch to replica PVC %v: %w", id, err)
+	}
+
+	log.Info("updating replica PVC", "pvc", pvcs.Items[0].Name, "diff", gcmp.Diff(pvcs.Items[0].Spec, targetSpec))
+
+	pvcs.Items[0].Spec = *targetSpec
+	if err := r.Update(ctx, &pvcs.Items[0]); err != nil {
+		return fmt.Errorf("update replica PVC %v: %w", id, err)
 	}
 
 	return nil

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -9,45 +9,14 @@ import (
 	gcmp "github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/clickhouse-operator/api/v1alpha1"
-	"github.com/clickhouse-operator/internal/controllerutil"
+	util "github.com/clickhouse-operator/internal/controllerutil"
 )
 
-type clusterObject[Status any] interface {
-	client.Object
-	GetGeneration() int64
-	Conditions() *[]metav1.Condition
-	NamespacedName() types.NamespacedName
-	GetStatus() *Status
-}
-
-// ReconcileContextBase provides a base context for reconciling a cluster object.
-// It provides common methods for reconciling.
-type ReconcileContextBase[S any, T clusterObject[S], ReplicaID comparable, ReplicaState any] struct {
-	Cluster T
-
-	// Should be populated by reconcileActiveReplicaStatus.
-	ReplicaState map[ReplicaID]ReplicaState
-}
-
-// Replica returns the state of the replica with the given ID.
-func (c *ReconcileContextBase[Status, T, ReplicaID, S]) Replica(id ReplicaID) S {
-	return c.ReplicaState[id]
-}
-
-// SetReplica sets the state of the replica with the given ID.
-func (c *ReconcileContextBase[Status, T, ReplicaID, S]) SetReplica(id ReplicaID, state S) bool {
-	_, exists := c.ReplicaState[id]
-	c.ReplicaState[id] = state
-	return exists
-}
-
 // NewCondition creates a new condition with the given parameters.
-func (c *ReconcileContextBase[Status, T, ReplicaID, S]) NewCondition(
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) NewCondition(
 	condType v1.ConditionType,
 	status metav1.ConditionStatus,
 	reason v1.ConditionReason,
@@ -58,16 +27,16 @@ func (c *ReconcileContextBase[Status, T, ReplicaID, S]) NewCondition(
 		Status:             status,
 		Reason:             string(reason),
 		Message:            message,
-		ObservedGeneration: c.Cluster.GetGeneration(),
+		ObservedGeneration: r.Cluster.GetGeneration(),
 	}
 }
 
 // SetConditions sets the given conditions in the CRD status conditions.
-func (c *ReconcileContextBase[Status, T, ReplicaID, S]) SetConditions(
-	log controllerutil.Logger,
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) SetConditions(
+	log util.Logger,
 	conditions []metav1.Condition,
 ) bool {
-	clusterCond := c.Cluster.Conditions()
+	clusterCond := r.Cluster.Conditions()
 	if *clusterCond == nil {
 		*clusterCond = make([]metav1.Condition, 0, len(conditions))
 	}
@@ -85,32 +54,25 @@ func (c *ReconcileContextBase[Status, T, ReplicaID, S]) SetConditions(
 }
 
 // SetCondition sets a single condition in the CRD status conditions.
-func (c *ReconcileContextBase[Status, T, ReplicaID, S]) SetCondition(
-	log controllerutil.Logger,
-	condType v1.ConditionType,
-	status metav1.ConditionStatus,
-	reason v1.ConditionReason,
-	message string,
-) bool {
-	return c.SetConditions(log, []metav1.Condition{c.NewCondition(condType, status, reason, message)})
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) SetCondition(log util.Logger, cond metav1.Condition) bool {
+	return r.SetConditions(log, []metav1.Condition{cond})
 }
 
 // UpsertCondition upserts the given condition into the CRD status conditions.
 // Returns true if the condition was changed. Useful to precise detect if condition transition happened.
-func (c *ReconcileContextBase[Status, T, ReplicaID, S]) UpsertCondition(
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) UpsertCondition(
 	ctx context.Context,
-	log controllerutil.Logger,
-	controller controller,
+	log util.Logger,
 	condition metav1.Condition,
 ) (bool, error) {
 	changed := false
-	crdInstance := c.Cluster.DeepCopyObject().(clusterObject[Status]) //nolint:forcetypeassert // safe cast
-	setStatusCondition(c.Cluster.Conditions(), condition)
+	crdInstance := r.Cluster.DeepCopyObject().(clusterObject[Status]) //nolint:forcetypeassert // safe cast
+	setStatusCondition(r.Cluster.Conditions(), condition)
 
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cli := controller.GetClient()
-		if err := cli.Get(ctx, c.Cluster.NamespacedName(), crdInstance); err != nil {
-			return fmt.Errorf("upsert condition %s: get resource %s: %w", condition.Type, c.Cluster.GetName(), err)
+		cli := r.GetClient()
+		if err := cli.Get(ctx, r.Cluster.NamespacedName(), crdInstance); err != nil {
+			return fmt.Errorf("upsert condition %s: get resource %s: %w", condition.Type, r.Cluster.GetName(), err)
 		}
 
 		if changed = setStatusCondition(crdInstance.Conditions(), condition); !changed {
@@ -129,52 +91,50 @@ func (c *ReconcileContextBase[Status, T, ReplicaID, S]) UpsertCondition(
 
 // UpsertConditionAndSendEvent upserts the given condition into the CRD status conditions.
 // Sends an event if the condition was changed.
-func (c *ReconcileContextBase[Status, T, ReplicaID, S]) UpsertConditionAndSendEvent(
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) UpsertConditionAndSendEvent(
 	ctx context.Context,
-	log controllerutil.Logger,
-	controller controller,
+	log util.Logger,
 	condition metav1.Condition,
 	eventType string,
 	eventReason v1.EventReason,
 	eventMessageFormat string,
 	eventMessageArgs ...any,
 ) (bool, error) {
-	changed, err := c.UpsertCondition(ctx, log, controller, condition)
+	changed, err := r.UpsertCondition(ctx, log, condition)
 	if err != nil {
 		return false, err
 	}
 
 	if changed {
-		controller.GetRecorder().Eventf(c.Cluster, eventType, eventReason, eventMessageFormat, eventMessageArgs...)
+		r.GetRecorder().Eventf(r.Cluster, eventType, eventReason, eventMessageFormat, eventMessageArgs...)
 		return true, nil
 	}
 
 	return false, nil
 }
 
-// UpsertStatus upserts the current status of the cluster into the CRD status.
-func (c *ReconcileContextBase[Status, T, ReplicaID, S]) UpsertStatus(
+// UpsertStatus upserts the current status of the Cluster into the CRD status.
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) UpsertStatus(
 	ctx context.Context,
-	log controllerutil.Logger,
-	controller controller,
+	log util.Logger,
 ) error {
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		cli := controller.GetClient()
+		cli := r.GetClient()
 
-		crdInstance := c.Cluster.DeepCopyObject().(clusterObject[Status]) //nolint:forcetypeassert // safe cast
-		if err := cli.Get(ctx, c.Cluster.NamespacedName(), crdInstance); err != nil {
-			return fmt.Errorf("upsert status: get resource %s: %w", c.Cluster.GetName(), err)
+		crdInstance := r.Cluster.DeepCopyObject().(clusterObject[Status]) //nolint:forcetypeassert // safe cast
+		if err := cli.Get(ctx, r.Cluster.NamespacedName(), crdInstance); err != nil {
+			return fmt.Errorf("upsert status: get resource %s: %w", r.Cluster.GetName(), err)
 		}
 
 		preStatus := crdInstance.GetStatus()
 
-		if reflect.DeepEqual(*preStatus, *c.Cluster.GetStatus()) {
+		if reflect.DeepEqual(*preStatus, *r.Cluster.GetStatus()) {
 			log.Info("statuses are equal, nothing to do")
 			return nil
 		}
 
-		log.Debug("status difference:\n" + gcmp.Diff(*preStatus, *c.Cluster.GetStatus()))
-		*crdInstance.GetStatus() = *c.Cluster.GetStatus()
+		log.Debug("status difference:\n" + gcmp.Diff(*preStatus, *r.Cluster.GetStatus()))
+		*crdInstance.GetStatus() = *r.Cluster.GetStatus()
 
 		return cli.Status().Update(ctx, crdInstance)
 	})


### PR DESCRIPTION
## Why

- Reduce code duplication
- Reduce the number of arguments passed along the reconciliation flow

## What

- Put reconciliation logic in a separate object that holds the reconciliation state
- Make updatePVC generic and reuse it for Keeper
