### PR TITLE
Minimal k8s version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,6 +197,58 @@ jobs:
       - name: Check Helm release status
         run: helm status my-release --namespace clickhouse-operator-system
 
+  compat-e2e-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "Minimal supported kubernetes with LTS ClickHouse release"
+            kind_version: v1.28.15
+            clickhouse_version: "25.8"
+          - name: "Latest kubernetes version with LTS ClickHouse release"
+            kind_version: v1.35.1
+            clickhouse_version: "25.8"
+          - name: "Supported ClickHouse versions"
+            kind_version: v1.30.13
+            clickhouse_version: "26.1,25.12,25.11,25.8,25.3"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Go Mod
+        run: go mod download
+
+      - name: Build image
+        run: make docker-build IMG="clickhouse.com/clickhouse-operator:v0.0.1" BUILD_TIME=e2e
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: kind
+          version: ${{ env.kind-version }}
+          config: ci/kind-cluster.config
+          node_image: "kindest/node:${{ matrix.kind_version }}"
+
+      - name: Run compatibility e2e tests
+        run: make test-compat-e2e
+        env:
+          CLICKHOUSE_VERSION: ${{ matrix.clickhouse_version }}
+
+      - name: Test Report
+        uses: dorny/test-reporter@v2
+        if: ${{ !cancelled() }}
+        with:
+          name: compat-e2e (k8s ${{ matrix.k8s_version }}${{ matrix.clickhouse_version && format(', ch {0}', matrix.clickhouse_version) || '' }})
+          badge-title: compat-e2e (k8s ${{ matrix.k8s_version }})
+          path: "**/report/*.xml"
+          reporter: java-junit
+
   e2e-test:
     needs: [ lint, bundle, build_and_test, helm-validate, helm-test ]
     strategy:
@@ -242,7 +294,7 @@ jobs:
   ci-success-check:
     name: All CI checks passed
     runs-on: ubuntu-latest
-    needs: [ lint, bundle, build_and_test, helm-validate, helm-test, e2e-test ]
+    needs: [ lint, bundle, build_and_test, helm-validate, helm-test, compat-e2e-test, e2e-test ]
     if: always()
     steps:
       - name: Determine CI status

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,10 @@ test-keeper-e2e: ## Run keeper e2e tests.
 test-clickhouse-e2e: ## Run clickhouse e2e tests.
 	go test ./test/e2e/ --ginkgo.label-filter clickhouse -test.timeout 30m --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
+.PHONY: test-compat-e2e  # Run compatibility smoke tests across ClickHouse versions.
+test-compat-e2e: ## Run compatibility e2e tests.
+	go test ./test/e2e/ --ginkgo.label-filter compatibility -test.timeout 30m --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
+
 .PHONY: lint
 lint: golangci-lint codespell ## Run golangci-lint linter and codespell
 	$(GOLANGCI_LINT) run

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The Operator handles the full lifecycle of ClickHouse clusters, including scalin
 ### Prerequisites
 - go version v1.25.0+
 - docker version 17.03+
-- `kubectl` version v1.30.0+
-- Access to a Kubernetes v1.30.0+ cluster
+- `kubectl` version v1.28.0+
+- Access to a Kubernetes v1.28.0+ cluster
 - cert-manager installed in the cluster (for webhook certificates)
 
 ### Quick Start

--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -203,6 +203,8 @@ type ClickHouseCluster struct {
 
 	Spec   ClickHouseClusterSpec   `json:"spec,omitempty"`
 	Status ClickHouseClusterStatus `json:"status,omitempty"`
+
+	specificName string `json:"-"`
 }
 
 // ClickHouseReplicaID identifies a ClickHouse replica within the cluster.
@@ -306,9 +308,13 @@ func (v *ClickHouseCluster) Conditions() *[]metav1.Condition {
 	return &v.Status.Conditions
 }
 
-// SpecificName returns cluster name with resource suffix. Used to generate resource names.
+// SpecificName returns cluster name with resource suffix. Used to generate resource names that may be used in DNS.
 func (v *ClickHouseCluster) SpecificName() string {
-	return v.GetName() + "-clickhouse"
+	if v.specificName == "" {
+		v.specificName = normalizeName(v.Name) + "-clickhouse"
+	}
+
+	return v.specificName
 }
 
 // Shards returns requested number of shards in the ClickHouseCluster.

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -288,6 +289,11 @@ func (s *DefaultPasswordSelector) Validate() error {
 	}
 
 	return nil
+}
+
+// normalizeName removes dots from name to make it valid for use as a hostname or label value, where dots are not allowed.
+func normalizeName(name string) string {
+	return strings.ReplaceAll(name, ".", "-")
 }
 
 // formatPodHostname returns hostname for the first pod in the StatefulSet.

--- a/api/v1alpha1/keepercluster_types.go
+++ b/api/v1alpha1/keepercluster_types.go
@@ -166,6 +166,8 @@ type KeeperCluster struct {
 
 	Spec   KeeperClusterSpec   `json:"spec,omitempty"`
 	Status KeeperClusterStatus `json:"status,omitempty"`
+
+	specificName string `json:"-"`
 }
 
 // KeeperReplicaID represents ClickHouse Keeper replica ID. Used for naming resources and RAFT configuration.
