### PR TITLE
Lower kubernetes version to v1.30+

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The Operator handles the full lifecycle of ClickHouse clusters, including scalin
 ### Prerequisites
 - go version v1.25.0+
 - docker version 17.03+
-- `kubectl` version v1.33.0+
-- Access to a Kubernetes v1.33.0+ cluster
+- `kubectl` version v1.30.0+
+- Access to a Kubernetes v1.30.0+ cluster
 - cert-manager installed in the cluster (for webhook certificates)
 
 ### Quick Start

--- a/config/manifests/bases/clickhouse-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/clickhouse-operator.clusterserviceversion.yaml
@@ -170,7 +170,7 @@ spec:
   - email: operator@clickhouse.com
     name: ClickHouse Team
   maturity: alpha
-  minKubeVersion: 1.33.0
+  minKubeVersion: 1.30.0
   provider:
     name: ClickHouse Inc.
     url: https://clickhouse.com

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -4,7 +4,7 @@ This guide covers installing the ClickHouse Operator using Helm charts.
 
 ## Prerequisites
 
-- Kubernetes cluster v1.33.0 or later
+- Kubernetes cluster v1.30.0 or later
 - Helm v3.0 or later
 - kubectl configured to communicate with your cluster
 

--- a/docs/installation/kubectl.md
+++ b/docs/installation/kubectl.md
@@ -4,8 +4,8 @@ This guide covers installing the ClickHouse Operator using kubectl and manifest 
 
 ## Prerequisites
 
-- Kubernetes cluster v1.33.0 or later
-- kubectl v1.33.0 or later
+- Kubernetes cluster v1.30.0 or later
+- kubectl v1.30.0 or later
 - Cluster admin permissions
 
 ## Install from Release Manifests

--- a/docs/installation/olm.md
+++ b/docs/installation/olm.md
@@ -11,7 +11,7 @@ This guide covers installing the ClickHouse Operator using Operator Lifecycle Ma
 
 ## Prerequisites
 
-- Kubernetes cluster version 1.33.0 or later
+- Kubernetes cluster version 1.30.0 or later
 - kubectl configured to access your cluster
 - Cluster admin permissions
 - Installed OLM (Operator Lifecycle Manager)


### PR DESCRIPTION
## Why

Operator-hub CI uses Kubernetes v.1.30, so it allows it to pass

## What

Lower Kubernetes version to v1.30+ in csv and docs
