### PR TITLE
Fix spec modification issue, add spec fuzzing tests. Relax default anti-affinity rules.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,6 +120,23 @@ jobs:
           path: "**/report/*.xml"
           reporter: java-junit
 
+  fuzz_specs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Go Mod
+        run: go mod download
+
+      - name: Run fuzz tests
+        run: make fuzz
+
   helm-test:
     runs-on: ubuntu-latest
     steps:
@@ -286,7 +303,7 @@ jobs:
   ci-success-check:
     name: All CI checks passed
     runs-on: ubuntu-latest
-    needs: [ lint, bundle, build_and_test, helm-test, compat-e2e-test, e2e-test ]
+    needs: [ lint, bundle, build_and_test, fuzz_specs, helm-test, compat-e2e-test, e2e-test ]
     if: always()
     steps:
       - name: Determine CI status

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,14 @@ test-ci: manifests generate fmt vet envtest ## Run tests in CI env.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e | grep -v /helm) \
 	-v -count=1 -race -coverprofile cover.out --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
+fuzz-keeper: generate # Run keeper spec fuzz tests
+	go test -run=^$$ -fuzz=FuzzClusterSpec -fuzztime 60s ./internal/controller/keeper
+
+fuzz-clickhouse: generate # Run clickhouse spec fuzz tests
+	go test -run=^$$ -fuzz=FuzzClusterSpec -fuzztime 60s ./internal/controller/clickhouse
+
+fuzz: fuzz-keeper fuzz-clickhouse ## Run all fuzz tests
+
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e: ## Run all e2e tests.

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,14 +1,15 @@
 load('ext://cert_manager', 'deploy_cert_manager')
 load("ext://restart_process", "docker_build_with_restart")
 
-enable_cert_manager=False
 enable_prometheus=False
 deploy_source='kustomize'
 secure_clusters = True
 image_repo = "ghcr.io/clickhouse/clickhouse-operator"
 
-if enable_cert_manager:
+if not local("kubectl wait --for=condition=Available -n cert-manager deployment/cert-manager", quiet=True, echo_off=True):
     deploy_cert_manager(version='v1.19.2')
