### PR TITLE
Remove ignores, after documentation

### DIFF
--- a/ci/.markdown-link-check.json
+++ b/ci/.markdown-link-check.json
@@ -2,9 +2,6 @@
   "ignorePatterns": [
     {
       "pattern": "^https://github.com/ClickHouse/clickhouse-operator/issues$"
-    },
-    {
-      "pattern": "^https://clickhouse.com/docs/img/.*$"
     }
   ]
 }


### PR DESCRIPTION
## Why

Documentation is rolled out in public, and links can be resolved.

## What

Remove ignores from link-check config
