### PR TITLE
chore add rows.Err check in tests

### DIFF
--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -826,6 +826,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				response[shard] = sum
 			}
 
+			Expect(rows.Err()).ToNot(HaveOccurred())
+
 			return gcmp.Diff(response, map[string]int64{
 				"0": 20,
 				"1": 25,

--- a/test/testutil/clickhouse_client.go
+++ b/test/testutil/clickhouse_client.go
@@ -195,6 +195,10 @@ func (c *ClickHouseClient) CheckRead(ctx context.Context, order int) error {
 				return fmt.Errorf("expected 10 rows on %v, got more", id)
 			}
 
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("reading results of query test data on %v: %w", id, err)
+			}
+
 			return nil
 		}()
 		if err != nil {
@@ -223,6 +227,10 @@ func (c *ClickHouseClient) QueryRow(ctx context.Context, query string, result an
 
 	if err := rows.Scan(result); err != nil {
 		return fmt.Errorf("scan row: %w", err)
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read query results: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Why

add missing `rows.Err()` handling in tests.
handling `rows.Err` should always be performed, see previous related [PR](https://github.com/ClickHouse/clickhouse-operator/pull/107).

while the change is not impactful for these tests, it makes the codebase pass the (not public yet) linter checks. This will make it simpler to integrate the linter once it is public.