### PR TITLE
fix: helm chart use wrong values field for manager container security…

### DIFF
--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -88,7 +88,7 @@ spec:
                         protocol: TCP
                       {{- end }}
                   resources: {{ toYaml .Values.manager.resources | nindent 22 }}
-                  securityContext: {{ toYaml .Values.manager.securityContext | nindent 22 }}
+                  securityContext: {{ toYaml .Values.manager.containerSecurityContext | nindent 22 }}
                   {{- if .Values.certManager.enable }}
                   volumeMounts:
                       - mountPath: /tmp/k8s-server/serving-certs

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -39,7 +39,7 @@ manager:
 
     ## Container-level security settings
     ##
-    securityContext:
+    containerSecurityContext:
         allowPrivilegeEscalation: false
         capabilities:
             drop:


### PR DESCRIPTION
When deploying operator using helm chart, with a namespace configured with restricted security profile, pod does not start. The custom values content is correct, but generated deploy template is wrong : the field used for container `securityContext` use the wrong values field.

Namespace :

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: clickhouse-operator-system
  labels:
    pod-security.kubernetes.io/enforce: restricted
    pod-security.kubernetes.io/warn: restricted
```

## Why

<!--
Please describe why you are proposing this code change. This should include
at least a single text paragraph.
-->
This change use the proper values field for deployement.

## What

<!--
Please explain what you did. For small/trivial changes a single paragraph is
probably sufficient.
-->
I only changed the used field in values.

## Related Issues

<!-- Link to related issues using #issue-number -->

Fixes #
Related to #
