### PR TITLE
Fix WATCH_NAMESPACE typo in helm chart

### DIFF
--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -62,7 +62,7 @@ spec:
                       - /manager
                   {{- $env := append .Values.manager.env (dict "name" "ENABLE_WEBHOOKS" "value" (printf "%t" .Values.webhook.enable)) }}
                   {{- if not (empty .Values.watchNamespaces) }}
-                  {{-   $env = append $env (dict "name" "WATCH_NAMESPACES" "value" (join "," .Values.watchNamespaces)) }}
+                  {{-   $env = append $env (dict "name" "WATCH_NAMESPACE" "value" (join "," .Values.watchNamespaces)) }}
                   {{- end }}
                   env: {{ toYaml $env | nindent 22 }}
                   image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"


### PR DESCRIPTION
There a typo making the operator always watch all namespaces even when configured to limit to a list
