### PR TITLE
Add default AccessModes to data disk. Allow custom data disk mounts.

### DIFF
--- a/api/v1alpha1/defaults.go
+++ b/api/v1alpha1/defaults.go
@@ -1,5 +1,9 @@
 package v1alpha1
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
 const (
 	DefaultKeeperContainerRepository = "docker.io/clickhouse/clickhouse-keeper"
 	DefaultKeeperContainerTag        = "latest"
@@ -21,11 +25,12 @@ const (
 	DefaultClickHouseMemoryLimit   = "1Gi"
 	DefaultClickHouseMemoryRequest = "256Mi"
 
-	DefaulClickHouseShardCount    = 1
+	DefaultClickHouseShardCount   = 1
 	DefaultClickHouseReplicaCount = 3
 
 	DefaultMaxLogFiles = 50
 
 	// DefaultClusterDomain is the default Kubernetes cluster domain suffix for DNS resolution.
 	DefaultClusterDomain = "cluster.local"
+	DefaultAccessMode    = corev1.ReadWriteOnce
 )

--- a/api/v1alpha1/keepercluster_types.go
+++ b/api/v1alpha1/keepercluster_types.go
@@ -34,9 +34,9 @@ type KeeperClusterSpec struct {
 	ContainerTemplate ContainerTemplateSpec `json:"containerTemplate,omitempty"`
 
 	// Settings for the replicas storage.
-	// +required
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Data Volume Claim Spec"
-	DataVolumeClaimSpec corev1.PersistentVolumeClaimSpec `json:"dataVolumeClaimSpec,omitempty"`
+	DataVolumeClaimSpec *corev1.PersistentVolumeClaimSpec `json:"dataVolumeClaimSpec,omitempty"`
 
 	// Additional labels that are added to resources.
 	// +optional
@@ -90,6 +90,10 @@ func (s *KeeperClusterSpec) WithDefaults() {
 
 	if err := controllerutil.ApplyDefault(s, defaultSpec); err != nil {
 		panic(fmt.Sprintf("unable to apply defaults: %v", err))
+	}
+
+	if s.DataVolumeClaimSpec != nil && len(s.DataVolumeClaimSpec.AccessModes) == 0 {
+		s.DataVolumeClaimSpec.AccessModes = []corev1.PersistentVolumeAccessMode{DefaultAccessMode}
 	}
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -105,7 +105,11 @@ func (in *ClickHouseClusterSpec) DeepCopyInto(out *ClickHouseClusterSpec) {
 	}
 	in.PodTemplate.DeepCopyInto(&out.PodTemplate)
 	in.ContainerTemplate.DeepCopyInto(&out.ContainerTemplate)
-	in.DataVolumeClaimSpec.DeepCopyInto(&out.DataVolumeClaimSpec)
+	if in.DataVolumeClaimSpec != nil {
+		in, out := &in.DataVolumeClaimSpec, &out.DataVolumeClaimSpec
+		*out = new(v1.PersistentVolumeClaimSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))
@@ -364,7 +368,11 @@ func (in *KeeperClusterSpec) DeepCopyInto(out *KeeperClusterSpec) {
 	}
 	in.PodTemplate.DeepCopyInto(&out.PodTemplate)
 	in.ContainerTemplate.DeepCopyInto(&out.ContainerTemplate)
-	in.DataVolumeClaimSpec.DeepCopyInto(&out.DataVolumeClaimSpec)
+	if in.DataVolumeClaimSpec != nil {
+		in, out := &in.DataVolumeClaimSpec, &out.DataVolumeClaimSpec
+		*out = new(v1.PersistentVolumeClaimSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
+++ b/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
@@ -4324,7 +4324,6 @@ spec:
                 minimum: 0
                 type: integer
             required:
-            - dataVolumeClaimSpec
             - keeperClusterRef
             type: object
           status:

--- a/config/crd/bases/clickhouse.com_keeperclusters.yaml
+++ b/config/crd/bases/clickhouse.com_keeperclusters.yaml
@@ -4257,8 +4257,6 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                 type: object
-            required:
-            - dataVolumeClaimSpec
             type: object
           status:
             description: KeeperClusterStatus defines the observed state of KeeperCluster.

--- a/config/samples/v1alpha1_clickhouse.yaml
+++ b/config/samples/v1alpha1_clickhouse.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   replicas: 2
   dataVolumeClaimSpec:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi

--- a/config/samples/v1alpha1_keeper.yaml
+++ b/config/samples/v1alpha1_keeper.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   replicas: 3
   dataVolumeClaimSpec:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi

--- a/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
@@ -4134,7 +4134,6 @@ spec:
                                 minimum: 0
                                 type: integer
                         required:
-                            - dataVolumeClaimSpec
                             - keeperClusterRef
                         type: object
                     status:

--- a/dist/chart/templates/crd/keeperclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/keeperclusters.clickhouse.com.yaml
@@ -4075,8 +4075,6 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                         type: object
                                 type: object
-                        required:
-                            - dataVolumeClaimSpec
                         type: object
                     status:
                         description: KeeperClusterStatus defines the observed state of KeeperCluster.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,8 +84,6 @@ Configure persistent storage:
 spec:
   dataVolumeClaimSpec:
     storageClassName: fast-ssd  # Optional: consider your storage class based on the installed CSI
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 100Gi

--- a/examples/aws_eks_gp3.yaml
+++ b/examples/aws_eks_gp3.yaml
@@ -87,8 +87,6 @@ spec:
   replicas: 3
   dataVolumeClaimSpec:
     storageClassName: gp3
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
@@ -118,8 +116,6 @@ spec:
   replicas: 3
   dataVolumeClaimSpec:
     storageClassName: gp3
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 50Gi

--- a/examples/cluster_with_ssl.yaml
+++ b/examples/cluster_with_ssl.yaml
@@ -72,11 +72,9 @@ metadata:
 spec:
   replicas: 3
   dataVolumeClaimSpec:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
-        storage: 1Gi
+        storage: 2Gi
   podTemplate:
     topologyZoneKey: topology.kubernetes.io/zone
     nodeHostnameKey: kubernetes.io/hostname
@@ -94,11 +92,9 @@ metadata:
 spec:
   replicas: 3
   dataVolumeClaimSpec:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
-        storage: 2Gi
+        storage: 4Gi
   keeperClusterRef:
     name: sample
   podTemplate:

--- a/examples/custom_configuration.yaml
+++ b/examples/custom_configuration.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   replicas: 3
   dataVolumeClaimSpec:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
@@ -18,8 +16,6 @@ metadata:
 spec:
   replicas: 2
   dataVolumeClaimSpec:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 2Gi

--- a/examples/gcp_gke_ssd.yaml
+++ b/examples/gcp_gke_ssd.yaml
@@ -73,8 +73,6 @@ spec:
   replicas: 3
   dataVolumeClaimSpec:
     storageClassName: premium-rwo
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
@@ -104,8 +102,6 @@ spec:
   replicas: 2
   dataVolumeClaimSpec:
     storageClassName: premium-rwo
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 20Gi

--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   replicas: 3
   dataVolumeClaimSpec:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi
@@ -18,8 +16,6 @@ metadata:
 spec:
   replicas: 2
   dataVolumeClaimSpec:
-    accessModes:
-      - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi

--- a/internal/controller/clickhouse/config.go
+++ b/internal/controller/clickhouse/config.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+	"github.com/ClickHouse/clickhouse-operator/internal"
 	"github.com/ClickHouse/clickhouse-operator/internal/controller"
 	"github.com/ClickHouse/clickhouse-operator/internal/controller/keeper"
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
@@ -226,7 +227,7 @@ func baseConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, id v1
 	}
 
 	params := baseConfigParams{
-		Path: BaseDataPath,
+		Path: internal.ClickHouseDataPath,
 		Log:  controller.GenerateLoggerConfig(r.Cluster.Spec.Settings.Logger, LogPath, "clickhouse-server"),
 		Macros: map[string]any{
 			"cluster": DefaultClusterName,

--- a/internal/controller/clickhouse/constants.go
+++ b/internal/controller/clickhouse/constants.go
@@ -30,8 +30,7 @@ const (
 	KeyFilename         = "clickhouse-server.key"
 	CustomCAFilename    = "custom-ca.crt"
 
-	LogPath      = "/var/log/clickhouse-server/"
-	BaseDataPath = "/var/lib/clickhouse/"
+	LogPath = "/var/log/clickhouse-server/"
 
 	DefaultClusterName       = "default"
 	KeeperPathUsers          = "/clickhouse/access"

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -829,12 +829,15 @@ func (r *clickhouseReconciler) updateReplica(ctx context.Context, log ctrlutil.L
 		return nil, nil
 	}
 
-	if !gcmp.Equal(replica.StatefulSet.Spec.VolumeClaimTemplates[0].Spec, r.Cluster.Spec.DataVolumeClaimSpec) {
-		if err = r.UpdatePVC(ctx, log, id, r.Cluster.Spec.DataVolumeClaimSpec); err != nil {
-			return nil, fmt.Errorf("update replica %s PVC: %w", id, err)
-		}
+	if r.Cluster.Spec.DataVolumeClaimSpec != nil {
+		if !gcmp.Equal(replica.StatefulSet.Spec.VolumeClaimTemplates[0].Spec, r.Cluster.Spec.DataVolumeClaimSpec) {
+			if err = r.UpdatePVC(ctx, log, id, *r.Cluster.Spec.DataVolumeClaimSpec); err != nil {
+				//nolint:nilerr // Error is logged internally and event sent
+				return nil, nil
+			}
 
-		statefulSet.Spec.VolumeClaimTemplates = replica.StatefulSet.Spec.VolumeClaimTemplates
+			statefulSet.Spec.VolumeClaimTemplates = replica.StatefulSet.Spec.VolumeClaimTemplates
+		}
 	}
 
 	log.Info("updating replica StatefulSet", "stateful_set", statefulSet.Name)

--- a/internal/controller/clickhouse/templates_test.go
+++ b/internal/controller/clickhouse/templates_test.go
@@ -19,7 +19,9 @@ var _ = Describe("BuildVolumes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
 			},
-			Spec: v1.ClickHouseClusterSpec{},
+			Spec: v1.ClickHouseClusterSpec{
+				DataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{},
+			},
 		}
 		volumes, mounts, err := buildVolumes(&ctx, v1.ClickHouseReplicaID{})
 		Expect(err).To(Not(HaveOccurred()))
@@ -47,7 +49,7 @@ var _ = Describe("BuildVolumes", func() {
 		volumes, mounts, err := buildVolumes(&ctx, v1.ClickHouseReplicaID{})
 		Expect(err).To(Not(HaveOccurred()))
 		Expect(volumes).To(HaveLen(4))
-		Expect(mounts).To(HaveLen(6))
+		Expect(mounts).To(HaveLen(4))
 		checkVolumeMounts(volumes, mounts)
 	})
 
@@ -75,6 +77,7 @@ var _ = Describe("BuildVolumes", func() {
 						MountPath: "/etc/my-extra-volume",
 					}},
 				},
+				DataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{},
 			},
 		}
 		volumes, mounts, err := buildVolumes(&ctx, v1.ClickHouseReplicaID{})
@@ -108,6 +111,7 @@ var _ = Describe("BuildVolumes", func() {
 						MountPath: "/etc/clickhouse-server/config.d/",
 					}},
 				},
+				DataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{},
 			},
 		}
 		volumes, mounts, err := buildVolumes(&ctx, v1.ClickHouseReplicaID{})
@@ -160,6 +164,7 @@ var _ = Describe("BuildVolumes", func() {
 						MountPath: "/etc/clickhouse-server/tls/",
 					}},
 				},