+else:
+    print("cert-manager is already deployed")
 
 if enable_prometheus:
     prometheus_operator_url = "https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.87.0/bundle.yaml"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/client-go v0.35.1
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.23.1
+	sigs.k8s.io/randfill v1.0.0
 )
 
 require (
@@ -121,7 +122,6 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.33.0 // indirect
 	sigs.k8s.io/gateway-api v1.4.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/internal/controller/clickhouse/constants.go
+++ b/internal/controller/clickhouse/constants.go
@@ -39,6 +39,7 @@ const (
 
 	ContainerName          = "clickhouse-server"
 	DefaultRevisionHistory = 10
+	MaximalAffinityWeight  = 100
 
 	InterserverUserName        = "interserver"
 	OperatorManagementUsername = "operator"

--- a/internal/controller/clickhouse/templates.go
+++ b/internal/controller/clickhouse/templates.go
@@ -200,239 +200,9 @@ func templateConfigMap(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (*cor
 }
 
 func templateStatefulSet(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (*appsv1.StatefulSet, error) {
-	volumes, volumeMounts, err := buildVolumes(r, id)
+	podSpec, err := templatePodSpec(r, id)
 	if err != nil {
-		return nil, fmt.Errorf("build volumes: %w", err)
-	}
-
-	protocols := buildProtocols(r.Cluster)
-
-	var probeCommand []string
-	if protocol, ok := protocols["http"]; ok && protocol.Port > 0 {
-		probeCommand = []string{"/bin/bash", "-c", fmt.Sprintf(
-			"wget -qO- http://%s | grep -o Ok.",
-			net.JoinHostPort("127.0.0.1", strconv.Itoa(PortHTTP)),
-		)}
-	} else {
-		probeCommand = []string{"/bin/bash", "-c", fmt.Sprintf(
-			"wget --ca-certificate=%s -qO- https://%s | grep -o Ok.",
-			path.Join(TLSConfigPath, CABundleFilename),
-			net.JoinHostPort(r.Cluster.HostnameByID(id), strconv.Itoa(PortHTTPSecure)),
-		)}
-	}
-
-	livenessProbe := controller.DefaultLivenessProbeSettings
-	livenessProbe.ProbeHandler = corev1.ProbeHandler{
-		Exec: &corev1.ExecAction{
-			Command: probeCommand,
-		},
-	}
-
-	readinessProbe := controller.DefaultReadinessProbeSettings
-	readinessProbe.ProbeHandler = corev1.ProbeHandler{
-		Exec: &corev1.ExecAction{
-			Command: probeCommand,
-		},
-	}
-
-	container := corev1.Container{
-		Name:            ContainerName,
-		Image:           r.Cluster.Spec.ContainerTemplate.Image.String(),
-		ImagePullPolicy: r.Cluster.Spec.ContainerTemplate.ImagePullPolicy,
-		Resources:       r.Cluster.Spec.ContainerTemplate.Resources,
-		Env: append([]corev1.EnvVar{
-			{
-				Name:  "CLICKHOUSE_CONFIG",
-				Value: path.Join(ConfigPath, ConfigFileName),
-			},
-			{
-				Name:  "CLICKHOUSE_SKIP_USER_SETUP",
-				Value: "1",
-			},
-		}, r.Cluster.Spec.ContainerTemplate.Env...),
-		Ports: []corev1.ContainerPort{
-			{
-				Protocol:      corev1.ProtocolTCP,
-				Name:          "prometheus",
-				ContainerPort: PortPrometheusScrape,
-			},
-			{
-				Protocol:      corev1.ProtocolTCP,
-				Name:          "interserver",
-				ContainerPort: PortInterserver,
-			},
-		},
-		VolumeMounts:             volumeMounts,
-		LivenessProbe:            &livenessProbe,
-		ReadinessProbe:           &readinessProbe,
-		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		SecurityContext: &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"IPC_LOCK", "PERFMON", "SYS_PTRACE"},
-			},
-		},
-	}
-
-	for _, secret := range secretsToEnvMapping {
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name: secret.Env,
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: r.Cluster.SecretName(),
-					},
-					Key: secret.Key,
-				},
-			},
-		})
-	}
-
-	container.Ports = make([]corev1.ContainerPort, 0, len(protocols))
-	for name, protocol := range protocols {
-		if protocol.Port == 0 {
-			continue
-		}
-
-		container.Ports = append(container.Ports, corev1.ContainerPort{
-			Protocol:      corev1.ProtocolTCP,
-			Name:          name,
-			ContainerPort: int32(protocol.Port),
-		})
-	}
-
-	controllerutil.SortKey(container.Ports, func(port corev1.ContainerPort) string {
-		return port.Name
-	})
-
-	if r.Cluster.Spec.ContainerTemplate.SecurityContext != nil {
-		securityContext := r.Cluster.Spec.ContainerTemplate.SecurityContext.DeepCopy()
-		if err := controllerutil.ApplyDefault(securityContext, *container.SecurityContext); err != nil {
-			return nil, fmt.Errorf("apply container security context overrides: %w", err)
-		}
-
-		container.SecurityContext = securityContext
-	}
-
-	if r.Cluster.Spec.Settings.DefaultUserPassword != nil {
-		var (
-			secretRef    *corev1.SecretKeySelector
-			configMapRef *corev1.ConfigMapKeySelector
-		)
-
-		if r.Cluster.Spec.Settings.DefaultUserPassword.Secret != nil {
-			secretRef = &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: r.Cluster.Spec.Settings.DefaultUserPassword.Secret.Name,
-				},
-				Key: r.Cluster.Spec.Settings.DefaultUserPassword.Secret.Key,
-			}
-		}
-
-		if r.Cluster.Spec.Settings.DefaultUserPassword.ConfigMap != nil {
-			configMapRef = &corev1.ConfigMapKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: r.Cluster.Spec.Settings.DefaultUserPassword.ConfigMap.Name,
-				},
-				Key: r.Cluster.Spec.Settings.DefaultUserPassword.ConfigMap.Key,
-			}
-		}
-
-		container.Env = append(container.Env, corev1.EnvVar{
-			Name: EnvDefaultUserPassword,
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef:    secretRef,
-				ConfigMapKeyRef: configMapRef,
-			},
-		})
-	}
-
-	serverPodSpec := corev1.PodSpec{
-		TerminationGracePeriodSeconds: r.Cluster.Spec.PodTemplate.TerminationGracePeriodSeconds,
-		TopologySpreadConstraints:     r.Cluster.Spec.PodTemplate.TopologySpreadConstraints,
-		ImagePullSecrets:              r.Cluster.Spec.PodTemplate.ImagePullSecrets,
-		NodeSelector:                  r.Cluster.Spec.PodTemplate.NodeSelector,
-		Affinity:                      r.Cluster.Spec.PodTemplate.Affinity,
-		Tolerations:                   r.Cluster.Spec.PodTemplate.Tolerations,
-		SchedulerName:                 r.Cluster.Spec.PodTemplate.SchedulerName,
-		ServiceAccountName:            r.Cluster.Spec.PodTemplate.ServiceAccountName,
-		RestartPolicy:                 corev1.RestartPolicyAlways,
-		DNSPolicy:                     corev1.DNSClusterFirst,
-		Volumes:                       volumes,
-		SecurityContext:               r.Cluster.Spec.PodTemplate.SecurityContext,
-		Containers: []corev1.Container{
-			container,
-		},
-	}
-
-	if r.Cluster.Spec.PodTemplate.TopologyZoneKey != nil && *r.Cluster.Spec.PodTemplate.TopologyZoneKey != "" {
-		if serverPodSpec.Affinity == nil {
-			serverPodSpec.Affinity = &corev1.Affinity{}
-		}
-
-		if serverPodSpec.Affinity.PodAntiAffinity == nil {
-			serverPodSpec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
-		}
-
-		if serverPodSpec.Affinity.PodAffinity == nil {
-			serverPodSpec.Affinity.PodAffinity = &corev1.PodAffinity{}
-		}
-
-		shardID := strconv.Itoa(int(id.ShardID))
-		serverPodSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(serverPodSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, corev1.PodAffinityTerm{
-			TopologyKey: *r.Cluster.Spec.PodTemplate.TopologyZoneKey,
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					controllerutil.LabelAppKey:            r.Cluster.SpecificName(),
-					controllerutil.LabelRoleKey:           controllerutil.LabelClickHouseValue,
-					controllerutil.LabelClickHouseShardID: shardID,
-				},
-			},
-		})
-		serverPodSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(serverPodSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution, corev1.WeightedPodAffinityTerm{
-			PodAffinityTerm: corev1.PodAffinityTerm{
-				TopologyKey: *r.Cluster.Spec.PodTemplate.TopologyZoneKey,
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						controllerutil.LabelAppKey:  r.keeper.SpecificName(),
-						controllerutil.LabelRoleKey: controllerutil.LabelKeeperValue,
-					},
-				},
-			},
-			Weight: 1,
-		})
-		serverPodSpec.TopologySpreadConstraints = append(serverPodSpec.TopologySpreadConstraints, corev1.TopologySpreadConstraint{
-			MaxSkew:           1,
-			TopologyKey:       *r.Cluster.Spec.PodTemplate.TopologyZoneKey,
-			WhenUnsatisfiable: corev1.DoNotSchedule,
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					controllerutil.LabelAppKey:            r.Cluster.SpecificName(),
-					controllerutil.LabelRoleKey:           controllerutil.LabelClickHouseValue,
-					controllerutil.LabelClickHouseShardID: shardID,
-				},
-			},
-		})
-	}
-
-	if r.Cluster.Spec.PodTemplate.NodeHostnameKey != nil && *r.Cluster.Spec.PodTemplate.NodeHostnameKey != "" {
-		if serverPodSpec.Affinity == nil {
-			serverPodSpec.Affinity = &corev1.Affinity{}
-		}
-
-		if serverPodSpec.Affinity.PodAntiAffinity == nil {
-			serverPodSpec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
-		}
-
-		serverPodSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(serverPodSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, corev1.PodAffinityTerm{
-			TopologyKey: *r.Cluster.Spec.PodTemplate.NodeHostnameKey,
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					controllerutil.LabelAppKey:  r.Cluster.SpecificName(),
-					controllerutil.LabelRoleKey: controllerutil.LabelClickHouseValue,
-				},
-			},
-		})
+		return nil, fmt.Errorf("template pod spec: %w", err)
 	}
 
 	resourceLabels := controllerutil.MergeMaps(r.Cluster.Spec.Labels, id.Labels(), map[string]string{
@@ -463,7 +233,7 @@ func templateStatefulSet(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (*a
 					"kubectl.kubernetes.io/default-container": ContainerName,
 				}),
 			},
-			Spec: serverPodSpec,
+			Spec: podSpec,
 		},
 		RevisionHistoryLimit: ptr.To[int32](DefaultRevisionHistory),
 	}
@@ -475,7 +245,7 @@ func templateStatefulSet(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (*a
 				Labels:      resourceLabels,
 				Annotations: r.Cluster.Spec.Annotations,
 			},
-			Spec: *r.Cluster.Spec.DataVolumeClaimSpec,
+			Spec: *r.Cluster.Spec.DataVolumeClaimSpec.DeepCopy(),
 		}}
 	}
 
