### PR TITLE
Refactor documentation to use it as source for docs website

### DIFF
--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -27,8 +27,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: tcort/github-action-markdown-link-check@v1
         with:
-          config-file: ci/.markdown-link-check.json
-          file-extension: '.md'
+          file-path: |
+            README.md
+            docs/README.md
+            docs/development.md
 
   api-reference-generated:
     name: API Reference Generated

--- a/Makefile
+++ b/Makefile
@@ -516,7 +516,7 @@ docs-generate-api-ref: crd-ref-docs ## Generate API reference documentation from
 		--config=docs/templates/.crd-ref-docs.yaml \
 		--templates-dir=docs/templates \
 		--renderer=markdown \
-		--output-path=docs/api_reference.md \
+		--output-path=docs/04_api_reference.md \
 		--max-depth=10
 
 .PHONY: docs-lint-vale
@@ -527,7 +527,7 @@ docs-lint-vale: ## Run Vale linter on documentation
 .PHONY: docs-link-check
 docs-link-check: ## Run markdown-link-check on documentation
 	@command -v markdown-link-check >/dev/null 2>&1 || { echo "markdown-link-check is required but not installed. npm install -g markdown-link-check"; exit 1; }
-	markdown-link-check -c ci/.markdown-link-check.json *.md docs
+	markdown-link-check README.md docs/README.md docs/development.md
 
 .PHONY: docs-lint
 docs-lint: docs-lint-vale docs-link-check ## Run all documentation linters

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Operator handles the full lifecycle of ClickHouse clusters, including scalin
 ## Getting Started
 
 ### Prerequisites
-- go version v1.25.0+
+- go version v1.26.0+
 - docker version 17.03+
 - `kubectl` version v1.28.0+
 - Access to a Kubernetes v1.28.0+ cluster

--- a/ci/.markdown-link-check.json
+++ b/ci/.markdown-link-check.json
@@ -1,7 +1,0 @@
-{
-  "ignorePatterns": [
-    {
-      "pattern": "^https://github.com/ClickHouse/clickhouse-operator/issues$"
-    }
-  ]
-}