+				DataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{},
 			},
 		}
 		volumes, mounts, err := buildVolumes(&ctx, v1.ClickHouseReplicaID{})

--- a/internal/controller/keeper/constants.go
+++ b/internal/controller/keeper/constants.go
@@ -2,6 +2,8 @@ package keeper
 
 import (
 	"github.com/blang/semver/v4"
+
+	"github.com/ClickHouse/clickhouse-operator/internal"
 )
 
 const (
@@ -24,9 +26,8 @@ const (
 
 	LogPath = "/var/log/clickhouse-keeper/"
 
-	BaseDataPath        = "/var/lib/clickhouse/"
-	StorageLogPath      = BaseDataPath + "coordination/log/"
-	StorageSnapshotPath = BaseDataPath + "coordination/snapshots/"
+	StorageLogPath      = internal.KeeperDataPath + "/coordination/log/"
+	StorageSnapshotPath = internal.KeeperDataPath + "/coordination/snapshots/"
 
 	ContainerName          = "clickhouse-keeper"
 	DefaultRevisionHistory = 10

--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -762,12 +762,15 @@ func (r *keeperReconciler) updateReplica(ctx context.Context, log ctrlutil.Logge
 		return nil, nil
 	}
 
-	if !gcmp.Equal(replica.StatefulSet.Spec.VolumeClaimTemplates[0].Spec, r.Cluster.Spec.DataVolumeClaimSpec) {
-		if err = r.UpdatePVC(ctx, log, replicaID, r.Cluster.Spec.DataVolumeClaimSpec); err != nil {
-			return nil, fmt.Errorf("update replica %d PVC: %w", replicaID, err)
-		}
+	if r.Cluster.Spec.DataVolumeClaimSpec != nil {
+		if !gcmp.Equal(replica.StatefulSet.Spec.VolumeClaimTemplates[0].Spec, r.Cluster.Spec.DataVolumeClaimSpec) {
+			if err = r.UpdatePVC(ctx, log, replicaID, *r.Cluster.Spec.DataVolumeClaimSpec); err != nil {
+				//nolint:nilerr // Error is logged internally and event sent
+				return nil, nil
+			}
 
-		statefulSet.Spec.VolumeClaimTemplates = replica.StatefulSet.Spec.VolumeClaimTemplates
+			statefulSet.Spec.VolumeClaimTemplates = replica.StatefulSet.Spec.VolumeClaimTemplates
+		}
 	}
 
 	log.Info("updating replica StatefulSet", "stateful_set", statefulSet.Name)

--- a/internal/validation_constants.go
+++ b/internal/validation_constants.go
@@ -7,6 +7,9 @@ const (
 
 	QuorumConfigVolumeName = "clickhouse-keeper-quorum-config-volume"
 	ConfigVolumeName       = "clickhouse-keeper-config-volume"
+
+	KeeperDataPath     = "/var/lib/clickhouse"
+	ClickHouseDataPath = "/var/lib/clickhouse"
 )
 
 var (

--- a/internal/webhook/v1alpha1/common.go
+++ b/internal/webhook/v1alpha1/common.go
@@ -1,15 +1,29 @@
 package v1alpha1
 
 import (
+	"errors"
 	"fmt"
+	"path"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// ValidateCustomVolumeMounts validates that the provided volume mounts correspond to defined volumes and
+// validateCustomVolumeMounts validates that the provided volume mounts correspond to defined volumes and
 // do not use any reserved volume names. It returns a slice of errors for any validation issues found.
-func ValidateCustomVolumeMounts(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, reservedVolumeNames []string) []error {
-	var errs []error
+func validateVolumes(
+	volumes []corev1.Volume,
+	volumeMounts []corev1.VolumeMount,
+	reservedVolumeNames []string,
+	dataPath string,
+	hasDataVolume bool,
+) (admission.Warnings, []error) {
+	var (
+		warnings admission.Warnings
+		errs     []error
+	)
+
+	dataPath = path.Clean(dataPath)
 
 	definedVolumes := make(map[string]corev1.Volume, len(volumes))
 	for _, volume := range volumes {
@@ -22,7 +36,12 @@ func ValidateCustomVolumeMounts(volumes []corev1.Volume, volumeMounts []corev1.V
 		definedVolumes[volume.Name] = volume
 	}
 
+	hasMountAtDataPath := false
 	for _, volumeMount := range volumeMounts {
+		if path.Clean(volumeMount.MountPath) == dataPath {
+			hasMountAtDataPath = true
+		}
+
 		if _, ok := definedVolumes[volumeMount.Name]; !ok {
 			err := fmt.Errorf("the volume mount '%s' is invalid because the volume is not defined", volumeMount.Name)
 			errs = append(errs, err)
@@ -36,5 +55,26 @@ func ValidateCustomVolumeMounts(volumes []corev1.Volume, volumeMounts []corev1.V
 		}
 	}
 
-	return errs
+	if hasDataVolume && hasMountAtDataPath {
+		errs = append(errs, fmt.Errorf("cannot mount a custom volume at the data path %q when a data volume is defined", dataPath))
+	}
+
+	if !hasDataVolume && !hasMountAtDataPath {
+		warnings = append(warnings, fmt.Sprintf("no volume is mounted at the data path %q, which may lead to data loss if the cluster is restarted", dataPath))
+	}
+
+	return warnings, errs
+}
+
+// validateDataVolumeSpecChanges validates that changes to the DataVolumeClaimSpec after cluster creation.
+func validateDataVolumeSpecChanges(oldSpec, newSpec *corev1.PersistentVolumeClaimSpec) error {
+	if oldSpec == nil && newSpec != nil {
+		return errors.New("data volume cannot be added after cluster creation")
+	}
+
+	if oldSpec != nil && newSpec == nil {
+		return errors.New("data volume cannot be removed after cluster creation")
+	}
+
+	return nil
 }

--- a/internal/webhook/v1alpha1/keepercluster_webhook_test.go
+++ b/internal/webhook/v1alpha1/keepercluster_webhook_test.go
@@ -26,6 +26,7 @@ var _ = Describe("KeeperCluster Webhook", func() {
 				Spec: chv1.KeeperClusterSpec{},
 			}
 			Expect(k8sClient.Create(ctx, keeperCluster)).Should(Succeed())
+			deferCleanup(keeperCluster)
 			Expect(k8sClient.Get(ctx, keeperCluster.NamespacedName(), keeperCluster)).Should(Succeed())
 
 			Expect(keeperCluster.Spec.ContainerTemplate.Image.Repository).Should(Equal(chv1.DefaultKeeperContainerRepository))
@@ -34,47 +35,87 @@ var _ = Describe("KeeperCluster Webhook", func() {
 				corev1.ResourceMemory: resource.MustParse(chv1.DefaultKeeperMemoryLimit),
 			}))
 		})
+
+		It("Should set default access modes if data volume enabled", func(ctx context.Context) {
+			keeperCluster := &chv1.KeeperCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test-default",
+				},
+				Spec: chv1.KeeperClusterSpec{
+					DataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, keeperCluster)).Should(Succeed())
+			deferCleanup(keeperCluster)
+			Expect(k8sClient.Get(ctx, keeperCluster.NamespacedName(), keeperCluster)).Should(Succeed())
+
+			Expect(keeperCluster.Spec.DataVolumeClaimSpec.AccessModes).To(ContainElement(chv1.DefaultAccessMode))
+		})
 	})
 
 	Context("When creating KeeperCluster under Validating Webhook", func() {
-		keeperCluster := &chv1.KeeperCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "test-keeper-validate",
-			},
+		meta := metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-keeper-validate",
 		}
 
 		It("Should check TLS enabled if required", func(ctx context.Context) {
 			By("Rejecting wrong settings")
-			keeperCluster.Spec.Settings.TLS = chv1.ClusterTLSSpec{
-				Enabled:  false,
-				Required: true,
+			cluster := chv1.KeeperCluster{
+				ObjectMeta: meta,
+				Spec: chv1.KeeperClusterSpec{
+					Settings: chv1.KeeperSettings{
+						TLS: chv1.ClusterTLSSpec{
+							Enabled:  false,
+							Required: true,
+						},
+					},
+				},
 			}
 
-			err := k8sClient.Create(ctx, keeperCluster)
+			err := k8sClient.Create(ctx, &cluster)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("TLS cannot be required"))
 		})
 
 		It("Should check certificate passed if TLS enabled", func(ctx context.Context) {
 			By("Rejecting wrong settings")
-			keeperCluster.Spec.Settings.TLS = chv1.ClusterTLSSpec{
-				Enabled: true,
+			cluster := chv1.KeeperCluster{
+				ObjectMeta: meta,
+				Spec: chv1.KeeperClusterSpec{
+					Settings: chv1.KeeperSettings{
+						TLS: chv1.ClusterTLSSpec{
+							Enabled: true,
+						},
+					},
+				},
 			}
 
-			err := k8sClient.Create(ctx, keeperCluster)
+			err := k8sClient.Create(ctx, &cluster)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("serverCertSecret must be specified"))
 		})
 
 		It("Should check that all volumes from volume mounts are exists", func(ctx context.Context) {
-			cluster := keeperCluster.DeepCopy()
+			cluster := chv1.KeeperCluster{
+				ObjectMeta: meta,
+				Spec: chv1.KeeperClusterSpec{
+					ContainerTemplate: chv1.ContainerTemplateSpec{
+						VolumeMounts: []corev1.VolumeMount{{
+							Name: "non-existing-volume",
+						}},
+					},
+				},
+			}
 
-			cluster.Spec.ContainerTemplate.VolumeMounts = []corev1.VolumeMount{{
-				Name: "non-existing-volume",
-			}}
 			By("Rejecting cr with non existing volume")
-			err := k8sClient.Create(ctx, cluster)
+			err := k8sClient.Create(ctx, &cluster)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("the volume mount 'non-existing-volume' is invalid because the volume is not defined"))
 
@@ -82,9 +123,98 @@ var _ = Describe("KeeperCluster Webhook", func() {
 			cluster.Spec.PodTemplate.Volumes = []corev1.Volume{{
 				Name: "clickhouse-keeper-config-volume",
 			}}
-			err = k8sClient.Create(ctx, cluster)
+			err = k8sClient.Create(ctx, &cluster)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("reserved and cannot be used"))
+		})
+
+		It("Should reject cluster with custom volume mounted at data path when DataVolumeClaimSpec is defined", func(ctx context.Context) {
+			cluster := chv1.KeeperCluster{
+				ObjectMeta: meta,
+				Spec: chv1.KeeperClusterSpec{
+					DataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+					PodTemplate: chv1.PodTemplateSpec{
+						Volumes: []corev1.Volume{{
+							Name: "custom-data",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						}},
+					},
+					ContainerTemplate: chv1.ContainerTemplateSpec{
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "custom-data",
+							MountPath: "/var/lib/clickhouse",
+						}},
+					},
+				},
+			}
+
+			By("Rejecting cr with data volume mount collision")
+			err := k8sClient.Create(ctx, &cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot mount a custom volume at the data path"))
+		})
+
+		It("Should warn when no volume is mounted at data path without DataVolumeClaimSpec", func(ctx context.Context) {
+			cluster := chv1.KeeperCluster{
+				ObjectMeta: meta,
+				Spec:       chv1.KeeperClusterSpec{},
+			}
+
+			By("Creating diskless cluster with warning")
+			Expect(k8sClient.Create(ctx, &cluster)).To(Succeed())
+			deferCleanup(&cluster)
+
+			By("Verifying warning about data loss")
+			Expect(warnings).To(ContainElement(ContainSubstring("no volume is mounted at the data path")))
+		})
+
+		It("Should check that data volume cannot be added after creation", func(ctx context.Context) {
+			cluster := chv1.KeeperCluster{
+				ObjectMeta: meta,
+				Spec:       chv1.KeeperClusterSpec{},
+			}
+			Expect(k8sClient.Create(ctx, &cluster)).To(Succeed())
+			deferCleanup(&cluster)
+
+			cluster.Spec.DataVolumeClaimSpec = &corev1.PersistentVolumeClaimSpec{Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			}}
+
+			By("Rejecting cr with added data volume")
+			err := k8sClient.Update(ctx, &cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot be added"))
+		})
+
+		It("Should check that data volume cannot be removed after creation", func(ctx context.Context) {
+			cluster := chv1.KeeperCluster{
+				ObjectMeta: meta,
+				Spec: chv1.KeeperClusterSpec{
+					DataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, &cluster)).To(Succeed())
+			deferCleanup(&cluster)
+			cluster.Spec.DataVolumeClaimSpec = nil
+
+			By("Rejecting cr with added data volume")
+			err := k8sClient.Update(ctx, &cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot be removed"))
 		})
 	})
 })


### PR DESCRIPTION
- Add ReadWriteOnce as the default AccessMode for data volume
- Allow to disable PVC to mount custom volumes at the data path
- Improve error handling in PVC update to proceed with the rest of the reconciliation steps after PVC update failures

Closes: #75
