### PR TITLE
Add explicit default cluster defenition with internal_replication=1 and generated cluster secret

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -106,9 +106,6 @@ linters:
     gosec:
       excludes:
         - G204
-    godot:
-      exclude:
-        - "^ *\\+operator-sdk:"
     ireturn:
       allow:
         - error
@@ -117,6 +114,7 @@ linters:
         - generic
         - Option$
         - github.com\/ClickHouse\/clickhouse-go/v2\.Conn
+        - github.com\/ClickHouse\/clickhouse-go\/v2\/lib\/driver\.Rows
         - k8s.io
     wsl_v5:
       allow-whole-block: true

--- a/internal/controller/clickhouse/constants.go
+++ b/internal/controller/clickhouse/constants.go
@@ -47,10 +47,12 @@ const (
 	EnvInterserverPassword = "CLICKHOUSE_INTERSERVER_PASSWORD"
 	EnvDefaultUserPassword = "CLICKHOUSE_DEFAULT_USER_PASSWORD"
 	EnvKeeperIdentity      = "CLICKHOUSE_KEEPER_IDENTITY"
+	EnvClusterSecret       = "CLICKHOUSE_CLUSTER_SECRET"
 
 	SecretKeyInterserverPassword = "interserver-password"
 	SecretKeyManagementPassword  = "management-password"
 	SecretKeyKeeperIdentity      = "keeper-identity"
+	SecretKeyClusterSecret       = "cluster-secret"
 )
 
 var (
@@ -59,5 +61,14 @@ var (
 		SecretKeyInterserverPassword: "%s",
 		SecretKeyManagementPassword:  "%s",
 		SecretKeyKeeperIdentity:      "clickhouse:%s",
+		SecretKeyClusterSecret:       "%s",
+	}
+	secretsToEnvMapping = []struct {
+		Key string
+		Env string
+	}{
+		{Key: SecretKeyInterserverPassword, Env: EnvInterserverPassword},
+		{Key: SecretKeyKeeperIdentity, Env: EnvKeeperIdentity},
+		{Key: SecretKeyClusterSecret, Env: EnvClusterSecret},
 	}
 )

--- a/internal/controller/clickhouse/templates/base.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/base.yaml.tmpl
@@ -2,8 +2,8 @@ path: {{ .Path }}
 logger:
 {{ yaml .Log | indent 2 }}
 macros:
-  {{- range $key, $value := .Macros }}
-  {{ $key }}: {{ $value }}
+  {{- range $i, $m := .Macros }}
+  {{ $m.Name }}: {{ $m.Value }}
   {{- end }}
 
 {{- /* Replication settings */}}
@@ -18,6 +18,21 @@ zookeeper:
     {{- end }}
   identity:
     "@from_env": {{ .KeeperIdentityEnv }}
+
+remote_servers:
+  default:
+    secret:
+      "@from_env": {{ .ClusterSecretEnv }}
+    shard:
+    {{- $ctx := .}}
+    {{- range $shard, $replicas := .ClusterHosts }}
+      - internal_replication: true
+        replica:
+        {{- range $i, $replica := $replicas }}
+          - host: {{ $replica }}
+            port: {{ $ctx.ManagementPort }}
+        {{- end }}
+    {{- end }}
 
 distributed_ddl:
   path: {{ .DistributedDDLPath }}

--- a/internal/controller/clickhouse/templates/network.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/network.yaml.tmpl
@@ -12,17 +12,17 @@ interserver_http_credentials:
 tcp_port: {{ .ManagementPort }}
 
 protocols:
-{{- range $name, $protocol := .Protocols }}
-  {{ $name }}:
-    type: {{ $protocol.Type }}
-    {{- if ne $protocol.Impl "" }}
-    impl: {{ $protocol.Impl }}
+{{- range $protocol := .Protocols }}
+  {{ $protocol.Name }}:
+    type: {{ $protocol.Protocol.Type }}
+    {{- if ne $protocol.Protocol.Impl "" }}
+    impl: {{ $protocol.Protocol.Impl }}
     {{- end }}
-    {{- if ne $protocol.Port 0 }}
-    port: {{ $protocol.Port }}
+    {{- if ne $protocol.Protocol.Port 0 }}
+    port: {{ $protocol.Protocol.Port }}
     {{- end }}
-    {{- if ne $protocol.Description "" }}
-    description: {{ $protocol.Description }}
+    {{- if ne $protocol.Protocol.Description "" }}
+    description: {{ $protocol.Protocol.Description }}
     {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Why

`internal_replication` is a reasonable default
cluster `secret`  is needed to authenticate on remote nodes if the default user password is set

## What

Added an explicit default cluster with all replicas, internal_replication, and generated cluster secret.
Use lists instead of maps in config generators for determinism
E2e test

## Related Issues

Fixes: #82