--- a/docs/01_overview.md
+++ b/docs/01_overview.md
@@ -1,0 +1,41 @@
+---
+position: 1
+slug: /clickhouse-operator/overview
+title: 'ClickHouse Operator'
+keywords: ['kubernetes']
+description: 'Overview page for the ClickHouse Operator - a Kubernetes operator that automates the deployment, configuration, and management of ClickHouse clusters and ClickHouse Keeper clusters on Kubernetes.'
+doc_type: 'guide'
+sidebar_label: 'Overview'
+---
+
+The ClickHouse Operator is a Kubernetes operator that automates the deployment, configuration, and management of ClickHouse clusters and ClickHouse Keeper clusters on Kubernetes.
+It provides declarative cluster management through custom resources, enabling users to easily create highly-available ClickHouse deployments.
+
+The Operator handles the full lifecycle of ClickHouse clusters including scaling, upgrades, and configuration management.
+
+## Features {#features}
+
+- **ClickHouse Cluster Management**: Create and manage ClickHouse clusters
+- **ClickHouse Keeper Integration**: Built-in support for ClickHouse Keeper clusters for distributed coordination
+- **Storage Provisioning**: Customizable persistent volume claims with storage class selection
+- **High Availability**: Fault tolerant installations for ClickHouse and Keeper clusters
+- **Security**: Built-in security features TLS/SSL support for secure cluster communication
+- **Monitoring**: Prometheus metrics integration for observability
+
+## Installation {#installation}
+
+Choose your preferred installation method:
+
+- [Manifests Installation](./02_install/kubectl.md) - Install using kubectl/kustomize
+- [Helm Installation](./02_install/helm.md) - Install using Helm charts
+- [Operator Lifecycle Manager (OLM) Installation](./02_install/olm.md) - Install using OLM
+
+## Guides {#guides}
+
+- **[Introduction](./03_guides/01_introduction.md)** - General overview of ClickHouse Operator concepts
+- **[Configuration Guide](./03_guides/02_configuration.md)** - Configure ClickHouse and Keeper clusters
+
+## Reference {#reference}
+
+- **[API Reference](./04_api_reference.md)** - Complete API documentation for custom resources
+- **[Source Code](https://github.com/ClickHouse/clickhouse-operator)** - Explore the Operator's source code on GitHub

--- a/docs/02_install/_category_.yml
+++ b/docs/02_install/_category_.yml
@@ -1,0 +1,4 @@
+position: 2
+label: 'Install'
+collapsible: true
+collapsed: true

--- a/docs/02_install/helm.md
+++ b/docs/02_install/helm.md
@@ -1,14 +1,21 @@
-# Installation with Helm
+---
+slug: /clickhouse-operator/install/helm
+title: 'Install the ClickHouse Operator with Helm'
+keywords: ['kubernetes']
+description: 'This guide covers installing the ClickHouse Operator using Helm charts.'
+doc_type: 'guide'
+sidebar_label: 'Helm'
+---
 
 This guide covers installing the ClickHouse Operator using Helm charts.
 
-## Prerequisites
+## Prerequisites {#prerequisites}
 
 - Kubernetes cluster v1.28.0 or later
 - Helm v3.0 or later
 - kubectl configured to communicate with your cluster
 
-## Install Helm
+## Install Helm {#install-helm}
 
 If you don't have Helm installed:
 
@@ -22,14 +29,17 @@ Verify installation:
 helm version
 ```
 
-## Install the Operator
+## Install the Operator {#install-the-operator}
 
-**NOTE:**  By default Helm chart deploys ClickHouse Operator with webhooks enabled and requires cert-manager installed.
+:::note
+By default Helm chart deploys ClickHouse Operator with webhooks enabled and requires cert-manager installed.
+:::
+
 ```bash
 helm install cert-manager oci://quay.io/jetstack/charts/cert-manager -n cert-manager --create-namespace --set crds.enabled=true
 ```
 
-### From OCI Helm Repository
+### From OCI Helm repository {#from-oci-helm-repository}
 
 Install the latest release
 ```bash
@@ -46,7 +56,7 @@ Install a specific operator version
        --set-json="manager.container.tag=<operator version>
 ```
 
-### From Local Chart
+### From Local Chart {#from-local-chart}
 
 Clone the repository and install from the local chart:
 
@@ -56,5 +66,6 @@ cd clickhouse-operator
 helm install clickhouse-operator ./dist/chart
 ```
 
-### Configuration Options
-For advanced configuration options, refer to the [values.yaml](../../dist/chart/values.yaml) file in the Helm chart
+### Configuration options {#configuration-options}
+
+For advanced configuration options, refer to the [values.yaml](https://github.com/ClickHouse/clickhouse-operator/blob/main/dist/chart/values.yaml) file in the Helm chart

--- a/docs/02_install/kubectl.md
+++ b/docs/02_install/kubectl.md
@@ -1,16 +1,25 @@
-# Installation with kubectl
+---
+slug: /clickhouse-operator/install/kubectl
+title: 'Install the ClickHouse Operator with kubectl'
+keywords: ['kubernetes']
+description: 'This guide covers installing the ClickHouse Operator using kubectl and manifest files.'
+doc_type: 'guide'
+sidebar_label: 'kubectl'
+---
 
 This guide covers installing the ClickHouse Operator using kubectl and manifest files.
 
-## Prerequisites
+## Prerequisites {#prerequisites}
 
 - Kubernetes cluster v1.28.0 or later
 - kubectl v1.28.0 or later
 - Cluster admin permissions
 
-## Install from Release Manifests
+## Install from Release Manifests {#install-from-release-manifests}
 
-**NOTE:** Requires cert-manager to issue webhook certificates.
+:::note
+Requires cert-manager to issue webhook certificates.
+:::
 
 Install the operator and CRDs from the latest release:
 
@@ -27,7 +36,7 @@ This will:
 6. Configure SSL certificates using cert-manager
 7. Enable metrics endpoint
 
-## Verify Installation
+## Verify Installation {#verify-installation}
 
 Check that the operator is running:
 
@@ -36,7 +45,7 @@ kubectl get pods -n clickhouse-operator-system
 ```
 
 Expected output:
-```
+```text
 NAME                                                 READY   STATUS    RESTARTS   AGE
 clickhouse-operator-controller-manager-xxxxxxxxxx    1/1     Running   0          1m
 ```
@@ -48,23 +57,23 @@ kubectl get crd | grep clickhouse.com
 ```
 
 Expected output:
-```
+```text
 clickhouseclusters.clickhouse.com    2025-01-06T00:00:00Z
 keeperclusters.clickhouse.com        2025-01-06T00:00:00Z
 ```
 
-## Configure Custom Deployment Options
+## Configure Custom Deployment Options {#configure-custom-deployment-options}
 
 If you want to configure operator deployment options, follow the steps below.
 
-### 1. Clone the Repository
+### 1. Clone the Repository {#clone-the-repository}
 
 ```bash
 git clone https://github.com/ClickHouse/clickhouse-operator.git
 cd clickhouse-operator
 ```
 
-### 2. Configure installation options
+### 2. Configure installation options {#configure-installation-options}
 
 Edit config/default/kustomization.yaml to enable/disable features as needed.
 
@@ -73,7 +82,7 @@ Edit config/default/kustomization.yaml to enable/disable features as needed.
 * To enable ServiceMonitor for Prometheus Operator, uncomment the `[PROMETHEUS]` section.
 * To enable operator network policies, uncomment the `[NETWORK POLICY]` section.
 
-### 3. Build and Deploy
+### 3. Build and Deploy {#build-and-deploy}
 
 Build the operator manifests and apply them:
 

--- a/docs/02_install/olm.md
+++ b/docs/02_install/olm.md
@@ -1,24 +1,24 @@
-# OLM Installation
+---
+slug: /clickhouse-operator/install/olm
+title: 'Install the ClickHouse Operator with Operator Lifecycle Manager (OLM)'
+keywords: ['kubernetes']
+description: 'This guide covers installing the ClickHouse Operator using Operator Lifecycle Manager (OLM).'
+doc_type: 'guide'
+sidebar_label: 'OLM'
+---
 
 This guide covers installing the ClickHouse Operator using Operator Lifecycle Manager (OLM).
 
-## Table of Contents
-
-- [Prerequisites](#prerequisites)
-- [Install OLM](#install-olm)
-- [Install the Operator](#install-the-operator)
-- [Uninstall](#uninstall)
-
-## Prerequisites
+## Prerequisites {#prerequisites}
 
 - Kubernetes cluster version 1.28.0 or later
 - kubectl configured to access your cluster
 - Cluster admin permissions
 - Installed OLM (Operator Lifecycle Manager)
 
-## Install OLM
+## Install OLM {#install-olm}
 
-If OLM is not already installed in your cluster, install it:
+If OLM isn't already installed in your cluster, install it:
 
 ```bash
 # Check if OLM is installed
@@ -28,9 +28,9 @@ kubectl get ns olm
 curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.28.0/install.sh | bash -s v0.28.0
 ```
 
-## Install the Operator
+## Install the Operator {#install-the-operator}
 
-### Install from GitHub Catalog
+### Install from GitHub Catalog {#install-from-github-catalog}
 
 ```bash
 # Create the operator namespace
@@ -77,7 +77,12 @@ spec:
   installPlanApproval: Automatic
 EOF
 ```
-## Uninstall
+
+### Install from OperatorHub {#install-from-operatorhub}
+
+Follow the instructions on the [OperatorHub page for ClickHouse Operator](https://operatorhub.io/operator/clickhouse-operator) to install the operator using OLM.
+
+## Uninstall {#uninstall}
 
 ```bash
 # Delete the subscription
@@ -92,8 +97,9 @@ kubectl delete operatorgroup clickhouse-operator-group -n clickhouse-operator-sy
 # Delete the Operator view
 kubectl delete operator clickhouse-operator.clickhouse-operator-system
 ```
+
 More info about uninstalling can be found in the [OLM documentation](https://olm.operatorframework.io/docs/tasks/uninstall-operator/).
 
-## Additional Resources
+## Additional Resources {#additional-resources}
 
 - [Operator Lifecycle Manager Documentation](https://olm.operatorframework.io/docs)

--- a/docs/03_guides/01_introduction.md
+++ b/docs/03_guides/01_introduction.md
@@ -1,17 +1,17 @@
-# Introduction to the ClickHouse Operator
+---
+position: 1
+slug: /clickhouse-operator/guides/introduction
+title: 'Introduction'
+keywords: ['kubernetes']
+description: 'This document provides an overview of key concepts and usage patterns for the ClickHouse Operator.'
+doc_type: 'guide'
+---
+
+# Introduction to the ClickHouse Operator {#introduction-to-the-clickhouse-operator}
 
 This document provides an overview of key concepts and usage patterns for the ClickHouse Operator.
 
-## Table of Contents
-
-- [What is the ClickHouse Operator](#what-is-the-clickhouse-operator)
-- [Custom Resources](#custom-resources)
-- [Coordination](#coordination)
-- [Schema Replication](#schema-replication)
-- [Storage Management](#storage-management)
-- [Default configuration Highlights](#default-configuration-highlights)
-
-## What is the ClickHouse Operator
+## What is the ClickHouse Operator {#what-is-the-clickhouse-operator}
 
 The ClickHouse Operator is a Kubernetes operator that automates the deployment and management of ClickHouse clusters on Kubernetes. Built using the operator pattern, it extends the Kubernetes API with custom resources that represent ClickHouse clusters and their dependencies.
 
@@ -23,11 +23,11 @@ The operator handles:
 - Rolling updates and upgrades
 - Storage provisioning
 
-## Custom Resources
+## Custom resources {#custom-resources}
 
 The operator provides two main custom resource definitions (CRDs):
 
-### ClickHouseCluster
+### ClickHouseCluster {#clickhousecluster}
 
 Represents a ClickHouse database cluster with configurable replicas and shards.
 
@@ -47,7 +47,7 @@ spec:
         storage: 100Gi
 ```
 
-### KeeperCluster
+### KeeperCluster {#keepercluster}
 
 Represents a ClickHouse Keeper cluster for distributed coordination (ZooKeeper replacement).
 
@@ -64,24 +64,26 @@ spec:
         storage: 10Gi
 ```
 
-## Coordination
+## Coordination {#coordination}
 
-### ClickHouse Keeper is Required
+### ClickHouse Keeper is required {#clickhouse-keeper-is-required}
 
-Every ClickHouseCluster requires a ClickHouse Keeper cluster for distributed coordination. 
+Every ClickHouseCluster requires a ClickHouse Keeper cluster for distributed coordination.
 The Keeper cluster must be referenced in the ClickHouseCluster spec using `keeperClusterRef`.
 
-###  One-to-One Keeper Relationship
+###  One-to-One Keeper relationship {#one-to-one-keeper-relationship}
 
-Each ClickHouseCluster must have its own dedicated KeeperCluster. You cannot share a single KeeperCluster between multiple ClickHouseClusters.
+Each ClickHouseCluster must have its own dedicated KeeperCluster. You can't share a single KeeperCluster between multiple ClickHouseClusters.
 
-**Why?** The operator automatically generates a unique authentication key for each ClickHouseCluster to access its Keeper. This key is stored in a Secret and cannot be shared.
+**Why?** The operator automatically generates a unique authentication key for each ClickHouseCluster to access its Keeper. This key is stored in a Secret and can't be shared.
 
 **Consequences**:
-- Multiple ClickHouseClusters cannot reference the same KeeperCluster
+- Multiple ClickHouseClusters can't reference the same KeeperCluster
 - Recreating a ClickHouseCluster requires recreating its KeeperCluster
 
-**NOTE**: Persistent Volumes are not deleted automatically when ClickHouseCluster or KeeperCluster resources are deleted.
+:::note
+Persistent Volumes aren't deleted automatically when ClickHouseCluster or KeeperCluster resources are deleted.
+:::
 
 When recreating a cluster:
 1. Delete the ClickHouseCluster resource
@@ -92,14 +94,14 @@ When recreating a cluster:
 
 To avoid authentication errors, either delete the Persistent Volumes manually or recreate both clusters together with fresh storage.
 
-## Schema Replication
+## Schema Replication {#schema-replication}
 
 The ClickHouse Operator automatically replicates database definitions across all replicas in a cluster.
 
-### What Gets Replicated
+### What Gets Replicated {#what-gets-replicated}
 
 The operator synchronizes:
-- [Replicated](https://clickhouse.com/docs/engines/database-engines/replicated) database definitions
+- [Replicated](/engines/database-engines/replicated) database definitions
 - Integration database engines (PostgreSQL, MySQL, etc.)
 
 The operator does **not** synchronize:
@@ -107,9 +109,11 @@ The operator does **not** synchronize:
 - Local tables in non-replicated databases
 - Table data (handled by ClickHouse replication)
 
-### Recommended: Use Replicated Database Engine
+### Recommended: Use Replicated database engine {#recommended-use-replicated-database-engine}
 
-**✅ Best Practice**: Always use the [Replicated](https://clickhouse.com/docs/engines/database-engines/replicated) database engine for production deployments.
+:::tip Best practice
+Always use the [Replicated](/docs/engines/database-engines/replicated) database engine for production deployments.
+:::
 
 Benefits:
 - Automatic schema replication across all nodes
@@ -123,22 +127,22 @@ Create databases with distributed DDL:
 CREATE DATABASE my_database ON CLUSTER 'default' ENGINE = Replicated;
 ```
 
-### Avoid Non-Replicated Engines
+### Avoid non-Replicated engines {#avoid-non-replicated-engines}
 
 Non-replicated database engines (Atomic, Lazy, SQLite, Ordinary) require manual schema management:
 - Tables must be created individually on each replica
 - Schema drift can occur between nodes
-- Operator cannot automatically sync new replicas
+- Operator can't automatically sync new replicas
 
-### Disable Schema Replication
+### Disable schema replication {#disable-schema-replication}
 
 To disable automatic schema replication, set `spec.settings.enableDatabaseSync` to `false` in the ClickHouseCluster resource.
 
-## Storage Management
+## Storage management {#storage-management}
 
 The operator manages storage through Kubernetes PersistentVolumeClaims (PVCs).
 
-### Data Volume Configuration
+### Data volume configuration {#data-volume-configuration}
 
 Specify storage requirements in `dataVolumeClaimSpec`:
 
@@ -153,7 +157,7 @@ spec:
         storage: 500Gi
 ```
 
-### Storage Lifecycle
+### Storage Lifecycle {#storage-lifecycle}
 
 - **Creation**: PVCs are created automatically with the cluster
 - **Expansion**: Supported if StorageClass allows volume expansion
@@ -173,7 +177,7 @@ kubectl wait --for=delete pod -l app.kubernetes.io/instance=my-cluster
 kubectl delete pvc -l app.kubernetes.io/instance=sample-cluster
 ```
 
-## Default configuration Highlights
+## Default configuration highlights {#default-configuration-highlights}
 
 * **Pre-configured Cluster:** Cluster named 'default' containing all ClickHouse nodes.
 * **Default macros:** Some useful macros are pre-defined:
@@ -183,7 +187,7 @@ kubectl delete pvc -l app.kubernetes.io/instance=sample-cluster
 * **Replicated storage for Role Based Access Control(RBAC) entities**
 * **Replicated storage for User Defined Functions(UDF)**
 
-## Next Steps
+## Next steps {#next-steps}
 
-- [Configuration Guide](./configuration.md) - Detailed configuration options
-- [API Reference](./api_reference.md) - Complete API documentation
+- [Configuration Guide](./02_configuration.md) - Detailed configuration options
+- [API Reference](../04_api_reference.md) - Complete API documentation

--- a/docs/03_guides/_category_.yml
+++ b/docs/03_guides/_category_.yml
@@ -1,0 +1,4 @@
+position: 3
+label: 'Guides'
+collapsible: true
+collapsed: true

--- a/docs/04_api_reference.md
+++ b/docs/04_api_reference.md
@@ -1,14 +1,21 @@
-# API Reference
+---
+position: 1
+slug: /clickhouse-operator/reference/api-reference
+title: 'ClickHouse Operator API reference'
+keywords: ['kubernetes']
+description: 'This document provides detailed API reference for the ClickHouse Operator custom resources.'
+doc_type: 'reference'
+sidebar_label: 'API reference'
+---
+
+# ClickHouse Operator API reference {#clickhouse-operator-api-reference}
 
 This document provides detailed API reference for the ClickHouse Operator custom resources.
 
-
-
-
-## ClickHouseCluster
+## ClickHouseCluster {#clickhousecluster}
 
 ClickHouseCluster is the Schema for the `clickhouseclusters` API.
-### API Version and Kind
+### API Version and Kind {#clickhousecluster-api-version-and-kind}
 
 ```yaml
 apiVersion: clickhouse.com/v1alpha1
@@ -23,11 +30,10 @@ kind: ClickHouseCluster
 Appears in:
 - [ClickHouseClusterList](#clickhouseclusterlist)
 
-
-## ClickHouseClusterList
+## ClickHouseClusterList {#clickhouseclusterlist}
 
 ClickHouseClusterList contains a list of ClickHouseCluster.
-### API Version and Kind
+### API Version and Kind {#clickhouseclusterlist-api-version-and-kind}
 
 ```yaml
 apiVersion: clickhouse.com/v1alpha1
@@ -38,8 +44,7 @@ kind: ClickHouseClusterList
 |-------|------|-------------|----------|---------|
 | `items` | [ClickHouseCluster](#clickhousecluster) array |  | true |  |
 
-
-## ClickHouseClusterSpec
+## ClickHouseClusterSpec {#clickhouseclusterspec}
 
 ClickHouseClusterSpec defines the desired state of ClickHouseCluster.
 
@@ -59,8 +64,7 @@ ClickHouseClusterSpec defines the desired state of ClickHouseCluster.
 Appears in:
 - [ClickHouseCluster](#clickhousecluster)
 
-
-## ClickHouseClusterStatus
+## ClickHouseClusterStatus {#clickhouseclusterstatus}
 
 ClickHouseClusterStatus defines the observed state of ClickHouseCluster.
 
@@ -77,9 +81,7 @@ ClickHouseClusterStatus defines the observed state of ClickHouseCluster.
 Appears in:
 - [ClickHouseCluster](#clickhousecluster)
 
-
-
-## ClickHouseSettings
+## ClickHouseSettings {#clickhousesettings}
 
 ClickHouseSettings defines ClickHouse server settings options.
 
@@ -95,8 +97,7 @@ ClickHouseSettings defines ClickHouse server settings options.
 Appears in:
 - [ClickHouseClusterSpec](#clickhouseclusterspec)
 
-
-## ClusterTLSSpec
+## ClusterTLSSpec {#clustertlsspec}
 
 ClusterTLSSpec defines cluster TLS configuration.
 
@@ -111,10 +112,7 @@ Appears in:
 - [ClickHouseSettings](#clickhousesettings)
 - [KeeperSettings](#keepersettings)
 
-
-
-
-## ConfigMapKeySelector
+## ConfigMapKeySelector {#configmapkeyselector}
 
 ConfigMapKeySelector selects a key of a ConfigMap.
 
@@ -126,8 +124,7 @@ ConfigMapKeySelector selects a key of a ConfigMap.
 Appears in:
 - [DefaultPasswordSelector](#defaultpasswordselector)
 
-
-## ContainerImage
+## ContainerImage {#containerimage}
 
 ContainerImage defines a container image with repository, tag or hash.
 
@@ -140,8 +137,7 @@ ContainerImage defines a container image with repository, tag or hash.
 Appears in:
 - [ContainerTemplateSpec](#containertemplatespec)
 
-
-## ContainerTemplateSpec
+## ContainerTemplateSpec {#containertemplatespec}
 
 ContainerTemplateSpec describes the container configuration overrides for the cluster's containers.
 
@@ -158,8 +154,7 @@ Appears in:
 - [ClickHouseClusterSpec](#clickhouseclusterspec)
 - [KeeperClusterSpec](#keeperclusterspec)
 
-
-## DefaultPasswordSelector
+## DefaultPasswordSelector {#defaultpasswordselector}
 
 DefaultPasswordSelector selects the source for the default user's password.
 
@@ -172,13 +167,10 @@ DefaultPasswordSelector selects the source for the default user's password.
 Appears in:
 - [ClickHouseSettings](#clickhousesettings)
 
-
-
-
-## KeeperCluster
+## KeeperCluster {#keepercluster}
 
 KeeperCluster is the Schema for the `keeperclusters` API.
-### API Version and Kind
+### API Version and Kind {#keepercluster-api-version-and-kind}
 
 ```yaml
 apiVersion: clickhouse.com/v1alpha1
@@ -193,11 +185,10 @@ kind: KeeperCluster
 Appears in:
 - [KeeperClusterList](#keeperclusterlist)
 
-
-## KeeperClusterList
+## KeeperClusterList {#keeperclusterlist}
 
 KeeperClusterList contains a list of KeeperCluster.
-### API Version and Kind
+### API Version and Kind {#keeperclusterlist-api-version-and-kind}
 
 ```yaml
 apiVersion: clickhouse.com/v1alpha1
@@ -208,8 +199,7 @@ kind: KeeperClusterList
 |-------|------|-------------|----------|---------|
 | `items` | [KeeperCluster](#keepercluster) array |  | true |  |
 
-
-## KeeperClusterSpec
+## KeeperClusterSpec {#keeperclusterspec}
 
 KeeperClusterSpec defines the desired state of KeeperCluster.
 
@@ -227,8 +217,7 @@ KeeperClusterSpec defines the desired state of KeeperCluster.
 Appears in:
 - [KeeperCluster](#keepercluster)
 
-
-## KeeperClusterStatus
+## KeeperClusterStatus {#keeperclusterstatus}
 
 KeeperClusterStatus defines the observed state of KeeperCluster.
 
@@ -245,9 +234,7 @@ KeeperClusterStatus defines the observed state of KeeperCluster.
 Appears in:
 - [KeeperCluster](#keepercluster)
 
-
-
-## KeeperSettings
+## KeeperSettings {#keepersettings}
 
 KeeperSettings defines ClickHouse Keeper server configuration.
 
@@ -260,8 +247,7 @@ KeeperSettings defines ClickHouse Keeper server configuration.
 Appears in:
 - [KeeperClusterSpec](#keeperclusterspec)
 
-
-## LoggerConfig
+## LoggerConfig {#loggerconfig}
 
 LoggerConfig defines server logging configuration.
 
@@ -277,8 +263,7 @@ Appears in:
 - [ClickHouseSettings](#clickhousesettings)
 - [KeeperSettings](#keepersettings)
 
-
-## PodTemplateSpec
+## PodTemplateSpec {#podtemplatespec}
 
 PodTemplateSpec describes the pod configuration overrides for the cluster's pods.
 
@@ -301,8 +286,7 @@ Appears in:
 - [ClickHouseClusterSpec](#clickhouseclusterspec)
 - [KeeperClusterSpec](#keeperclusterspec)
 
-
-## SecretKeySelector
+## SecretKeySelector {#secretkeyselector}
 
 SecretKeySelector selects a key of a Secret.
 
@@ -314,4 +298,3 @@ SecretKeySelector selects a key of a Secret.
 Appears in:
 - [ClusterTLSSpec](#clustertlsspec)
 - [DefaultPasswordSelector](#defaultpasswordselector)
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,17 @@
-# Table of contents
+# ClickHouse Operator Documentation
 
-## Installation
+## To read the documentation, visit the [ClickHouse Docs](https://clickhouse.com/docs/clickhouse-operator/overview).
 
-Choose your preferred installation method:
+This directory contains the documentation sources for the ClickHouse Operator.
 
-- [Manifests Installation](./installation/kubectl.md) - Install using kubectl/kustomize
-- [Helm Installation](./installation/helm.md) - Install using Helm charts
-- [Operator Lifecycle Manager (OLM) Installation](./installation/olm.md) - Install using OLM
+The [clickhouse-docs](https://github.com/ClickHouse/clickhouse-docs) repository copies `.md` and `.yml` files into its `docs/kubernetes-operator/` directory during its
+build process.
 
-## Guides
+## API Reference Generation
 
-- **[Introduction](./introduction.md)** - General overview of ClickHouse Operator concepts
-- **[Configuration Guide](./configuration.md)** - Configure ClickHouse and Keeper clusters
+The API reference (`04_api_reference.md`) is generated from CRD types:
 
-## Reference
-
-- **[API Reference](./api_reference.md)** - Complete API documentation for custom resources
-- [ClickHouse Documentation](https://clickhouse.com/docs) - Official ClickHouse documentation
-
-## Development
-
-- [Development Guide](./development.md) - Contributors guide for developing the operator
-
-## Support
-
-- GitHub Issues: [Report bugs and request features](https://github.com/ClickHouse/clickhouse-operator/issues)
+```bash
+make docs-generate-api-ref
+```
+`templates/` contains the templates used for generating the API reference documentation.

--- a/docs/templates/gv_details.tpl
+++ b/docs/templates/gv_details.tpl
@@ -1,6 +1,6 @@
 {{- define "gvDetails" -}}
-{{- $gv := . -}}
-{{ range $gv.SortedTypes }}
-{{- template "type" . }}
-{{ end -}}
+{{- $gv := . }}
+{{- range $gv.SortedTypes }}
+{{-   template "type" . }}
+{{- end }}
 {{- end -}}

--- a/docs/templates/gv_list.tpl
+++ b/docs/templates/gv_list.tpl
@@ -1,10 +1,20 @@
 {{- define "gvList" -}}
 {{- $groupVersions := . -}}
-# API Reference
+---
+position: 1
+slug: /clickhouse-operator/reference/api-reference
+title: 'ClickHouse Operator API reference'
+keywords: ['kubernetes']
+description: 'This document provides detailed API reference for the ClickHouse Operator custom resources.'
+doc_type: 'reference'
+sidebar_label: 'API reference'
+---
+
+# ClickHouse Operator API reference {#clickhouse-operator-api-reference}
 
 This document provides detailed API reference for the ClickHouse Operator custom resources.
 
-{{ range $groupVersions }}
-{{ template "gvDetails" . }}
-{{ end }}
+{{- range $groupVersions }}
+{{- template "gvDetails" . }}
+{{- end }}
 {{- end -}}

--- a/docs/templates/type.tpl
+++ b/docs/templates/type.tpl
@@ -10,12 +10,12 @@
 {{ $type := . -}}
 {{-  if markdownShouldRenderType $type }}
 
-## {{ $type.Name }}
+## {{ $type.Name }} {#{{ lower $type.Name }}}
 
 {{ $type.Doc }}
 
 {{- if $type.GVK }}
-### API Version and Kind
+### API Version and Kind {#{{ $type.Name | lower }}-api-version-and-kind}
 
 ```yaml
 apiVersion: {{ $type.GVK.Group }}/{{ $type.GVK.Version }}


### PR DESCRIPTION
## Why

To use docs/ folder as the source of truth for the clickhouse-docs repo during documentation build.

## What

Rewrote all documentation files to the clickhouse-docs docusaurus format