@@ -512,6 +282,269 @@ func generateConfigForSingleReplica(r *clickhouseReconciler, id v1.ClickHouseRep
 	}
 
 	return configFiles, nil
+}
+
+func templatePodSpec(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (corev1.PodSpec, error) {
+	cr := r.Cluster
+
+	volumes, volumeMounts, err := buildVolumes(r, id)
+	if err != nil {
+		return corev1.PodSpec{}, fmt.Errorf("build volumes: %w", err)
+	}
+
+	container, err := templateContainer(cr, id, volumeMounts)
+	if err != nil {
+		return corev1.PodSpec{}, fmt.Errorf("template container: %w", err)
+	}
+
+	podTemplate := cr.Spec.PodTemplate.DeepCopy()
+	podSpec := corev1.PodSpec{
+		TerminationGracePeriodSeconds: podTemplate.TerminationGracePeriodSeconds,
+		TopologySpreadConstraints:     podTemplate.TopologySpreadConstraints,
+		ImagePullSecrets:              podTemplate.ImagePullSecrets,
+		NodeSelector:                  podTemplate.NodeSelector,
+		Affinity:                      podTemplate.Affinity,
+		Tolerations:                   podTemplate.Tolerations,
+		SchedulerName:                 podTemplate.SchedulerName,
+		ServiceAccountName:            podTemplate.ServiceAccountName,
+		SecurityContext:               podTemplate.SecurityContext,
+		RestartPolicy:                 corev1.RestartPolicyAlways,
+		DNSPolicy:                     corev1.DNSClusterFirst,
+		Volumes:                       volumes,
+		Containers: []corev1.Container{
+			container,
+		},
+	}
+
+	if podTemplate.TopologyZoneKey != nil && *podTemplate.TopologyZoneKey != "" {
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &corev1.Affinity{}
+		}
+
+		if podSpec.Affinity.PodAntiAffinity == nil {
+			podSpec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
+		}
+
+		if podSpec.Affinity.PodAffinity == nil {
+			podSpec.Affinity.PodAffinity = &corev1.PodAffinity{}
+		}
+
+		shardID := strconv.Itoa(int(id.ShardID))
+		podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			corev1.WeightedPodAffinityTerm{
+				Weight: MaximalAffinityWeight,
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					TopologyKey: *podTemplate.TopologyZoneKey,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							controllerutil.LabelAppKey:            cr.SpecificName(),
+							controllerutil.LabelRoleKey:           controllerutil.LabelClickHouseValue,
+							controllerutil.LabelClickHouseShardID: shardID,
+						},
+					},
+				},
+			})
+		podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			podSpec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			corev1.WeightedPodAffinityTerm{
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					TopologyKey: *podTemplate.TopologyZoneKey,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							controllerutil.LabelAppKey:  r.keeper.SpecificName(),
+							controllerutil.LabelRoleKey: controllerutil.LabelKeeperValue,
+						},
+					},
+				},
+				Weight: 1,
+			})
+		podSpec.TopologySpreadConstraints = append(
+			podSpec.TopologySpreadConstraints,
+			corev1.TopologySpreadConstraint{
+				MaxSkew:           1,
+				TopologyKey:       *podTemplate.TopologyZoneKey,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						controllerutil.LabelAppKey:            cr.SpecificName(),
+						controllerutil.LabelRoleKey:           controllerutil.LabelClickHouseValue,
+						controllerutil.LabelClickHouseShardID: shardID,
+					},
+				},
+			})
+	}
+
+	if podTemplate.NodeHostnameKey != nil && *podTemplate.NodeHostnameKey != "" {
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &corev1.Affinity{}
+		}
+
+		if podSpec.Affinity.PodAntiAffinity == nil {
+			podSpec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
+		}
+
+		podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			corev1.PodAffinityTerm{
+				TopologyKey: *podTemplate.NodeHostnameKey,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						controllerutil.LabelAppKey:  cr.SpecificName(),
+						controllerutil.LabelRoleKey: controllerutil.LabelClickHouseValue,
+					},
+				},
+			})
+	}
+
+	return podSpec, nil
+}
+
+func templateContainer(cr *v1.ClickHouseCluster, id v1.ClickHouseReplicaID, volumeMounts []corev1.VolumeMount) (corev1.Container, error) {
+	containerTemplate := cr.Spec.ContainerTemplate.DeepCopy()
+	protocols := buildProtocols(cr)
+
+	var probeCommand []string
+	if protocol, ok := protocols["http"]; ok && protocol.Port > 0 {
+		probeCommand = []string{"/bin/bash", "-c", fmt.Sprintf(
+			"wget -qO- http://%s | grep -o Ok.",
+			net.JoinHostPort("127.0.0.1", strconv.Itoa(PortHTTP)),
+		)}
+	} else {
+		probeCommand = []string{"/bin/bash", "-c", fmt.Sprintf(
+			"wget --ca-certificate=%s -qO- https://%s | grep -o Ok.",
+			path.Join(TLSConfigPath, CABundleFilename),
+			net.JoinHostPort(cr.HostnameByID(id), strconv.Itoa(PortHTTPSecure)),
+		)}
+	}
+
+	livenessProbe := controller.DefaultLivenessProbeSettings
+	livenessProbe.ProbeHandler = corev1.ProbeHandler{
+		Exec: &corev1.ExecAction{
+			Command: probeCommand,
+		},
+	}
+
+	readinessProbe := controller.DefaultReadinessProbeSettings
+	readinessProbe.ProbeHandler = corev1.ProbeHandler{
+		Exec: &corev1.ExecAction{
+			Command: probeCommand,
+		},
+	}
+
+	container := corev1.Container{
+		Name:            ContainerName,
+		Image:           containerTemplate.Image.String(),
+		ImagePullPolicy: containerTemplate.ImagePullPolicy,
+		Resources:       containerTemplate.Resources,
+		Env: append([]corev1.EnvVar{
+			{
+				Name:  "CLICKHOUSE_CONFIG",
+				Value: path.Join(ConfigPath, ConfigFileName),
+			},
+			{
+				Name:  "CLICKHOUSE_SKIP_USER_SETUP",
+				Value: "1",
+			},
+		}, containerTemplate.Env...),
+		Ports: []corev1.ContainerPort{
+			{
+				Protocol:      corev1.ProtocolTCP,
+				Name:          "prometheus",
+				ContainerPort: PortPrometheusScrape,
+			},
+			{
+				Protocol:      corev1.ProtocolTCP,
+				Name:          "interserver",
+				ContainerPort: PortInterserver,
+			},
+		},
+		VolumeMounts:             volumeMounts,
+		LivenessProbe:            &livenessProbe,
+		ReadinessProbe:           &readinessProbe,
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"IPC_LOCK", "PERFMON", "SYS_PTRACE"},
+			},
+		},
+	}
+
+	for _, secret := range secretsToEnvMapping {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name: secret.Env,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: cr.SecretName(),
+					},
+					Key: secret.Key,
+				},
+			},
+		})
+	}
+
+	container.Ports = make([]corev1.ContainerPort, 0, len(protocols))
+	for name, protocol := range protocols {
+		if protocol.Port == 0 {
+			continue
+		}
+
+		container.Ports = append(container.Ports, corev1.ContainerPort{
+			Protocol:      corev1.ProtocolTCP,
+			Name:          name,
+			ContainerPort: int32(protocol.Port),
+		})
+	}
+
+	controllerutil.SortKey(container.Ports, func(port corev1.ContainerPort) string {
+		return port.Name
+	})
+
+	if containerTemplate.SecurityContext != nil {
+		securityContext := containerTemplate.SecurityContext
+		if err := controllerutil.ApplyDefault(securityContext, *container.SecurityContext); err != nil {
+			return corev1.Container{}, fmt.Errorf("apply container security context overrides: %w", err)
+		}
+
+		container.SecurityContext = securityContext
+	}
+
+	if cr.Spec.Settings.DefaultUserPassword != nil {
+		var (
+			secretRef    *corev1.SecretKeySelector
+			configMapRef *corev1.ConfigMapKeySelector
+		)
+
+		if cr.Spec.Settings.DefaultUserPassword.Secret != nil {
+			secretRef = &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: cr.Spec.Settings.DefaultUserPassword.Secret.Name,
+				},
+				Key: cr.Spec.Settings.DefaultUserPassword.Secret.Key,
+			}
+		}
+
+		if cr.Spec.Settings.DefaultUserPassword.ConfigMap != nil {
+			configMapRef = &corev1.ConfigMapKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: cr.Spec.Settings.DefaultUserPassword.ConfigMap.Name,
+				},
+				Key: cr.Spec.Settings.DefaultUserPassword.ConfigMap.Key,
+			}
+		}
+
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name: EnvDefaultUserPassword,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef:    secretRef,
+				ConfigMapKeyRef: configMapRef,
+			},
+		})
+	}
+
+	return container, nil
 }
 
 type protocol struct {
@@ -681,8 +714,13 @@ func buildVolumes(r *clickhouseReconciler, id v1.ClickHouseReplicaID) ([]corev1.
 		})
 	}
 
