### PR TITLE
Support all installModes, selection of watched namespaces

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -65,6 +65,10 @@ spec:
         env:
           - name: ENABLE_WEBHOOKS
             value: "false"
+          - name: WATCH_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['olm.targetNamespaces']
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false

--- a/config/manifests/bases/clickhouse-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/clickhouse-operator.clusterserviceversion.yaml
@@ -148,11 +148,11 @@ spec:
       deployments: null
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
-  - supported: false
+  - supported: true
     type: MultiNamespace
   - supported: true
     type: AllNamespaces

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -61,6 +61,9 @@ spec:
                   command:
                       - /manager
                   {{- $env := append .Values.manager.env (dict "name" "ENABLE_WEBHOOKS" "value" (printf "%t" .Values.webhook.enable)) }}
+                  {{- if not (empty .Values.watchNamespaces) }}
+                  {{-   $env = append $env (dict "name" "WATCH_NAMESPACES" "value" (join "," .Values.watchNamespaces)) }}
+                  {{- end }}
                   env: {{ toYaml $env | nindent 22 }}
                   image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
                   imagePullPolicy: {{ .Values.manager.image.pullPolicy }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -6,6 +6,10 @@
 ##
 # fullnameOverride: ""
 
+## List of namespaces to watch for resources.
+##
+watchNamespaces: [ ]
+
 # Configure the controller manager deployment
 ##
 manager:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.27.5
 	github.com/onsi/gomega v1.38.3
+	github.com/sethvargo/go-envconfig v1.3.0
 	go.uber.org/zap v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/sethvargo/go-envconfig v1.3.0 h1:gJs+Fuv8+f05omTpwWIu6KmuseFAXKrIaOZSh8RMt0U=
+github.com/sethvargo/go-envconfig v1.3.0/go.mod h1:JLd0KFWQYzyENqnEPWWZ49i4vzZo/6nRidxI8YvGiHw=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -1,0 +1,24 @@
+package environment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sethvargo/go-envconfig"
+)
+
+// Environment holds all environment variables for the application.
+type Environment struct {
+	EnableWebhooks bool     `env:"ENABLE_WEBHOOKS, default=true"`
+	WatchNamespace []string `env:"WATCH_NAMESPACE"`
+}
+
+// GetEnvironment processes environment variables and returns an Environment struct.
+func GetEnvironment(ctx context.Context) (Environment, error) {
+	var env Environment
+	if err := envconfig.Process(ctx, &env); err != nil {
+		return Environment{}, fmt.Errorf("process environment variables: %w", err)
+	}
+
+	return env, nil
+}

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -1,0 +1,58 @@
+package environment
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sethvargo/go-envconfig"
+)
+
+func TestTypes(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Environment Suite")
+}
+
+var _ = DescribeTable("Environment variables parsing",
+	func(ctx context.Context, vars map[string]string, expected Environment) {
+		var result Environment
+		Expect(envconfig.ProcessWith(ctx, &envconfig.Config{
+			Target:   &result,
+			Lookuper: envconfig.MapLookuper(vars),
+		})).To(Succeed())
+		Expect(result).To(BeEquivalentTo(expected))
+	},
+	Entry("default values", nil, Environment{
+		EnableWebhooks: true,
+		WatchNamespace: nil,
+	}),
+	Entry("explicit enabled webhook", map[string]string{
+		"ENABLE_WEBHOOKS": "true",
+	}, Environment{
+		EnableWebhooks: true,
+	}),
+	Entry("explicit disabled webhook", map[string]string{
+		"ENABLE_WEBHOOKS": "false",
+	}, Environment{
+		EnableWebhooks: false,
+	}),
+	Entry("parse single namespace", map[string]string{
+		"WATCH_NAMESPACE": "target_namespace",
+	}, Environment{
+		EnableWebhooks: true,
+		WatchNamespace: []string{"target_namespace"},
+	}),
+	Entry("parse multiple namespace", map[string]string{
+		"WATCH_NAMESPACE": "target,namespace",
+	}, Environment{
+		EnableWebhooks: true,
+		WatchNamespace: []string{"target", "namespace"},
+	}),
+	Entry("empty namespace behaves as not set", map[string]string{
+		"WATCH_NAMESPACE": "",
+	}, Environment{
+		EnableWebhooks: true,
+	}),
+)


### PR DESCRIPTION
## Why

Allows to deploy multiple operators in a single cluster or restricting operators' SA permissions 

## What

Added the WATCH_NAMESPACES env variable that restricts operator' scope. For OLM installations, it's set to special annotation.