### PR TITLE
fix: correct array index in logger toFields to prevent panic

### DIFF
--- a/internal/controllerutil/logger.go
+++ b/internal/controllerutil/logger.go
@@ -80,7 +80,7 @@ func (l Logger) toFields(args ...any) []zap.Field {
 	for i := 0; i < len(args); i += 2 {
 		key, ok := args[i].(string)
 		if !ok {
-			l.l.Fatal("non string key found", zap.Any("key", args[i*2]))
+			l.l.Fatal("non string key found", zap.Any("key", args[i]))
 			return nil
 		}
 


### PR DESCRIPTION
The `toFields` function increments i by 2 in each loop iteration, but used args[i*2] instead of args[i] when logging non-string keys. This would cause out of bounds access and panic!

- When i=2: i*2=4 (out of bounds for 4-element array)
- When i=4: i*2=8 (panic)

## Why

To preclude panics for smth that should be innocuous, like logging.

## What

Just use the correct index.

## Related Issues

I consider this small enough to not to open issue, lmk otherwise.