-	volumes = append(volumes, r.Cluster.Spec.PodTemplate.Volumes...)
-	volumeMounts = append(volumeMounts, r.Cluster.Spec.ContainerTemplate.VolumeMounts...)
+	for _, volume := range r.Cluster.Spec.PodTemplate.Volumes {
+		volumes = append(volumes, *volume.DeepCopy())
+	}
+
+	for _, volumeMount := range r.Cluster.Spec.ContainerTemplate.VolumeMounts {
+		volumeMounts = append(volumeMounts, *volumeMount.DeepCopy())
+	}
 
 	volumes, volumeMounts, err := controller.ProjectVolumes(volumes, volumeMounts)
 	if err != nil {

--- a/internal/controller/clickhouse/templates_test.go
+++ b/internal/controller/clickhouse/templates_test.go
@@ -1,6 +1,9 @@
 package clickhouse
 
 import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -8,9 +11,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/randfill"
 
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
 	"github.com/ClickHouse/clickhouse-operator/internal"
+	"github.com/ClickHouse/clickhouse-operator/internal/controller/testutil"
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
 )
 
@@ -310,4 +315,61 @@ func checkVolumeMounts(volumes []corev1.Volume, mounts []corev1.VolumeMount) {
 		mountPaths[mount.MountPath] = struct{}{}
 		ExpectWithOffset(1, volumeMap).To(HaveKey(mount.Name), "Mount %s is not in volumes", mount.Name)
 	}
+}
+
+func FuzzClusterSpec(f *testing.F) {
+	// Manually added cases
+	f.Add([]byte("02"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fill := testutil.NewSpecFiller(data)
+		r := &clickhouseReconciler{
+			reconcilerBase: reconcilerBase{
+				Cluster: newClickHouseCluster(fill),
+			},
+			keeper: v1.KeeperCluster{ObjectMeta: metav1.ObjectMeta{Name: "keeper"}},
+		}
+		id := v1.ClickHouseReplicaID{ShardID: 1, Index: 1}
+
+		crBefore := r.Cluster.DeepCopy()
+
+		stsFirst, err1 := templateStatefulSet(r, id)
+		if diff := cmp.Diff(crBefore.Spec, r.Cluster.Spec); diff != "" {
+			t.Errorf("ClusterSpec mutated:\n%s", diff)
+		}
+
+		stsSecond, err2 := templateStatefulSet(r, id)
+		if diff := cmp.Diff(crBefore.Spec, r.Cluster.Spec); diff != "" {
+			t.Errorf("ClusterSpec mutated:\n%s", diff)
+		}
+
+		if err1 == nil {
+			if diff := cmp.Diff(stsFirst, stsSecond); diff != "" {
+				t.Errorf("result differs:\n%s", diff)
+			}
+		} else {
+			if err1.Error() != err2.Error() {
+				t.Errorf("errors differ: %v vs %v", err1, err2)
+			}
+		}
+	})
+}
+
+func newClickHouseCluster(f *randfill.Filler) *v1.ClickHouseCluster {
+	cr := &v1.ClickHouseCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app": "clickhouse-operator",
+			},
+			Annotations: map[string]string{
+				"annotation1": "value1",
+			},
+		},
+	}
+	f.Fill(&cr.Spec)
+	cr.Spec.WithDefaults()
+
+	return cr
 }

--- a/internal/controller/keeper/constants.go
+++ b/internal/controller/keeper/constants.go
@@ -31,6 +31,7 @@ const (
 
 	ContainerName          = "clickhouse-keeper"
 	DefaultRevisionHistory = 10
+	MaximalAffinityWeight  = 100
 )
 
 var breakingStatefulSetVersion, _ = semver.Parse("0.0.1")

--- a/internal/controller/keeper/templates.go
+++ b/internal/controller/keeper/templates.go
@@ -234,10 +234,10 @@ func getStatefulSetRevision(cr *v1.KeeperCluster) (string, error) {
 	return hash, nil
 }
 