@@ -213,7 +215,11 @@ func (v *KeeperCluster) Conditions() *[]metav1.Condition {
 
 // SpecificName returns cluster name with resource suffix. Used to generate resource names.
 func (v *KeeperCluster) SpecificName() string {
-	return v.GetName() + "-keeper"
+	if v.specificName == "" {
+		v.specificName = normalizeName(v.Name) + "-keeper"
+	}
+
+	return v.specificName
 }
 
 // Replicas returns requested number of replicas in the cluster.

--- a/config/manifests/bases/clickhouse-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/clickhouse-operator.clusterserviceversion.yaml
@@ -170,7 +170,7 @@ spec:
   - email: operator@clickhouse.com
     name: ClickHouse Team
   maturity: alpha
-  minKubeVersion: 1.30.0
+  minKubeVersion: 1.28.0
   provider:
     name: ClickHouse Inc.
     url: https://clickhouse.com

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -4,7 +4,7 @@ This guide covers installing the ClickHouse Operator using Helm charts.
 
 ## Prerequisites
 
-- Kubernetes cluster v1.30.0 or later
+- Kubernetes cluster v1.28.0 or later
 - Helm v3.0 or later
 - kubectl configured to communicate with your cluster
 

--- a/docs/installation/kubectl.md
+++ b/docs/installation/kubectl.md
@@ -4,8 +4,8 @@ This guide covers installing the ClickHouse Operator using kubectl and manifest 
 
 ## Prerequisites
 
-- Kubernetes cluster v1.30.0 or later
-- kubectl v1.30.0 or later
+- Kubernetes cluster v1.28.0 or later
+- kubectl v1.28.0 or later
 - Cluster admin permissions
 
 ## Install from Release Manifests

--- a/docs/installation/olm.md
+++ b/docs/installation/olm.md
@@ -11,7 +11,7 @@ This guide covers installing the ClickHouse Operator using Operator Lifecycle Ma
 
 ## Prerequisites
 
-- Kubernetes cluster version 1.30.0 or later
+- Kubernetes cluster version 1.28.0 or later
 - kubectl configured to access your cluster
 - Cluster admin permissions
 - Installed OLM (Operator Lifecycle Manager)

--- a/test/e2e/compatibility_e2e_test.go
+++ b/test/e2e/compatibility_e2e_test.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	"context"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
+	"k8s.io/utils/ptr"
+
+	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+)
+
+var _ = Context("Compatibility", Label("compatibility"), func() {
+	versionTag := os.Getenv("CLICKHOUSE_VERSION")
+	if versionTag == "" {
+		It("should have CLICKHOUSE_VERSION env var set", func() {
+			Fail("CLICKHOUSE_VERSION env var not set")
+		})
+
+		return
+	}
+
+	body := func(ctx context.Context, version string) {
+		dc, err := discovery.NewDiscoveryClientForConfig(config)
+		Expect(err).NotTo(HaveOccurred())
+		serverVersion, err := dc.ServerVersion()
+		Expect(err).NotTo(HaveOccurred())
+		By("running on Kubernetes " + serverVersion.GitVersion)
+
+		keeper := v1.KeeperCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      "compat-keeper-" + version,
+			},
+			Spec: v1.KeeperClusterSpec{
+				Replicas:            new(int32(3)),
+				DataVolumeClaimSpec: &defaultStorage,
+				ContainerTemplate: v1.ContainerTemplateSpec{
+					Image: v1.ContainerImage{
+						Tag: version,
+					},
+				},
+			},
+		}
+		clickhouse := v1.ClickHouseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      "compat-ch-" + version,
+			},
+			Spec: v1.ClickHouseClusterSpec{
+				Replicas:            new(int32(3)),
+				DataVolumeClaimSpec: &defaultStorage,
+				KeeperClusterRef: &corev1.LocalObjectReference{
+					Name: keeper.Name,
+				},
+				ContainerTemplate: v1.ContainerTemplateSpec{
+					Image: v1.ContainerImage{
+						Tag: version,
+					},
+				},
+			},
+		}
+
+		By("creating KeeperCluster")
+		Expect(k8sClient.Create(ctx, &keeper)).To(Succeed())
+		DeferCleanup(func(ctx context.Context) {
+			Expect(k8sClient.Delete(ctx, &keeper)).To(Succeed())
+		})
+
+		By("creating ClickHouseCluster")
+		Expect(k8sClient.Create(ctx, &clickhouse)).To(Succeed())
+		DeferCleanup(func(ctx context.Context) {
+			Expect(k8sClient.Delete(ctx, &clickhouse)).To(Succeed())
+		})
+
+		By("ensuring KeeperCluster is healthy")
+		WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
+		KeeperRWChecks(ctx, &keeper, ptr.To(0))
+
+		By("ensuring ClickHouseCluster is healthy")
+		WaitClickHouseUpdatedAndReady(ctx, &clickhouse, 2*time.Minute, false)
+		ClickHouseRWChecks(ctx, &clickhouse, ptr.To(0))
+	}
+
+	tableArgs := []any{body}
+	for version := range strings.SplitSeq(versionTag, ",") {
+		tableArgs = append(tableArgs, Entry("version: "+version, version))
+	}
+
+	DescribeTable("should successfully work", tableArgs...)
+})


### PR DESCRIPTION
## Why

Some users run older versions of k8s, and we need a way to ensure compatibility.

## What

Added e2e test that creates a basic cluster with the specified version and added a new CI job that runs it on different k8s versions.
