### PR TITLE
Fix markdown-link-check in CI, ignore logo links until docs rolled out

### DIFF
--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -21,4 +21,5 @@ jobs:
       - uses: actions/checkout@v6
       - uses: tcort/github-action-markdown-link-check@v1
         with:
-          config-file: docs/markdown-link-check.json
+          config-file: ci/.markdown-link-check.json
+          file-extension: '.md'

--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ docs-lint-vale: ## Run Vale linter on documentation
 .PHONY: docs-link-check
 docs-link-check: ## Run markdown-link-check on documentation
 	@command -v markdown-link-check >/dev/null 2>&1 || { echo "markdown-link-check is required but not installed. npm install -g markdown-link-check"; exit 1; }
-	markdown-link-check -c docs/.markdown-link-check.json README.md docs
+	markdown-link-check -c ci/.markdown-link-check.json *.md docs
 
 .PHONY: docs-lint
 docs-lint: docs-lint-vale docs-link-check ## Run all documentation linters

--- a/ci/.markdown-link-check.json
+++ b/ci/.markdown-link-check.json
@@ -2,6 +2,9 @@
   "ignorePatterns": [
     {
       "pattern": "^https://github.com/ClickHouse/clickhouse-operator/issues$"
+    },
+    {
+      "pattern": "^https://clickhouse.com/docs/img/.*$"
     }
   ]
 }


### PR DESCRIPTION
## Why

Currently, the CI check does nothing. It will fail because the documentation is not deployed yet.

## What

Fix configs and add docs links to exceptions