-func templateConfigMap(cr *v1.KeeperCluster, extraConfig map[string]any, replicaID v1.KeeperReplicaID) (*corev1.ConfigMap, error) {
-	config, err := generateConfigForSingleReplica(cr, extraConfig, replicaID)
+func templateConfigMap(cr *v1.KeeperCluster, extraConfig map[string]any, id v1.KeeperReplicaID) (*corev1.ConfigMap, error) {
+	config, err := generateConfigForSingleReplica(cr, extraConfig, id)
 	if err != nil {
-		return nil, fmt.Errorf("generate configmap for replica %q: %w", replicaID, err)
+		return nil, fmt.Errorf("generate configmap for replica %q: %w", id, err)
 	}
 
 	return &corev1.ConfigMap{
@@ -246,9 +246,9 @@ func templateConfigMap(cr *v1.KeeperCluster, extraConfig map[string]any, replica
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        cr.ConfigMapNameByReplicaID(replicaID),
+			Name:        cr.ConfigMapNameByReplicaID(id),
 			Namespace:   cr.Namespace,
-			Labels:      controllerutil.MergeMaps(cr.Spec.Labels, replicaLabels(cr, replicaID)),
+			Labels:      controllerutil.MergeMaps(cr.Spec.Labels, replicaLabels(cr, id)),
 			Annotations: cr.Spec.Annotations,
 		},
 		Data: map[string]string{
@@ -257,180 +257,13 @@ func templateConfigMap(cr *v1.KeeperCluster, extraConfig map[string]any, replica
 	}, nil
 }
 
-func templateStatefulSet(cr *v1.KeeperCluster, replicaID v1.KeeperReplicaID) (*appsv1.StatefulSet, error) {
-	volumes, volumeMounts, err := buildVolumes(cr, replicaID)
+func templateStatefulSet(cr *v1.KeeperCluster, id v1.KeeperReplicaID) (*appsv1.StatefulSet, error) {
+	podSpec, err := templatePodSpec(cr, id)
 	if err != nil {
-		return nil, fmt.Errorf("build volumes for StatefulSet: %w", err)
+		return nil, fmt.Errorf("template pod spec: %w", err)
 	}
 
-	probeAction := corev1.ExecAction{
-		Command: []string{"/bin/bash", "-c",
-			fmt.Sprintf("wget -qO- http://%s/ready | grep -o '\"status\":\"ok\"'",
-				net.JoinHostPort("127.0.0.1", strconv.Itoa(PortHTTPControl)),
-			),
-		},
-	}
-
-	livenessProbe := controller.DefaultLivenessProbeSettings
-	livenessProbe.ProbeHandler = corev1.ProbeHandler{
-		Exec: &probeAction,
-	}
-
-	readinessProbe := controller.DefaultReadinessProbeSettings
-	readinessProbe.ProbeHandler = corev1.ProbeHandler{
-		Exec: &probeAction,
-	}
-
-	keeperContainer := corev1.Container{
-		Name:            ContainerName,
-		Image:           cr.Spec.ContainerTemplate.Image.String(),
-		ImagePullPolicy: cr.Spec.ContainerTemplate.ImagePullPolicy,
-		Resources:       cr.Spec.ContainerTemplate.Resources,
-		Env: append([]corev1.EnvVar{
-			{
-				Name:  "KEEPER_CONFIG",
-				Value: QuorumConfigPath + QuorumConfigFileName,
-			},
-		}, cr.Spec.ContainerTemplate.Env...),
-		Ports: []corev1.ContainerPort{
-			{
-				Protocol:      corev1.ProtocolTCP,
-				Name:          "raft-ipc",
-				ContainerPort: PortInterserver,
-			},
-			{
-				Protocol:      corev1.ProtocolTCP,
-				Name:          "prometheus",
-				ContainerPort: PortPrometheusScrape,
-			},
-		},
-		VolumeMounts:             volumeMounts,
-		LivenessProbe:            &livenessProbe,
-		ReadinessProbe:           &readinessProbe,
-		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
-		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		// Default capabilities given to ClickHouse keeper.
-		// For more information, see https://unofficial-kubernetes.readthedocs.io/en/latest/concepts/policy/container-capabilities/
-		// IPC_LOCK
-		// •  Lock memory (mlock(2), mlockall(2), mmap(2), shmctl(2));
-		// •  Allocate memory using huge pages (memfd_create(2), mmap(2), shmctl(2)).
-		// ^^ Needed for better performance.
-		//
-		// SYS_PTRACE
-		// •  Trace arbitrary processes using ptrace(2);
-		// •  apply get_robust_list(2) to arbitrary processes;
-		// •  transfer data to or from the memory of arbitrary processes using process_vm_readv(2) and process_vm_writev(2);
-		// •  inspect processes using kcmp(2).
-		// ^^ Needed to get Kernel's performance counters from inside the container (to use perf)
-		//
-		// PERFMON
-		// 	 Employ various performance-monitoring mechanisms, including:
-		// •  call perf_event_open(2);
-		// •  employ various BPF operations that have performance implications.
-		// ^^ Needed to get Kernel's performance counters from inside the container (to use perf)
-		SecurityContext: &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"IPC_LOCK", "PERFMON", "SYS_PTRACE"},
-			},
-		},
-	}
-
-	if !cr.Spec.Settings.TLS.Enabled || !cr.Spec.Settings.TLS.Required {
-		keeperContainer.Ports = append(keeperContainer.Ports, corev1.ContainerPort{
-			Protocol:      corev1.ProtocolTCP,
-			Name:          "keeper",
-			ContainerPort: PortNative,
-		})
-	}
-
-	if cr.Spec.Settings.TLS.Enabled {
-		keeperContainer.Ports = append(keeperContainer.Ports, corev1.ContainerPort{
-			Protocol:      corev1.ProtocolTCP,
-			Name:          "keeper-secure",
-			ContainerPort: PortNativeSecure,
-		})
-	}
-
-	if cr.Spec.ContainerTemplate.SecurityContext != nil {
-		securityContext := cr.Spec.ContainerTemplate.SecurityContext.DeepCopy()
-		if err := controllerutil.ApplyDefault(securityContext, *keeperContainer.SecurityContext); err != nil {
-			return nil, fmt.Errorf("apply container security context overrides: %w", err)
-		}
-
-		keeperContainer.SecurityContext = securityContext
-	}
-
-	keeperPodSpec := corev1.PodSpec{
-		TerminationGracePeriodSeconds: cr.Spec.PodTemplate.TerminationGracePeriodSeconds,
-		TopologySpreadConstraints:     cr.Spec.PodTemplate.TopologySpreadConstraints,
-		ImagePullSecrets:              cr.Spec.PodTemplate.ImagePullSecrets,
-		NodeSelector:                  cr.Spec.PodTemplate.NodeSelector,
-		Affinity:                      cr.Spec.PodTemplate.Affinity,
-		Tolerations:                   cr.Spec.PodTemplate.Tolerations,
-		SchedulerName:                 cr.Spec.PodTemplate.SchedulerName,
-		ServiceAccountName:            cr.Spec.PodTemplate.ServiceAccountName,
-		RestartPolicy:                 corev1.RestartPolicyAlways,
-		DNSPolicy:                     corev1.DNSClusterFirst,
-		Volumes:                       volumes,
-		SecurityContext:               cr.Spec.PodTemplate.SecurityContext,
-		Containers: []corev1.Container{
-			keeperContainer,
-		},
-	}
-
-	if cr.Spec.PodTemplate.TopologyZoneKey != nil && *cr.Spec.PodTemplate.TopologyZoneKey != "" {
-		if keeperPodSpec.Affinity == nil {
-			keeperPodSpec.Affinity = &corev1.Affinity{}
-		}
-
-		if keeperPodSpec.Affinity.PodAntiAffinity == nil {
-			keeperPodSpec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
-		}
-
-		keeperPodSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(keeperPodSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, corev1.PodAffinityTerm{
-			TopologyKey: *cr.Spec.PodTemplate.TopologyZoneKey,
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					controllerutil.LabelAppKey:  cr.SpecificName(),
-					controllerutil.LabelRoleKey: controllerutil.LabelKeeperValue,
-				},
-			},
-		})
-
-		keeperPodSpec.TopologySpreadConstraints = append(keeperPodSpec.TopologySpreadConstraints, corev1.TopologySpreadConstraint{
-			MaxSkew:           1,
-			TopologyKey:       *cr.Spec.PodTemplate.TopologyZoneKey,
-			WhenUnsatisfiable: corev1.DoNotSchedule,
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					controllerutil.LabelAppKey:  cr.SpecificName(),
-					controllerutil.LabelRoleKey: controllerutil.LabelKeeperValue,
-				},
-			},
-		})
-	}
-
-	if cr.Spec.PodTemplate.NodeHostnameKey != nil && *cr.Spec.PodTemplate.NodeHostnameKey != "" {
-		if keeperPodSpec.Affinity == nil {
-			keeperPodSpec.Affinity = &corev1.Affinity{}
-		}
-
-		if keeperPodSpec.Affinity.PodAntiAffinity == nil {
-			keeperPodSpec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
-		}
-
-		keeperPodSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(keeperPodSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, corev1.PodAffinityTerm{
-			TopologyKey: *cr.Spec.PodTemplate.NodeHostnameKey,
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					controllerutil.LabelAppKey:  cr.SpecificName(),
-					controllerutil.LabelRoleKey: controllerutil.LabelKeeperValue,
-				},
-			},
-		})
-	}
-
-	resourceLabels := controllerutil.MergeMaps(cr.Spec.Labels, replicaLabels(cr, replicaID), map[string]string{
+	resourceLabels := controllerutil.MergeMaps(cr.Spec.Labels, replicaLabels(cr, id), map[string]string{
 		controllerutil.LabelRoleKey:        controllerutil.LabelKeeperValue,
 		controllerutil.LabelAppK8sKey:      controllerutil.LabelKeeperValue,
 		controllerutil.LabelInstanceK8sKey: cr.SpecificName(),
@@ -438,7 +271,7 @@ func templateStatefulSet(cr *v1.KeeperCluster, replicaID v1.KeeperReplicaID) (*a
 
 	spec := appsv1.StatefulSetSpec{
 		Selector: &metav1.LabelSelector{
-			MatchLabels: replicaLabels(cr, replicaID),
+			MatchLabels: replicaLabels(cr, id),
 		},
 		ServiceName:         cr.HeadlessServiceName(),
 		PodManagementPolicy: appsv1.ParallelPodManagement,
@@ -455,7 +288,7 @@ func templateStatefulSet(cr *v1.KeeperCluster, replicaID v1.KeeperReplicaID) (*a
 					"kubectl.kubernetes.io/default-container": ContainerName,
 				}),
 			},
-			Spec: keeperPodSpec,
+			Spec: podSpec,
 		},
 		RevisionHistoryLimit: ptr.To[int32](DefaultRevisionHistory),
 	}
@@ -467,7 +300,7 @@ func templateStatefulSet(cr *v1.KeeperCluster, replicaID v1.KeeperReplicaID) (*a
 				Labels:      resourceLabels,
 				Annotations: cr.Spec.Annotations,
 			},
-			Spec: *cr.Spec.DataVolumeClaimSpec,
+			Spec: *cr.Spec.DataVolumeClaimSpec.DeepCopy(),
 		}}
 	}
 
