### PR TITLE
Adjust default health probes paramenters. Fix clickhouse liveness probe

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -317,11 +317,11 @@ logger:
 
 Reference to a Secret or ConfigMap key containing a password.
 
-| Field          | Type                    | Required | Default     | Description                                                                                                                                                                                                                                                    |
-|----------------|-------------------------|----------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `passwordType` | `string`                | No       | `plaintext` | Type of password encoding. Possible values: `plaintext`, `sha256_password`, `sha256_hash`, `double_sha1_password`, `double_sha1_hash`. See [ClickHouse documentation](https://clickhouse.com/docs/en/operations/settings/settings-users#password) for details. |
-| `secret`       | `*SecretKeySelector`    | No       | -           | Select password from a Secret key. Mutually exclusive with `configMap`.                                                                                                                                                                                        |
-| `configMap`    | `*ConfigMapKeySelector` | No       | -           | Select password from a ConfigMap key. Mutually exclusive with `secret`.                                                                                                                                                                                        |
+| Field          | Type                    | Required | Default    | Description                                                                                                                                                                                                                        |
+|----------------|-------------------------|----------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `passwordType` | `string`                | No       | `password` | Type of password encoding. Possible values: `password`, `password_sha256_hex`, `password_double_sha1_hex`. See [ClickHouse documentation](https://clickhouse.com/docs/en/operations/settings/settings-users#password) for details. |
+| `secret`       | `*SecretKeySelector`    | No       | -          | Select password from a Secret key. Mutually exclusive with `configMap`.                                                                                                                                                            |
+| `configMap`    | `*ConfigMapKeySelector` | No       | -          | Select password from a ConfigMap key. Mutually exclusive with `secret`.                                                                                                                                                            |
 
 **Note**: You must specify either `secret` OR `configMap`, not both.
 
@@ -329,7 +329,7 @@ Reference to a Secret or ConfigMap key containing a password.
 
 ```yaml
 defaultUserPassword:
-  passwordType: plaintext  # Optional, default
+  passwordType: password  # Optional, default
   secret:
     name: clickhouse-password
     key: password
@@ -339,7 +339,7 @@ defaultUserPassword:
 
 ```yaml
 defaultUserPassword:
-  passwordType: sha256_password
+  passwordType: password_sha256_hex
   secret:
     name: clickhouse-password
     key: password_hash

--- a/internal/controller/clickhouse/config.go
+++ b/internal/controller/clickhouse/config.go
@@ -331,14 +331,14 @@ type clientConfigParams struct {
 }
 
 func clientConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, _ v1.ClickHouseReplicaID) (string, error) {
-	passEnv := EnvDefaultUserPassword
-	if r.Cluster.Spec.Settings.DefaultUserPassword == nil {
-		passEnv = ""
-	}
-
 	params := clientConfigParams{
 		ManagementPort:         PortManagement,
-		DefaultUserPasswordEnv: passEnv,
+		DefaultUserPasswordEnv: "",
+	}
+
+	// Only plaintext password could be set in client config.
+	if r.Cluster.Spec.Settings.DefaultUserPassword != nil && r.Cluster.Spec.Settings.DefaultUserPassword.PasswordType == "password" {
+		params.DefaultUserPasswordEnv = EnvDefaultUserPassword
 	}
 
 	builder := strings.Builder{}

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -12,12 +12,22 @@ const (
 )
 
 var (
-	// DefaultProbeSettings defines default settings for Kubernetes liveness and readiness probes.
+	// DefaultLivenessProbeSettings defines default settings for Kubernetes liveness probes.
 	//nolint: mnd // Magic numbers are used as constants.
-	DefaultProbeSettings = corev1.Probe{
-		TimeoutSeconds:   10,
-		PeriodSeconds:    1,
-		SuccessThreshold: 1,
-		FailureThreshold: 15,
+	DefaultLivenessProbeSettings = corev1.Probe{
+		InitialDelaySeconds: 60,
+		TimeoutSeconds:      10,
+		PeriodSeconds:       5,
+		FailureThreshold:    10,
+	}
+
+	// DefaultReadinessProbeSettings defines default settings for Kubernetes liveness probes.
+	//nolint: mnd // Magic numbers are used as constants.
+	DefaultReadinessProbeSettings = corev1.Probe{
+		InitialDelaySeconds: 5,
+		TimeoutSeconds:      10,
+		PeriodSeconds:       1,
+		SuccessThreshold:    5,
+		FailureThreshold:    10,
 	}
 )

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -328,7 +328,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Namespace: testNamespace,
 			},
 			Data: map[string][]byte{
-				"password": []byte(controllerutil.Sha256Hash([]byte(password))),
+				"password": []byte(passwordSha),
 			},
 		}
 		auth := clickhouse.Auth{


### PR DESCRIPTION
## Why

`clickhouse client` cll in the old liveness probe requires default user credentials and breaks in case it is unknown to the operator.
Existing documentation is wrong.


## What

Adjusted default probe settings and fixed the liveness probe command.

