### PR TITLE
fix wrong value key and bad spacing

### DIFF
--- a/dist/chart/templates/monitoring/servicemonitor.yaml
+++ b/dist/chart/templates/monitoring/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enable }}
+{{- if .Values.prometheus.service_monitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -8,8 +8,8 @@ metadata:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         control-plane: controller-manager
-  name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
-  namespace: {{ .Release.Namespace }}
+    name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "controller-manager-metrics-monitor" "context" $) }}
+    namespace: {{ .Release.Namespace }}
 spec:
     endpoints:
         - path: /metrics
@@ -37,8 +37,8 @@ spec:
             # Development/Test mode (insecure configuration)
             insecureSkipVerify: true
             {{- end }}
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
-      control-plane: controller-manager
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
+            control-plane: controller-manager
 {{- end }}


### PR DESCRIPTION
## Why

There are some minor bugs in the `servicemonitor.yaml` template of the helm chart as described in #94 and #95 

## What

This commit fixes the spacing issue that prevented rendering of the `servicemonitor.yaml` template and also sets the condition to the actual value in the `values.yaml` file.

## Related Issues



Fixes #94 
Fixes #95 