@@ -477,7 +310,7 @@ func templateStatefulSet(cr *v1.KeeperCluster, replicaID v1.KeeperReplicaID) (*a
 			APIVersion: "apps/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.StatefulSetNameByReplicaID(replicaID),
+			Name:      cr.StatefulSetNameByReplicaID(id),
 			Namespace: cr.Namespace,
 			Labels:    resourceLabels,
 			Annotations: controllerutil.MergeMaps(cr.Spec.Annotations, map[string]string{
@@ -494,7 +327,7 @@ func replicaLabels(cr *v1.KeeperCluster, id v1.KeeperReplicaID) map[string]strin
 	return labels
 }
 
-func generateConfigForSingleReplica(cr *v1.KeeperCluster, extraConfig map[string]any, replicaID v1.KeeperReplicaID) (string, error) {
+func generateConfigForSingleReplica(cr *v1.KeeperCluster, extraConfig map[string]any, id v1.KeeperReplicaID) (string, error) {
 	config := config{
 		ListenHost: "0.0.0.0",
 		Path:       internal.KeeperDataPath,
@@ -502,7 +335,7 @@ func generateConfigForSingleReplica(cr *v1.KeeperCluster, extraConfig map[string
 		Logger:     controller.GenerateLoggerConfig(cr.Spec.Settings.Logger, LogPath, "clickhouse-keeper"),
 		KeeperServer: keeperServer{
 			TCPPort:             PortNative,
-			ServerID:            strconv.FormatInt(int64(replicaID), 10),
+			ServerID:            strconv.FormatInt(int64(id), 10),
 			StoragePath:         internal.KeeperDataPath,
 			DigestEnabled:       true,
 			LogStoragePath:      StorageLogPath,
@@ -559,7 +392,204 @@ func generateConfigForSingleReplica(cr *v1.KeeperCluster, extraConfig map[string
 	return string(yamlConfig), nil
 }
 
-func buildVolumes(cr *v1.KeeperCluster, replicaID v1.KeeperReplicaID) ([]corev1.Volume, []corev1.VolumeMount, error) {
+func templatePodSpec(cr *v1.KeeperCluster, id v1.KeeperReplicaID) (corev1.PodSpec, error) {
+	volumes, volumeMounts, err := buildVolumes(cr, id)
+	if err != nil {
+		return corev1.PodSpec{}, fmt.Errorf("build volumes: %w", err)
+	}
+
+	container, err := templateContainer(cr, volumeMounts)
+	if err != nil {
+		return corev1.PodSpec{}, fmt.Errorf("template container: %w", err)
+	}
+
+	podTemplate := cr.Spec.PodTemplate.DeepCopy()
+	podSpec := corev1.PodSpec{
+		TerminationGracePeriodSeconds: podTemplate.TerminationGracePeriodSeconds,
+		TopologySpreadConstraints:     podTemplate.TopologySpreadConstraints,
+		ImagePullSecrets:              podTemplate.ImagePullSecrets,
+		NodeSelector:                  podTemplate.NodeSelector,
+		Affinity:                      podTemplate.Affinity,
+		Tolerations:                   podTemplate.Tolerations,
+		SchedulerName:                 podTemplate.SchedulerName,
+		ServiceAccountName:            podTemplate.ServiceAccountName,
+		SecurityContext:               podTemplate.SecurityContext,
+		RestartPolicy:                 corev1.RestartPolicyAlways,
+		DNSPolicy:                     corev1.DNSClusterFirst,
+		Volumes:                       volumes,
+		Containers: []corev1.Container{
+			container,
+		},
+	}
+
+	if podTemplate.TopologyZoneKey != nil && *podTemplate.TopologyZoneKey != "" {
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &corev1.Affinity{}
+		}
+
+		if podSpec.Affinity.PodAntiAffinity == nil {
+			podSpec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
+		}
+
+		podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+			podSpec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
+			corev1.WeightedPodAffinityTerm{
+				Weight: MaximalAffinityWeight,
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					TopologyKey: *podTemplate.TopologyZoneKey,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							controllerutil.LabelAppKey:  cr.SpecificName(),
+							controllerutil.LabelRoleKey: controllerutil.LabelKeeperValue,
+						},
+					},
+				},
+			})
+
+		podSpec.TopologySpreadConstraints = append(
+			podSpec.TopologySpreadConstraints,
+			corev1.TopologySpreadConstraint{
+				MaxSkew:           1,
+				TopologyKey:       *podTemplate.TopologyZoneKey,
+				WhenUnsatisfiable: corev1.DoNotSchedule,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						controllerutil.LabelAppKey:  cr.SpecificName(),
+						controllerutil.LabelRoleKey: controllerutil.LabelKeeperValue,
+					},
+				},
+			})
+	}
+
+	if podTemplate.NodeHostnameKey != nil && *podTemplate.NodeHostnameKey != "" {
+		if podSpec.Affinity == nil {
+			podSpec.Affinity = &corev1.Affinity{}
+		}
+
+		if podSpec.Affinity.PodAntiAffinity == nil {
+			podSpec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{}
+		}
+
+		podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			podSpec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
+			corev1.PodAffinityTerm{
+				TopologyKey: *podTemplate.NodeHostnameKey,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						controllerutil.LabelAppKey:  cr.SpecificName(),
+						controllerutil.LabelRoleKey: controllerutil.LabelKeeperValue,
+					},
+				},
+			})
+	}
+
+	return podSpec, nil
+}
+
+func templateContainer(cr *v1.KeeperCluster, volumeMounts []corev1.VolumeMount) (corev1.Container, error) {
+	containerTemplate := cr.Spec.ContainerTemplate.DeepCopy()
+
+	probeAction := corev1.ExecAction{
+		Command: []string{"/bin/bash", "-c",
+			fmt.Sprintf("wget -qO- http://%s/ready | grep -o '\"status\":\"ok\"'",
+				net.JoinHostPort("127.0.0.1", strconv.Itoa(PortHTTPControl)),
+			),
+		},
+	}
+
+	livenessProbe := controller.DefaultLivenessProbeSettings
+	livenessProbe.ProbeHandler = corev1.ProbeHandler{
+		Exec: &probeAction,
+	}
+
+	readinessProbe := controller.DefaultReadinessProbeSettings
+	readinessProbe.ProbeHandler = corev1.ProbeHandler{
+		Exec: &probeAction,
+	}
+
+	container := corev1.Container{
+		Name:            ContainerName,
+		Image:           containerTemplate.Image.String(),
+		ImagePullPolicy: containerTemplate.ImagePullPolicy,
+		Resources:       containerTemplate.Resources,
+		Env: append([]corev1.EnvVar{
+			{
+				Name:  "KEEPER_CONFIG",
+				Value: QuorumConfigPath + QuorumConfigFileName,
+			},
+		}, containerTemplate.Env...),
+		Ports: []corev1.ContainerPort{
+			{
+				Protocol:      corev1.ProtocolTCP,
+				Name:          "raft-ipc",
+				ContainerPort: PortInterserver,
+			},
+			{
+				Protocol:      corev1.ProtocolTCP,
+				Name:          "prometheus",
+				ContainerPort: PortPrometheusScrape,
+			},
+		},
+		VolumeMounts:             volumeMounts,
+		LivenessProbe:            &livenessProbe,
+		ReadinessProbe:           &readinessProbe,
+		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+		// Default capabilities given to ClickHouse keeper.
+		// For more information, see https://unofficial-kubernetes.readthedocs.io/en/latest/concepts/policy/container-capabilities/
+		// IPC_LOCK
+		// •  Lock memory (mlock(2), mlockall(2), mmap(2), shmctl(2));
+		// •  Allocate memory using huge pages (memfd_create(2), mmap(2), shmctl(2)).
+		// ^^ Needed for better performance.
+		//
+		// SYS_PTRACE
+		// •  Trace arbitrary processes using ptrace(2);
+		// •  apply get_robust_list(2) to arbitrary processes;
+		// •  transfer data to or from the memory of arbitrary processes using process_vm_readv(2) and process_vm_writev(2);
+		// •  inspect processes using kcmp(2).
+		// ^^ Needed to get Kernel's performance counters from inside the container (to use perf)
+		//
+		// PERFMON
+		// 	 Employ various performance-monitoring mechanisms, including:
+		// •  call perf_event_open(2);
+		// •  employ various BPF operations that have performance implications.
+		// ^^ Needed to get Kernel's performance counters from inside the container (to use perf)
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{"IPC_LOCK", "PERFMON", "SYS_PTRACE"},
+			},
+		},
+	}
+
+	if !cr.Spec.Settings.TLS.Enabled || !cr.Spec.Settings.TLS.Required {
+		container.Ports = append(container.Ports, corev1.ContainerPort{
+			Protocol:      corev1.ProtocolTCP,
+			Name:          "keeper",
+			ContainerPort: PortNative,
+		})
+	}
+
+	if cr.Spec.Settings.TLS.Enabled {
+		container.Ports = append(container.Ports, corev1.ContainerPort{
+			Protocol:      corev1.ProtocolTCP,
+			Name:          "keeper-secure",
+			ContainerPort: PortNativeSecure,
+		})
+	}
+
+	if containerTemplate.SecurityContext != nil {
+		securityContext := containerTemplate.SecurityContext
+		if err := controllerutil.ApplyDefault(securityContext, *container.SecurityContext); err != nil {
+			return corev1.Container{}, fmt.Errorf("apply container security context overrides: %w", err)
+		}
+
+		container.SecurityContext = securityContext
+	}
+
+	return container, nil
+}
+
+func buildVolumes(cr *v1.KeeperCluster, id v1.KeeperReplicaID) ([]corev1.Volume, []corev1.VolumeMount, error) {
 	volumeMounts := []corev1.VolumeMount{
 		{
 			Name:      internal.QuorumConfigVolumeName,
@@ -612,7 +642,7 @@ func buildVolumes(cr *v1.KeeperCluster, replicaID v1.KeeperReplicaID) ([]corev1.
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					DefaultMode: &defaultConfigMapMode,
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: cr.ConfigMapNameByReplicaID(replicaID),
+						Name: cr.ConfigMapNameByReplicaID(id),
 					},
 				},
 			},
@@ -642,10 +672,15 @@ func buildVolumes(cr *v1.KeeperCluster, replicaID v1.KeeperReplicaID) ([]corev1.
 		})
 	}
 
