### PR TITLE
fix: add nil checks before dereferencing Shards pointers in webhook

### DIFF
--- a/internal/webhook/v1alpha1/clickhousecluster_webhook.go
+++ b/internal/webhook/v1alpha1/clickhousecluster_webhook.go
@@ -80,7 +80,8 @@ func (w *ClickHouseClusterWebhook) ValidateUpdate(_ context.Context, oldObj, new
 	}
 
 	warns, err := w.validateImpl(newCluster)
-	if *oldCluster.Spec.Shards > *newCluster.Spec.Shards {
+	if oldCluster.Spec.Shards != nil && newCluster.Spec.Shards != nil &&
+		*oldCluster.Spec.Shards > *newCluster.Spec.Shards {
 		warns = append(warns, "Decreasing the number of shards is a destructive operation. It removes shards with all their data.")
 	}
 


### PR DESCRIPTION
## Why

The ValidateUpdate webhook could panic when comparing Shards values if either `oldCluster.Spec.Shards` or `newCluster.Spec.Shards` was nil.

This can happen when a cluster was created without explicitly setting the `Shards` field (relying on defaults) and then updated before the defaulting webhook properly initializes the value.

## What

Added standard  nil pointer checks!
