### PR TITLE
support pre-release kubeversion

### DIFF
--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: clickhouse-operator-helm
 type: application
 version: 0.0.1
 appVersion: "latest"
-kubeVersion: ">= 1.28.0"
+kubeVersion: ">= 1.28.0-0"
 description: |
   The ClickHouse Operator is a Kubernetes operator that automates the deployment, configuration, and management of ClickHouse clusters and ClickHouse Keeper clusters on Kubernetes.
   It provides declarative cluster management through custom resources, enabling users to easily create highly-available ClickHouse deployments.


### PR DESCRIPTION
## Why
Error: chart requires kubeVersion: >= 1.28.0 which is incompatible with Kubernetes v1.33.5-gke.2392000. Reference: https://codeengineered.com/blog/2022/helm-kubeversion-gke/