-	volumes, volumeMounts, err := controller.ProjectVolumes(
-		append(volumes, cr.Spec.PodTemplate.Volumes...),
-		append(volumeMounts, cr.Spec.ContainerTemplate.VolumeMounts...),
-	)
+	for _, volume := range cr.Spec.PodTemplate.Volumes {
+		volumes = append(volumes, *volume.DeepCopy())
+	}
+
+	for _, volumeMount := range cr.Spec.ContainerTemplate.VolumeMounts {
+		volumeMounts = append(volumeMounts, *volumeMount.DeepCopy())
+	}
+
+	volumes, volumeMounts, err := controller.ProjectVolumes(volumes, volumeMounts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create projected volumes: %w", err)
 	}

--- a/internal/controller/keeper/templates_test.go
+++ b/internal/controller/keeper/templates_test.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -9,8 +11,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/randfill"
 
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+	"github.com/ClickHouse/clickhouse-operator/internal/controller/testutil"
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
 )
 
@@ -225,3 +229,55 @@ var _ = Describe("templatePodDisruptionBudget", func() {
 		Expect(pdb.Spec.UnhealthyPodEvictionPolicy).To(BeNil())
 	})
 })
+
+func FuzzClusterSpec(f *testing.F) {
+	// Manually added cases
+	f.Add([]byte("2"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		fill := testutil.NewSpecFiller(data)
+		cr := newKeeperCluster(fill)
+		id := v1.KeeperReplicaID(1)
+
+		crBefore := cr.DeepCopy()
+
+		stsFirst, err1 := templateStatefulSet(cr, id)
+		if diff := cmp.Diff(crBefore.Spec, cr.Spec); diff != "" {
+			t.Errorf("ClusterSpec mutated:\n%s", diff)
+		}
+
+		stsSecond, err2 := templateStatefulSet(cr, id)
+		if diff := cmp.Diff(crBefore.Spec, cr.Spec); diff != "" {
+			t.Errorf("ClusterSpec mutated:\n%s", diff)
+		}
+
+		if err1 == nil {
+			if diff := cmp.Diff(stsFirst, stsSecond); diff != "" {
+				t.Errorf("result differs:\n%s", diff)
+			}
+		} else {
+			if err1.Error() != err2.Error() {
+				t.Errorf("errors differ: %v vs %v", err1, err2)
+			}
+		}
+	})
+}
+
+func newKeeperCluster(f *randfill.Filler) *v1.KeeperCluster {
+	cr := &v1.KeeperCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app": "clickhouse-operator",
+			},
+			Annotations: map[string]string{
+				"annotation1": "value1",
+			},
+		},
+	}
+	f.Fill(&cr.Spec)
+	cr.Spec.WithDefaults()
+
+	return cr
+}

