### PR TITLE
fix: use correct separator for container image digest references

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -30,7 +30,7 @@ func (c *ContainerImage) String() string {
 	}
 
 	if c.Hash != "" {
-		return fmt.Sprintf("%s:%s", c.Repository, c.Hash)
+		return fmt.Sprintf("%s@%s", c.Repository, c.Hash)
 	}
 
 	return c.Repository


### PR DESCRIPTION


## Why

Container image digests must use '@' separator, not ':'.
- Correct format: repository@sha256:abc123...
- Previous (wrong): repository:sha256:abc123...

The ':' separator is only valid for tags. Using it for digests results in invalid image references that container runtimes cannot pull.

## What

Consider `@` instead of `:` as first separator.