--- a/internal/controller/testutil/suite.go
+++ b/internal/controller/testutil/suite.go
@@ -13,16 +13,17 @@ import (
 	. "github.com/onsi/gomega"    //nolint:staticcheck
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-
-	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
-
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/randfill"
+
+	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
 )
 
 // TestSuit encapsulates the testing environment and utilities.
@@ -166,4 +167,31 @@ func AssertEvents(events chan string, expected map[string]int) {
 		}
 	}()
 	ExpectWithOffset(1, recordedEvents).To(BeEquivalentTo(expected))
+}
+
+// NewSpecFiller creates a new randfill.Filler from go-fuzz data,
+// with custom functions to handle specific fields that require special handling.
+func NewSpecFiller(data []byte) *randfill.Filler {
+	return randfill.NewFromGoFuzz(data).NilChance(0.3).NumElements(0, 3).Funcs(
+		// runtime.RawExtension contains a runtime.Object interface that randfill cannot fill.
+		func(r *k8sruntime.RawExtension, c randfill.Continue) {
+			if c.Bool() {
+				r.Raw = []byte(`{"key":"value"}`)
+			}
+		},
+		// DataSource contains a TypedObjectReference with interface-like fields.
+		func(pvc *corev1.PersistentVolumeClaimSpec, c randfill.Continue) {
+			c.FillNoCustom(pvc)
+			pvc.DataSource = nil
+			pvc.DataSourceRef = nil
+		},
+		// When TLS is enabled, ServerCertSecret must be non-nil.
+		func(tls *v1.ClusterTLSSpec, c randfill.Continue) {
+			c.FillNoCustom(tls)
+
+			if tls.Enabled && tls.ServerCertSecret == nil {
+				tls.ServerCertSecret = &corev1.LocalObjectReference{Name: "test-cert"}
+			}
+		},
+	)
 }


### PR DESCRIPTION
## Why

Accidental Spec modification led to wrong anti-affinity rules. After adding new spec fields, it may be forgotten to add checks, but spec fuzzing should help with that.
Existing anti-affinity rules prevented the deployment of a cluster with more replicas than zones. Now, zone distribution is handled only by TopologySpreadConstraints, and the anti-affinity rule has become preferred.

## What

Split STS generation on templateSts/templatePodSpec/templateContainer.
Make a copy of *Template instead of direct access
Added a fuzzing sanity test

## Related Issues

Fixes #112
