### PR TITLE
Don't restart pods on some config changes

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -37,6 +37,8 @@ const (
 	// ConditionTypeConfigurationInSync indicates that cluster configuration is in desired state.
 	ConditionTypeConfigurationInSync    ConditionType   = "ConfigurationInSync"
 	ConditionReasonConfigurationChanged ConditionReason = "ConfigurationChanged"
+	ConditionReasonConfigReloadFailed   ConditionReason = "ConfigReloadFailed"
+	ConditionReasonConfigReloadPending  ConditionReason = "ConfigReloadPending"
 
 	// ConditionTypeVersionInSync indicates that all replicas report the same version as the image.
 	ConditionTypeVersionInSync        ConditionType   = "VersionInSync"
@@ -52,6 +54,7 @@ const (
 	ConditionReasonMajorUpdateAvailable ConditionReason = "MajorUpdateAvailable"
 	ConditionReasonVersionOutdated      ConditionReason = "VersionOutdated"
 	ConditionReasonUpgradeCheckFailed   ConditionReason = "UpgradeCheckFailed"
+
 	// ConditionTypeReady indicates that cluster is ready to serve client requests.
 	ConditionTypeReady                      ConditionType   = "Ready"
 	ClickHouseConditionAllShardsReady       ConditionReason = "AllShardsReady"

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -52,7 +52,6 @@ const (
 	ConditionReasonMajorUpdateAvailable ConditionReason = "MajorUpdateAvailable"
 	ConditionReasonVersionOutdated      ConditionReason = "VersionOutdated"
 	ConditionReasonUpgradeCheckFailed   ConditionReason = "UpgradeCheckFailed"
-
 	// ConditionTypeReady indicates that cluster is ready to serve client requests.
 	ConditionTypeReady                      ConditionType   = "Ready"
 	ClickHouseConditionAllShardsReady       ConditionReason = "AllShardsReady"

--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -87,23 +87,50 @@ func (cmd *commander) Close() {
 	cmd.conns = map[v1.ClickHouseReplicaID]clickhouse.Conn{}
 }
 
-func (cmd *commander) Version(ctx context.Context, id v1.ClickHouseReplicaID) (string, error) {
+type replicaProbe struct {
+	Version              string
+	ReloadConfigRevision string
+}
+
+// Probe reads the replica server version and the latest applied reload-safe config revision.
+func (cmd *commander) Probe(ctx context.Context, id v1.ClickHouseReplicaID) (replicaProbe, error) {
 	conn, err := cmd.getConn(id)
 	if err != nil {
-		return "", fmt.Errorf("failed to get connection for replica %s: %w", id, err)
+		return replicaProbe{}, fmt.Errorf("failed to get connection for replica %s: %w", id, err)
 	}
 
-	var version string
-	if err := conn.QueryRow(ctx, "SELECT version()").Scan(&version); err != nil {
-		return "", fmt.Errorf("query version on replica %s: %w", id, err)
+	var probe replicaProbe
+
+	row := conn.QueryRow(ctx,
+		"SELECT version(),"+
+			" ifNull((SELECT collection[?] FROM system.named_collections WHERE name = ?), '')"+
+			" SETTINGS format_display_secrets_in_show_and_select=1",
+		OperatorConfigRevisionField, OperatorNamedCollectionName,
+	)
+	if err := row.Scan(&probe.Version, &probe.ReloadConfigRevision); err != nil {
+		return replicaProbe{}, fmt.Errorf("probe replica %s: %w", id, err)
 	}
 
-	version, err = controllerutil.ParseVersion(version)
+	probe.Version, err = controllerutil.ParseVersion(probe.Version)
 	if err != nil {
-		return "", fmt.Errorf("parse version from replica %s response: %w", id, err)
+		return replicaProbe{}, fmt.Errorf("parse version from replica %s response: %w", id, err)
 	}
 
-	return version, nil
+	return probe, nil
+}
+
+// ReloadConfig queries the replica to reload its configuration.
+func (cmd *commander) ReloadConfig(ctx context.Context, id v1.ClickHouseReplicaID) error {
+	conn, err := cmd.getConn(id)
+	if err != nil {
+		return fmt.Errorf("failed to get connection for replica %s: %w", id, err)
+	}
+
+	if err := conn.Exec(ctx, "SYSTEM RELOAD CONFIG"); err != nil {
+		return fmt.Errorf("reload config on replica %s: %w", id, err)
+	}
+
+	return nil
 }
 
 func (cmd *commander) SyncDatabases(ctx context.Context, log controllerutil.Logger, replicas []v1.ClickHouseReplicaID) bool {
@@ -150,34 +177,6 @@ func (cmd *commander) SyncDatabases(ctx context.Context, log controllerutil.Logg
 	}
 
 	return result
-}
-
-// ReloadConfig executes SYSTEM RELOAD CONFIG.
-func (cmd *commander) ReloadConfig(ctx context.Context, id v1.ClickHouseReplicaID) error {
-	conn, err := cmd.getConn(id)
-	if err != nil {
-		return fmt.Errorf("failed to get connection for replica %s: %w", id, err)
-	}
-
-	if err := conn.Exec(ctx, "SYSTEM RELOAD CONFIG"); err != nil {
-		return fmt.Errorf("reload config on replica %s: %w", id, err)
-	}
-
-	return nil
-}
-
-// ReloadUsers executes SYSTEM RELOAD USERS.
-func (cmd *commander) ReloadUsers(ctx context.Context, id v1.ClickHouseReplicaID) error {
-	conn, err := cmd.getConn(id)
-	if err != nil {
-		return fmt.Errorf("failed to get connection for replica %s: %w", id, err)
-	}
-
-	if err := conn.Exec(ctx, "SYSTEM RELOAD USERS"); err != nil {
-		return fmt.Errorf("reload users on replica %s: %w", id, err)
-	}
-
-	return nil
 }
 
 func (cmd *commander) Databases(ctx context.Context, id v1.ClickHouseReplicaID) (map[string]databaseDescriptor, error) {

--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -152,6 +152,34 @@ func (cmd *commander) SyncDatabases(ctx context.Context, log controllerutil.Logg
 	return result
 }
 
+// ReloadConfig executes SYSTEM RELOAD CONFIG.
+func (cmd *commander) ReloadConfig(ctx context.Context, id v1.ClickHouseReplicaID) error {
+	conn, err := cmd.getConn(id)
+	if err != nil {
+		return fmt.Errorf("failed to get connection for replica %s: %w", id, err)
+	}
+
+	if err := conn.Exec(ctx, "SYSTEM RELOAD CONFIG"); err != nil {
+		return fmt.Errorf("reload config on replica %s: %w", id, err)
+	}
+
+	return nil
+}
+
+// ReloadUsers executes SYSTEM RELOAD USERS.
+func (cmd *commander) ReloadUsers(ctx context.Context, id v1.ClickHouseReplicaID) error {
+	conn, err := cmd.getConn(id)
+	if err != nil {
+		return fmt.Errorf("failed to get connection for replica %s: %w", id, err)
+	}
+
+	if err := conn.Exec(ctx, "SYSTEM RELOAD USERS"); err != nil {
+		return fmt.Errorf("reload users on replica %s: %w", id, err)
+	}
+
+	return nil
+}
+
 func (cmd *commander) Databases(ctx context.Context, id v1.ClickHouseReplicaID) (map[string]databaseDescriptor, error) {
 	conn, err := cmd.getConn(id)
 	if err != nil {

--- a/internal/controller/clickhouse/commands_test.go
+++ b/internal/controller/clickhouse/commands_test.go
@@ -35,6 +35,7 @@ const (
 	testUsername                   = "operator"
 	keeperImage                    = "clickhouse/clickhouse-keeper:26.2"
 	clickhouseImage                = "clickhouse/clickhouse-server:26.2"
+	testConfigRevision             = "test-revision-v1"
 )
 
 func generateKeeperConfig() *strings.Reader {
@@ -70,8 +71,11 @@ remote_servers:
   default:
     shard:
       replica: [%s]
+named_collections:
+  __operator:
+    config_revision: %s
 display_secrets_in_show_and_select: true
-`, replica, keeperHostname, keeper.PortNative, strings.Join(replicas, ",")))
+`, replica, keeperHostname, keeper.PortNative, strings.Join(replicas, ","), testConfigRevision))
 }
 
 func generateUsersConfig() *strings.Reader {
@@ -218,12 +222,13 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 		})
 	})
 
-	It("should get every node version", func(ctx context.Context) {
+	It("should probe version and config revision in a single query", func(ctx context.Context) {
 		for id := range cmd.cluster.ReplicaIDs() {
 			Eventually(func(g Gomega) {
-				v, err := cmd.Version(ctx, id)
+				probe, err := cmd.Probe(ctx, id)
 				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(v).To(MatchRegexp(`^\d+\.\d+\.\d+\.\d+$`))
+				g.Expect(probe.Version).To(MatchRegexp(`^\d+\.\d+\.\d+\.\d+$`))
+				g.Expect(probe.ReloadConfigRevision).To(Equal(testConfigRevision))
 			}, "1m", "100ms").Should(Succeed())
 		}
 	})

--- a/internal/controller/clickhouse/config.go
+++ b/internal/controller/clickhouse/config.go
@@ -21,6 +21,8 @@ import (
 var (
 	//go:embed templates/base.yaml.tmpl
 	baseConfigTemplateStr string
+	//go:embed templates/cluster.yaml.tmpl
+	clusterConfigTemplateStr string
 	//go:embed templates/named_collections.yaml.tmpl
 	namedCollectionsTemplateStr string
 	//go:embed templates/network.yaml.tmpl
@@ -66,21 +68,29 @@ func init() {
 	}
 
 	for _, templateSpec := range []struct {
-		Path      string
-		Filename  string
-		Raw       string
-		Generator configGeneratorFunc
-		Enabled   func(r *clickhouseReconciler) bool
+		Path            string
+		Filename        string
+		Raw             string
+		Generator       configGeneratorFunc
+		Enabled         func(r *clickhouseReconciler) bool
+		RequiresRestart bool
 	}{{
-		Path:      ConfigPath,
-		Filename:  ConfigFileName,
-		Raw:       baseConfigTemplateStr,
-		Generator: baseConfigGenerator,
+		Path:            ConfigPath,
+		Filename:        ConfigFileName,
+		Raw:             baseConfigTemplateStr,
+		Generator:       baseConfigGenerator,
+		RequiresRestart: true,
 	}, {
 		Path:      path.Join(ConfigPath, ConfigDPath),
-		Filename:  "00-network.yaml",
-		Raw:       networkConfigTemplateStr,
-		Generator: networkConfigGenerator,
+		Filename:  "00-cluster.yaml",
+		Raw:       clusterConfigTemplateStr,
+		Generator: clusterConfigGenerator,
+	}, {
+		Path:            path.Join(ConfigPath, ConfigDPath),
+		Filename:        "00-network.yaml",
+		Raw:             networkConfigTemplateStr,
+		Generator:       networkConfigGenerator,
+		RequiresRestart: true,
 	}, {
 		Path:      path.Join(ConfigPath, ConfigDPath),
 		Filename:  "00-logs-tables.yaml",
@@ -108,19 +118,21 @@ func init() {
 		tmpl := template.Must(template.New("").Funcs(templateFuncs).Parse(templateSpec.Raw))
 
 		generators = append(generators, &templateConfigGenerator{
-			filename:  templateSpec.Filename,
-			path:      templateSpec.Path,
-			template:  tmpl,
-			generator: templateSpec.Generator,
-			enabled:   templateSpec.Enabled,
+			filename:        templateSpec.Filename,
+			path:            templateSpec.Path,
+			template:        tmpl,
+			generator:       templateSpec.Generator,
+			enabled:         templateSpec.Enabled,
+			requiresRestart: templateSpec.RequiresRestart,
 		})
 	}
 
 	generators = append(generators,
 		&extraConfigGenerator{
-			Name:          ExtraConfigFileName,
-			ConfigSubPath: ConfigDPath,
-			Getter:        func(r *clickhouseReconciler) []byte { return r.Cluster.Spec.Settings.ExtraConfig.Raw },
+			Name:            ExtraConfigFileName,
+			ConfigSubPath:   ConfigDPath,
+			requiresRestart: true,
+			Getter:          func(r *clickhouseReconciler) []byte { return r.Cluster.Spec.Settings.ExtraConfig.Raw },
 		},
 		&extraConfigGenerator{
 			Name:          ExtraUsersConfigFileName,
@@ -134,15 +146,17 @@ type configGenerator interface {
 	Path() string
 	ConfigKey() string
 	Enabled(r *clickhouseReconciler) bool
+	RequiresRestart() bool
 	Generate(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (string, error)
 }
 
 type templateConfigGenerator struct {
-	filename  string
-	path      string
-	template  *template.Template
-	generator configGeneratorFunc
-	enabled   func(r *clickhouseReconciler) bool
+	filename        string
+	path            string
+	template        *template.Template
+	generator       configGeneratorFunc
+	enabled         func(r *clickhouseReconciler) bool
+	requiresRestart bool
 }
 
 func (g *templateConfigGenerator) Filename() string {
@@ -161,6 +175,10 @@ func (g *templateConfigGenerator) Enabled(r *clickhouseReconciler) bool {
 	return g.enabled == nil || g.enabled(r)
 }
 
+func (g *templateConfigGenerator) RequiresRestart() bool {
+	return g.requiresRestart
+}
+
 func (g *templateConfigGenerator) Generate(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (string, error) {
 	data, err := g.generator(g.template, r, id)
 	if err != nil {
@@ -173,12 +191,8 @@ func (g *templateConfigGenerator) Generate(r *clickhouseReconciler, id v1.ClickH
 type configGeneratorFunc func(tmpl *template.Template, r *clickhouseReconciler, id v1.ClickHouseReplicaID) (string, error)
 
 type baseConfigParams struct {
-	Path   string
-	Log    controller.LoggerConfig
-	Macros []macro
-
-	KeeperNodes       []keeperNode
-	KeeperIdentityEnv string
+	Path string
+	Log  controller.LoggerConfig
 
 	DistributedDDLPath        string
 	DistributedDDLProfileName string
@@ -186,40 +200,10 @@ type baseConfigParams struct {
 	UsersZookeeperPath        string
 	UDFZookeeperPath          string
 
-	ClusterSecretEnv string
-	ManagementPort   uint16
-	ClusterHosts     [][]string
-
 	OpenSSL controller.OpenSSLConfig
 }
 
-type macro struct {
-	Name  string
-	Value any
-}
-type keeperNode struct {
-	Host   string
-	Port   int32
-	Secure bool
-}
-
-func baseConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, id v1.ClickHouseReplicaID) (string, error) {
-	keeperNodes := make([]keeperNode, 0, r.keeper.Replicas())
-	for _, host := range r.keeper.Hostnames() {
-		if r.keeper.Spec.Settings.TLS.Enabled {
-			keeperNodes = append(keeperNodes, keeperNode{
-				Host:   host,
-				Port:   keeper.PortNativeSecure,
-				Secure: true,
-			})
-		} else {
-			keeperNodes = append(keeperNodes, keeperNode{
-				Host: host,
-				Port: keeper.PortNative,
-			})
-		}
-	}
-
+func baseConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, _ v1.ClickHouseReplicaID) (string, error) {
 	openSSL := controller.OpenSSLConfig{}
 	if r.Cluster.Spec.Settings.TLS.Enabled {
 		params := controller.OpenSSLParams{
@@ -244,6 +228,82 @@ func baseConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, id v1
 		openSSL.Client.PreferServerCiphers = true
 	}
 
+	params := baseConfigParams{
+		Path: internal.ClickHouseDataPath,
+		Log:  controller.GenerateLoggerConfig(r.Cluster.Spec.Settings.Logger, LogPath, "clickhouse-server"),
+
+		DistributedDDLPath:        KeeperPathDistributedDDL,
+		DistributedDDLProfileName: DefaultProfileName,
+		UsersXMLPath:              UsersFileName,
+		UsersZookeeperPath:        KeeperPathUsers,
+		UDFZookeeperPath:          KeeperPathUDF,
+
+		OpenSSL: openSSL,
+	}
+
+	builder := strings.Builder{}
+	if err := tmpl.Execute(&builder, params); err != nil {
+		return "", fmt.Errorf("template base config: %w", err)
+	}
+
+	return builder.String(), nil
+}
+
+type clusterConfigParams struct {
+	Macros []macro
+
+	KeeperNodes       []keeperNode
+	KeeperIdentityEnv string
+
+	ClusterSecretEnv string
+	ManagementPort   uint16
+	ClusterHosts     [][]string
+
+	NamedCollections []namedCollection
+}
+
+const (
+	OperatorNamedCollectionName = "__operator"
+	OperatorConfigRevisionField = "config_revision"
+)
+
+type macro struct {
+	Name  string
+	Value any
+}
+type keeperNode struct {
+	Host   string
+	Port   int32
+	Secure bool
+}
+
+type namedCollection struct {
+	Name   string
+	Values []namedCollectionValue
+}
+
+type namedCollectionValue struct {
+	Key   string
+	Value string
+}
+
+func clusterConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, id v1.ClickHouseReplicaID) (string, error) {
+	keeperNodes := make([]keeperNode, 0, r.keeper.Replicas())
+	for _, host := range r.keeper.Hostnames() {
+		if r.keeper.Spec.Settings.TLS.Enabled {
+			keeperNodes = append(keeperNodes, keeperNode{
+				Host:   host,
+				Port:   keeper.PortNativeSecure,
+				Secure: true,
+			})
+		} else {
+			keeperNodes = append(keeperNodes, keeperNode{
+				Host: host,
+				Port: keeper.PortNative,
+			})
+		}
+	}
+
 	clusterHosts := make([][]string, r.Cluster.Shards())
 	for shard := range r.Cluster.Shards() {
 		hosts := make([]string, r.Cluster.Replicas())
@@ -254,9 +314,7 @@ func baseConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, id v1
 		clusterHosts[shard] = hosts
 	}
 
-	params := baseConfigParams{
-		Path: internal.ClickHouseDataPath,
-		Log:  controller.GenerateLoggerConfig(r.Cluster.Spec.Settings.Logger, LogPath, "clickhouse-server"),
+	params := clusterConfigParams{
 		Macros: []macro{
 			{Name: "cluster", Value: DefaultClusterName},
 			{Name: "shard", Value: id.ShardID},
@@ -266,22 +324,22 @@ func baseConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, id v1
 		KeeperNodes:       keeperNodes,
 		KeeperIdentityEnv: EnvKeeperIdentity,
 
-		DistributedDDLPath:        KeeperPathDistributedDDL,
-		DistributedDDLProfileName: DefaultProfileName,
-		UsersXMLPath:              UsersFileName,
-		UsersZookeeperPath:        KeeperPathUsers,
-		UDFZookeeperPath:          KeeperPathUDF,
-
 		ClusterSecretEnv: EnvClusterSecret,
 		ManagementPort:   PortManagement,
 		ClusterHosts:     clusterHosts,
 
-		OpenSSL: openSSL,
+		NamedCollections: []namedCollection{{
+			Name: OperatorNamedCollectionName,
+			Values: []namedCollectionValue{{
+				Key:   OperatorConfigRevisionField,
+				Value: r.revs.ReloadConfigRevision,
+			}},
+		}},
 	}
 
 	builder := strings.Builder{}
 	if err := tmpl.Execute(&builder, params); err != nil {
-		return "", fmt.Errorf("template base config: %w", err)
+		return "", fmt.Errorf("template cluster config: %w", err)
 	}
 
 	return builder.String(), nil
@@ -418,9 +476,10 @@ func namedCollectionsConfigGenerator(tmpl *template.Template, _ *clickhouseRecon
 }
 
 type extraConfigGenerator struct {
-	Name          string
-	ConfigSubPath string
-	Getter        func(r *clickhouseReconciler) []byte
+	Name            string
+	ConfigSubPath   string
+	requiresRestart bool
+	Getter          func(r *clickhouseReconciler) []byte
 }
 
 func (g *extraConfigGenerator) Filename() string {
@@ -437,6 +496,10 @@ func (g *extraConfigGenerator) ConfigKey() string {
 
 func (g *extraConfigGenerator) Enabled(r *clickhouseReconciler) bool {
 	return len(g.Getter(r)) > 0
+}
+
+func (g *extraConfigGenerator) RequiresRestart() bool {
+	return g.requiresRestart
 }
 
 func (g *extraConfigGenerator) Generate(r *clickhouseReconciler, _ v1.ClickHouseReplicaID) (string, error) {

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -431,7 +431,7 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 		Expect(updatedCR.Status.ObservedGeneration).To(Equal(updatedCR.Generation))
 		Expect(updatedCR.Status.UpdateRevision).NotTo(Equal(updatedCR.Status.CurrentRevision))
 		Expect(updatedCR.Status.ConfigurationRevision).NotTo(Equal(cr.Status.ConfigurationRevision))
-		Expect(updatedCR.Status.StatefulSetRevision).To(Equal(cr.Status.StatefulSetRevision))
+		Expect(updatedCR.Status.StatefulSetRevision).NotTo(Equal(cr.Status.StatefulSetRevision))
 	})
 
 	It("should use security context overrides from spec", func(ctx context.Context) {

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -34,40 +34,31 @@ func compareReplicaID(a, b v1.ClickHouseReplicaID) int {
 }
 
 type replicaState struct {
-	Error       bool `json:"error"`
-	StatefulSet *appsv1.StatefulSet
-	PVC         *corev1.PersistentVolumeClaim
-	Pinged      bool
-	Version     string
-}
+	replicaProbe
+	chctrl.ReplicaState
 
-func (r replicaState) Updated() bool {
-	if r.StatefulSet == nil {
-		return false
-	}
-
-	return r.StatefulSet.Generation == r.StatefulSet.Status.ObservedGeneration &&
-		r.StatefulSet.Status.UpdateRevision == r.StatefulSet.Status.CurrentRevision
+	ReloadError error
+	Error       bool
 }
 
 func (r replicaState) Ready() bool {
-	if r.StatefulSet == nil {
+	if r.STS == nil {
 		return false
 	}
 
-	return r.Pinged && r.StatefulSet.Status.ReadyReplicas == 1 // Not reliable, but allows to wait until pod is `green`
+	return r.Version != "" && r.STS.Status.ReadyReplicas == 1 // Not reliable, but allows to wait until pod is `green`
 }
 
 func (r replicaState) HasDiff(rev chctrl.RevisionState) bool {
-	return rev.ReplicaHasDiff(r.StatefulSet, r.PVC)
+	return rev.ReplicaHasDiff(r.ReplicaState)
 }
 
 func (r replicaState) UpdateStage(rev chctrl.RevisionState) chctrl.ReplicaUpdateStage {
-	if r.StatefulSet == nil {
+	if r.STS == nil {
 		return chctrl.StageNotExists
 	}
 
-	if r.Error {
+	if r.Error || r.ReloadError != nil {
 		return chctrl.StageError
 	}
 
@@ -79,7 +70,7 @@ func (r replicaState) UpdateStage(rev chctrl.RevisionState) chctrl.ReplicaUpdate
 		return chctrl.StageHasDiff
 	}
 
-	if !r.Ready() {
+	if !r.Ready() || r.ReloadConfigRevision != rev.ReloadConfigRevision {
 		return chctrl.StageNotReadyUpToDate
 	}
 
@@ -438,6 +429,11 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 		return chctrl.StepResult{}, fmt.Errorf("list StatefulSets: %w", err)
 	}
 
+	configMaps, err := chctrl.ListReplicaResources[v1.ClickHouseReplicaID, *corev1.ConfigMap, *corev1.ConfigMapList](ctx, &r.ResourceManager, v1.ClickHouseIDFromLabels)
+	if err != nil {
+		return chctrl.StepResult{}, fmt.Errorf("list replicas ConfigMaps: %w", err)
+	}
+
 	execResults := ctrlutil.ExecuteParallel(statefulSets.Items, func(sts appsv1.StatefulSet) (v1.ClickHouseReplicaID, replicaState, error) {
 		id, err := v1.ClickHouseIDFromLabels(sts.Labels)
 		if err != nil {
@@ -452,18 +448,26 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 			hasError = true
 		}
 
-		pinged := false
-		version := ""
+		var (
+			probe     replicaProbe
+			reloadErr error
+		)
 
 		if !hasError && sts.Status.ReadyReplicas > 0 && r.commander != nil {
 			ctx, cancel := context.WithTimeout(ctx, chctrl.LoadReplicaStateTimeout)
 			defer cancel()
 
-			version, err = r.commander.Version(ctx, id)
+			probe, err = r.commander.Probe(ctx, id)
 			if err != nil {
-				log.Debug("failed to query version on replica", "replica_id", id, "error", err)
-			} else {
-				pinged = true
+				log.Debug("failed to probe replica", "replica_id", id, "error", err)
+			}
+
+			if cfg, ok := configMaps[id]; ok && probe.ReloadConfigRevision != cfg.Annotations[ctrlutil.AnnotationReloadableConfigHash] {
+				if reloadErr = r.commander.ReloadConfig(ctx, id); reloadErr != nil {
+					log.Debug("replica config reload failed", "replica_id", id, "error", reloadErr)
+				} else if probe, err = r.commander.Probe(ctx, id); err != nil {
+					log.Debug("failed to re-probe replica after reload", "replica_id", id, "error", err)
+				}
 			}
 		}
 
@@ -478,11 +482,14 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 		log.Debug("load replica state done", "replica_id", id, "statefulset", sts.Name)
 
 		return id, replicaState{
-			StatefulSet: &sts,
-			PVC:         pvc,
-			Error:       hasError,
-			Pinged:      pinged,
-			Version:     version,
+			ReloadError:  reloadErr,
+			Error:        hasError,
+			replicaProbe: probe,
+			ReplicaState: chctrl.ReplicaState{
+				STS: &sts,
+				CFG: configMaps[id],
+				PVC: pvc,
+			},
 		}, nil
 	})
 
@@ -495,8 +502,8 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 		if _, ok := r.ReplicaState[id]; !ok {
 			r.ReplicaState[id] = res.Result
 		} else {
-			log.Debug(fmt.Sprintf("multiple StatefulSets for single replica %v", id),
-				"replica_id", id, "statefulset", res.Result.StatefulSet.Name)
+			log.Debug(fmt.Sprintf("multiple StatefulSets for single replica %s, %s",
+				r.ReplicaState[id].STS.Name, res.Result.STS.Name), "replica_id", id)
 		}
 	}
 
@@ -546,17 +553,21 @@ func (r *clickhouseReconciler) reconcileClusterRevisions(ctx context.Context, lo
 		return chctrl.StepBlocked(chctrl.RequeueOnRefreshTimeout), nil
 	}
 
-	r.revs.ConfigurationRevision, err = getConfigurationRevision(r)
+	cfgRev, err := getConfigurationRevisions(r)
 	if err != nil {
-		return chctrl.StepResult{}, fmt.Errorf("get configuration revision: %w", err)
+		return chctrl.StepResult{}, fmt.Errorf("get configuration revisions: %w", err)
 	}
 
-	if r.revs.ConfigurationRevision != r.Cluster.Status.ConfigurationRevision {
-		r.Cluster.Status.ConfigurationRevision = r.revs.ConfigurationRevision
-		log.Debug(fmt.Sprintf("observed new configuration revision %q", r.revs.ConfigurationRevision))
+	r.revs.ReloadConfigRevision = cfgRev.Reload
+	r.revs.RestartConfigRevision = cfgRev.Restart
+	r.revs.ConfigurationRevision = cfgRev.Config
+
+	if cfgRev.Config != r.Cluster.Status.ConfigurationRevision {
+		r.Cluster.Status.ConfigurationRevision = cfgRev.Config
+		log.Debug(fmt.Sprintf("observed new configuration revision %q", cfgRev.Config))
 	}
 
-	r.revs.StatefulSetRevision, err = getStatefulSetRevision(r)
+	r.revs.StatefulSetRevision, err = getStatefulSetRevision(r, r.revs.RestartConfigRevision)
 	if err != nil {
 		return chctrl.StepResult{}, fmt.Errorf("get StatefulSet revision: %w", err)
 	}
@@ -575,24 +586,32 @@ func (r *clickhouseReconciler) reconcileClusterRevisions(ctx context.Context, lo
 		}
 	}
 
-	var notUpdatedIDs []string
+	var notUpdated, reloadErr, notReloaded []string
 	for shard := range r.Cluster.Shards() {
 		for index := range r.Cluster.Replicas() {
 			id := v1.ClickHouseReplicaID{ShardID: shard, Index: index}
 			replica := r.ReplicaState[id]
 
 			if replica.HasDiff(r.revs) || !replica.Updated() {
-				notUpdatedIDs = append(notUpdatedIDs, id.String())
+				notUpdated = append(notUpdated, id.String())
+			}
+
+			if replica.ReloadError != nil {
+				reloadErr = append(reloadErr, id.String())
+			}
+
+			if replica.ReloadConfigRevision != r.revs.ReloadConfigRevision {
+				notReloaded = append(notReloaded, id.String())
 			}
 		}
 	}
 
-	r.SetCondition(chctrl.ConfigSyncCondition(notUpdatedIDs))
+	r.SetCondition(chctrl.ConfigSyncCondition(reloadErr, notUpdated, notReloaded))
 
 	exists := len(r.ReplicaState)
 	expected := int(r.Cluster.Replicas() * r.Cluster.Shards())
 
-	if len(notUpdatedIDs) == 0 && exists == expected {
+	if len(notUpdated) == 0 && len(reloadErr) == 0 && len(notReloaded) == 0 && exists == expected {
 		r.Cluster.Status.CurrentRevision = r.Cluster.Status.UpdateRevision
 	}
 
@@ -602,7 +621,7 @@ func (r *clickhouseReconciler) reconcileClusterRevisions(ctx context.Context, lo
 	}
 
 	{
-		cond, event := chctrl.GetVersionSyncCondition(r.versionProbe, replicaVersions, len(notUpdatedIDs) > 0)
+		cond, event := chctrl.GetVersionSyncCondition(r.versionProbe, replicaVersions, len(notUpdated) > 0)
 		r.SetCondition(cond, event...)
 	}
 
@@ -616,10 +635,10 @@ func (r *clickhouseReconciler) reconcileClusterRevisions(ctx context.Context, lo
 	return chctrl.StepContinue(), nil
 }
 
-// reconcileReplicaResources performs update on replicas ConfigMap and StatefulSet.
+// reconcileReplicaResources performs update on replicas ConfigMap, StatefulSet, PVC.
 // If there are replicas that has no created StatefulSet, creates immediately.
-// If all replicas exists performs rolling upgrade, with the following order preferences:
-// NotExists -> CrashLoop/ImagePullErr -> OnlySts -> OnlyConfig -> Any.
+// For existing and Ready replicas performs rolling update. Update priority:
+// NotExists -> StartupErrors -> UpdateInProgress -> HasDiff(rolling).
 func (r *clickhouseReconciler) reconcileReplicaResources(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
 	highestStage := chctrl.StageUpToDate
 
@@ -795,98 +814,65 @@ func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ct
 	return chctrl.StepContinue(), nil
 }
 
-type replicaResources struct {
-	cfg *corev1.ConfigMap
-	sts *appsv1.StatefulSet
-}
-
 func (r *clickhouseReconciler) reconcileCleanUp(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	var (
-		configMaps corev1.ConfigMapList
+	var replicasToRemove = map[v1.ClickHouseReplicaID]chctrl.ReplicaState{}
 
-		listOpts         = ctrlutil.AppRequirements(r.Cluster.Namespace, r.Cluster.SpecificName())
-		replicasToRemove = map[int32]map[int32]replicaResources{}
-	)
-
-	if err := r.GetClient().List(ctx, &configMaps, listOpts); err != nil {
-		return chctrl.StepResult{}, fmt.Errorf("list ConfigMaps: %w", err)
+	configMaps, err := chctrl.ListReplicaResources[v1.ClickHouseReplicaID, *corev1.ConfigMap, *corev1.ConfigMapList](ctx, &r.ResourceManager, v1.ClickHouseIDFromLabels)
+	if err != nil {
+		return chctrl.StepResult{}, fmt.Errorf("list replicas ConfigMaps: %w", err)
 	}
 
-	for _, configMap := range configMaps.Items {
-		id, err := v1.ClickHouseIDFromLabels(configMap.Labels)
-		if err != nil {
-			log.Warn("failed to get replica ID from ConfigMap labels", "configmap", configMap.Name, "error", err)
-			continue
-		}
-
+	for id, configMap := range configMaps {
 		if id.ShardID < r.Cluster.Shards() && id.Index < r.Cluster.Replicas() {
 			continue
 		}
 
-		if _, ok := replicasToRemove[id.ShardID]; !ok {
-			replicasToRemove[id.ShardID] = map[int32]replicaResources{}
+		replicasToRemove[id] = chctrl.ReplicaState{
+			CFG: configMap,
 		}
-
-		state := replicasToRemove[id.ShardID][id.Index]
-		state.cfg = &configMap
-		replicasToRemove[id.ShardID][id.Index] = state
 	}
 
-	var statefulSets appsv1.StatefulSetList
-	if err := r.GetClient().List(ctx, &statefulSets, listOpts); err != nil {
+	statefulSets, err := chctrl.ListReplicaResources[v1.ClickHouseReplicaID, *appsv1.StatefulSet, *appsv1.StatefulSetList](ctx, &r.ResourceManager, v1.ClickHouseIDFromLabels)
+	if err != nil {
 		return chctrl.StepResult{}, fmt.Errorf("list StatefulSets: %w", err)
 	}
 
-	for _, sts := range statefulSets.Items {
-		id, err := v1.ClickHouseIDFromLabels(sts.Labels)
-		if err != nil {
-			log.Warn("failed to get replica ID from StatefulSet labels", "statefulset", sts.Name, "error", err)
-			continue
-		}
-
+	for id, sts := range statefulSets {
 		if id.ShardID < r.Cluster.Shards() && id.Index < r.Cluster.Replicas() {
 			continue
 		}
 
-		if _, ok := replicasToRemove[id.ShardID]; !ok {
-			replicasToRemove[id.ShardID] = map[int32]replicaResources{}
-		}
-
-		state := replicasToRemove[id.ShardID][id.Index]
-		state.sts = &sts
-		replicasToRemove[id.ShardID][id.Index] = state
+		state := replicasToRemove[id]
+		state.STS = sts
+		replicasToRemove[id] = state
 	}
 
-	for shardID, replicas := range replicasToRemove {
-		inSync := !r.unsyncedShards[shardID]
+	for id, res := range replicasToRemove {
+		inSync := !r.unsyncedShards[id.ShardID]
 
-		for index, res := range replicas {
-			id := v1.ClickHouseReplicaID{ShardID: shardID, Index: index}
+		// Always delete orphaned ConfigMaps.
+		if res.CFG != nil && (inSync || res.STS == nil) {
+			log.Info("removing replica configmap", "replica_id", id, "configmap", res.CFG.Name)
 
-			// Always delete orphaned ConfigMaps.
-			if res.cfg != nil && (inSync || res.sts == nil) {
-				log.Info("removing replica configmap", "replica_id", id, "configmap", res.cfg.Name)
-
-				if err := r.Delete(ctx, res.cfg, v1.EventActionReconciling); err != nil {
-					log.Error(err, "failed to delete replica configmap", "replica_id", id, "configmap", res.cfg.Name)
-				}
+			if err := r.Delete(ctx, res.CFG, v1.EventActionReconciling); err != nil {
+				log.Error(err, "failed to delete replica configmap", "replica_id", id, "configmap", res.CFG.Name)
 			}
+		}
 
-			// Delete StatefulSets only if the entire shard is removed or shard sync succeeded.
-			if res.sts == nil {
-				continue
-			}
+		// Delete StatefulSets only if the entire shard is removed or shard sync succeeded.
+		if res.STS == nil {
+			continue
+		}
 
-			if !inSync {
-				log.Info("shard sync failed, skipping replica deletion", "replica_id", id)
-				continue
-			}
+		if !inSync {
+			log.Info("shard sync failed, skipping replica deletion", "replica_id", id)
+			continue
+		}
 
-			log.Info("removing replica statefulset", "replica_id", id, "statefulset", res.sts.Name)
+		log.Info("removing replica statefulset", "replica_id", id, "statefulset", res.STS.Name)
 
-			if err := r.Delete(ctx, res.sts, v1.EventActionReconciling); err != nil {
-				log.Error(err, "failed to delete replica statefulset", "replica_id", id, "statefulset", res.sts.Name)
-			}
+		if err := r.Delete(ctx, res.STS, v1.EventActionReconciling); err != nil {
+			log.Error(err, "failed to delete replica statefulset", "replica_id", id, "statefulset", res.STS.Name)
 		}
 	}
 
@@ -972,25 +958,27 @@ func (r *clickhouseReconciler) updateReplica(ctx context.Context, log ctrlutil.L
 		return nil, fmt.Errorf("template replica %s ConfigMap: %w", id, err)
 	}
 
-	statefulSet, err := templateStatefulSet(r, id)
+	statefulSet, err := templateStatefulSet(r, id, r.revs.RestartConfigRevision)
 	if err != nil {
 		return nil, fmt.Errorf("template replica %s StatefulSet: %w", id, err)
+	}
+
+	var pvc *corev1.PersistentVolumeClaim
+	if r.Cluster.Spec.DataVolumeClaimSpec != nil {
+		pvc = &corev1.PersistentVolumeClaim{Spec: *r.Cluster.Spec.DataVolumeClaimSpec}
 	}
 
 	replica := r.ReplicaState[id]
 
 	result, err := r.ReconcileReplicaResources(ctx, log, chctrl.ReplicaUpdateInput{
 		Revisions: r.revs,
-
-		DesiredConfigMap: configMap,
-
-		ExistingSTS:        replica.StatefulSet,
-		DesiredSTS:         statefulSet,
-		HasError:           replica.Error,
-		BreakingSTSVersion: breakingStatefulSetVersion,
-
-		ExistingPVC:    replica.PVC,
-		DesiredPVCSpec: r.Cluster.Spec.DataVolumeClaimSpec,
+		Existing:  replica.ReplicaState,
+		HasError:  replica.Error,
+		Desired: chctrl.ReplicaState{
+			CFG: configMap,
+			STS: statefulSet,
+			PVC: pvc,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("reconcile replica %s resources: %w", id, err)

--- a/internal/controller/clickhouse/templates.go
+++ b/internal/controller/clickhouse/templates.go
@@ -145,22 +145,52 @@ func templateClusterSecrets(cr *v1.ClickHouseCluster, existing corev1.Secret) (c
 	return secret, changed
 }
 
-func getConfigurationRevision(r *clickhouseReconciler) (string, error) {
-	config, err := generateConfigForSingleReplica(r, v1.ClickHouseReplicaID{})
-	if err != nil {
-		return "", fmt.Errorf("generate template configuration: %w", err)
-	}
-
-	hash, err := controllerutil.DeepHashObject(config)
-	if err != nil {
-		return "", fmt.Errorf("hash template configuration: %w", err)
-	}
-
-	return hash, nil
+type configRevisions struct {
+	Restart string
+	Reload  string
+	Config  string
 }
 
-func getStatefulSetRevision(r *clickhouseReconciler) (string, error) {
-	sts, err := templateStatefulSet(r, v1.ClickHouseReplicaID{})
+func getConfigurationRevisions(r *clickhouseReconciler) (configRevisions, error) {
+	reloadable := map[string]string{}
+	restartable := map[string]string{}
+
+	for _, generator := range generators {
+		if !generator.Enabled(r) {
+			continue
+		}
+
+		data, err := generator.Generate(r, v1.ClickHouseReplicaID{})
+		if err != nil {
+			return configRevisions{}, fmt.Errorf("generate config file %s: %w", generator.Path(), err)
+		}
+
+		if generator.RequiresRestart() {
+			restartable[generator.ConfigKey()] = data
+		} else {
+			reloadable[generator.ConfigKey()] = data
+		}
+	}
+
+	reloadableRev, err := controllerutil.DeepHashObject(reloadable)
+	if err != nil {
+		return configRevisions{}, fmt.Errorf("hash reloadable configuration: %w", err)
+	}
+
+	restartableRev, err := controllerutil.DeepHashObject(restartable)
+	if err != nil {
+		return configRevisions{}, fmt.Errorf("hash restartable configuration: %w", err)
+	}
+
+	return configRevisions{
+		Restart: restartableRev,
+		Reload:  reloadableRev,
+		Config:  fmt.Sprintf("%s:%s", reloadableRev, restartableRev),
+	}, nil
+}
+
+func getStatefulSetRevision(r *clickhouseReconciler, cfgRestartRevision string) (string, error) {
+	sts, err := templateStatefulSet(r, v1.ClickHouseReplicaID{}, cfgRestartRevision)
 	if err != nil {
 		return "", fmt.Errorf("generate template StatefulSet: %w", err)
 	}
@@ -198,7 +228,7 @@ func templateConfigMap(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (*cor
 	}, nil
 }
 
-func templateStatefulSet(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (*appsv1.StatefulSet, error) {
+func templateStatefulSet(r *clickhouseReconciler, id v1.ClickHouseReplicaID, cfgRestartRevision string) (*appsv1.StatefulSet, error) {
 	podSpec, err := templatePodSpec(r, id)
 	if err != nil {
 		return nil, fmt.Errorf("template pod spec: %w", err)
@@ -229,6 +259,7 @@ func templateStatefulSet(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (*a
 				GenerateName: r.Cluster.SpecificName(),
 				Labels:       resourceLabels,
 				Annotations: controllerutil.MergeMaps(r.Cluster.Spec.Annotations, map[string]string{
+					controllerutil.AnnotationConfigHash:       cfgRestartRevision,
 					"kubectl.kubernetes.io/default-container": ContainerName,
 				}),
 			},

--- a/internal/controller/clickhouse/templates/base.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/base.yaml.tmpl
@@ -1,38 +1,6 @@
 path: {{ .Path }}
 logger:
 {{ yaml .Log | indent 2 }}
-macros:
-  {{- range $i, $m := .Macros }}
-  {{ $m.Name }}: {{ $m.Value }}
-  {{- end }}
-
-{{- /* Replication settings */}}
-zookeeper:
-  nodes:
-    {{- range $index, $node := .KeeperNodes }}
-    - host: {{ $node.Host }}
-      port: {{ $node.Port }}
-      {{- if $node.Secure }}
-      secure: 1
-      {{- end }}
-    {{- end }}
-  identity:
-    "@from_env": {{ .KeeperIdentityEnv }}
-
-remote_servers:
-  default:
-    secret:
-      "@from_env": {{ .ClusterSecretEnv }}
-    shard:
-    {{- $ctx := .}}
-    {{- range $shard, $replicas := .ClusterHosts }}
-      - internal_replication: true
-        replica:
-        {{- range $i, $replica := $replicas }}
-          - host: {{ $replica }}
-            port: {{ $ctx.ManagementPort }}
-        {{- end }}
-    {{- end }}
 
 distributed_ddl:
   path: {{ .DistributedDDLPath }}

--- a/internal/controller/clickhouse/templates/cluster.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/cluster.yaml.tmpl
@@ -1,0 +1,41 @@
+macros:
+  {{- range $i, $m := .Macros }}
+  {{ $m.Name }}: {{ $m.Value }}
+  {{- end }}
+
+{{- /* Replication settings */}}
+zookeeper:
+  nodes:
+    {{- range $index, $node := .KeeperNodes }}
+    - host: {{ $node.Host }}
+      port: {{ $node.Port }}
+      {{- if $node.Secure }}
+      secure: 1
+      {{- end }}
+    {{- end }}
+  identity:
+    "@from_env": {{ .KeeperIdentityEnv }}
+
+remote_servers:
+  default:
+    secret:
+      "@from_env": {{ .ClusterSecretEnv }}
+    shard:
+    {{- $ctx := .}}
+    {{- range $shard, $replicas := .ClusterHosts }}
+      - internal_replication: true
+        replica:
+        {{- range $i, $replica := $replicas }}
+          - host: {{ $replica }}
+            port: {{ $ctx.ManagementPort }}
+        {{- end }}
+    {{- end }}
+
+{{- /* Named collections managed by the operator */}}
+named_collections:
+  {{- range .NamedCollections }}
+  {{ .Name }}:
+    {{- range .Values }}
+    {{ .Key }}: {{ .Value }}
+    {{- end }}
+  {{- end }}

--- a/internal/controller/clickhouse/templates_test.go
+++ b/internal/controller/clickhouse/templates_test.go
@@ -10,6 +10,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/randfill"
 
@@ -392,15 +393,96 @@ var _ = Describe("getStatefulSetRevision", func() {
 			},
 		}
 
-		rev, err := getStatefulSetRevision(&r)
+		rev, err := getStatefulSetRevision(&r, "fixed-cfg-rev")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rev).ToNot(BeEmpty())
 
 		r.Cluster.Spec.DataVolumeClaimSpec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("20Gi")
-		rev2, err := getStatefulSetRevision(&r)
+		rev2, err := getStatefulSetRevision(&r, "fixed-cfg-rev")
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(rev2).To(Equal(rev), "StatefulSet revision should not change when data disk spec changes")
+	})
+})
+
+var _ = Describe("getConfigurationRevisions", func() {
+	It("should generate idempotent non-empty revisions", func() {
+		r := &clickhouseReconciler{
+			Cluster: &v1.ClickHouseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: v1.ClickHouseClusterSpec{
+					Replicas: new(int32(1)),
+				},
+			},
+		}
+
+		revsFirst, err := getConfigurationRevisions(r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(revsFirst.Config).To(Not(BeEmpty()))
+		Expect(revsFirst.Restart).To(Not(BeEmpty()))
+		Expect(revsFirst.Reload).To(Not(BeEmpty()))
+
+		revsSecond, err := getConfigurationRevisions(r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(revsFirst).To(Equal(revsSecond))
+	})
+
+	It("reload revision should not depend on restartable configs", func() {
+		r := &clickhouseReconciler{
+			Cluster: &v1.ClickHouseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: v1.ClickHouseClusterSpec{
+					Replicas: new(int32(1)),
+				},
+			},
+		}
+
+		revsBefore, err := getConfigurationRevisions(r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(revsBefore.Config).To(Not(BeEmpty()))
+		Expect(revsBefore.Restart).To(Not(BeEmpty()))
+		Expect(revsBefore.Reload).To(Not(BeEmpty()))
+
+		// User-provided config always triggers restart for safety.
+		r.Cluster.Spec.Settings.ExtraConfig = runtime.RawExtension{Raw: []byte("{}")}
+
+		revsAfter, err := getConfigurationRevisions(r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(revsAfter.Config).To(Not(Equal(revsBefore.Config)))
+		Expect(revsAfter.Reload).To(Equal(revsBefore.Reload))
+		Expect(revsAfter.Restart).To(Not(Equal(revsBefore.Restart)))
+	})
+
+	It("restart revision should not depend on reloadable configs", func() {
+		r := &clickhouseReconciler{
+			Cluster: &v1.ClickHouseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: v1.ClickHouseClusterSpec{
+					Replicas: new(int32(1)),
+				},
+			},
+		}
+
+		revsBefore, err := getConfigurationRevisions(r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(revsBefore.Config).To(Not(BeEmpty()))
+		Expect(revsBefore.Restart).To(Not(BeEmpty()))
+		Expect(revsBefore.Reload).To(Not(BeEmpty()))
+
+		// Changes shard replicas list, reloadable
+		*r.Cluster.Spec.Replicas = 2
+
+		revsAfter, err := getConfigurationRevisions(r)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(revsAfter.Config).To(Not(Equal(revsBefore.Config)))
+		Expect(revsAfter.Reload).To(Not(Equal(revsBefore.Reload)))
+		Expect(revsAfter.Restart).To(Equal(revsBefore.Restart))
 	})
 })
 
@@ -435,12 +517,12 @@ func FuzzClusterSpec(f *testing.F) {
 
 		crBefore := r.Cluster.DeepCopy()
 
-		stsFirst, err1 := templateStatefulSet(r, id)
+		stsFirst, err1 := templateStatefulSet(r, id, "fixed-cfg-rev")
 		if diff := cmp.Diff(crBefore.Spec, r.Cluster.Spec); diff != "" {
 			t.Errorf("ClusterSpec mutated:\n%s", diff)
 		}
 
-		stsSecond, err2 := templateStatefulSet(r, id)
+		stsSecond, err2 := templateStatefulSet(r, id, "fixed-cfg-rev")
 		if diff := cmp.Diff(crBefore.Spec, r.Cluster.Spec); diff != "" {
 			t.Errorf("ClusterSpec mutated:\n%s", diff)
 		}

--- a/internal/controller/keeper/controller_test.go
+++ b/internal/controller/keeper/controller_test.go
@@ -265,10 +265,10 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 		Expect(updatedCR.Status.ObservedGeneration).To(Equal(updatedCR.Generation))
 		Expect(updatedCR.Status.UpdateRevision).NotTo(Equal(updatedCR.Status.CurrentRevision))
 		Expect(updatedCR.Status.ConfigurationRevision).NotTo(Equal(cr.Status.ConfigurationRevision))
-		Expect(updatedCR.Status.StatefulSetRevision).To(Equal(cr.Status.StatefulSetRevision))
+		Expect(updatedCR.Status.StatefulSetRevision).NotTo(Equal(cr.Status.StatefulSetRevision))
 	})
 
-	It("should merge extra config in configmap", func(ctx context.Context) {
+	It("should add extra config in configmap", func(ctx context.Context) {
 		updatedCR := cr.DeepCopy()
 		Expect(suite.Client.Get(ctx, cr.NamespacedName(), updatedCR)).To(Succeed())
 		testutil.ReconcileStatefulSets(ctx, updatedCR, suite)
@@ -282,7 +282,7 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 		Expect(updatedCR.Status.ObservedGeneration).To(Equal(updatedCR.Generation))
 		Expect(updatedCR.Status.UpdateRevision).NotTo(Equal(updatedCR.Status.CurrentRevision))
 		Expect(updatedCR.Status.ConfigurationRevision).NotTo(Equal(cr.Status.ConfigurationRevision))
-		Expect(updatedCR.Status.StatefulSetRevision).To(Equal(cr.Status.StatefulSetRevision))
+		Expect(updatedCR.Status.StatefulSetRevision).NotTo(Equal(cr.Status.StatefulSetRevision))
 
 		var configmap corev1.ConfigMap
 		Expect(suite.Client.Get(ctx, types.NamespacedName{

--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -25,27 +25,18 @@ import (
 )
 
 type replicaState struct {
-	Error       bool `json:"error"`
-	Status      serverStatus
-	StatefulSet *appsv1.StatefulSet
-	PVC         *corev1.PersistentVolumeClaim
-}
+	chctrl.ReplicaState
 
-func (r replicaState) Updated() bool {
-	if r.StatefulSet == nil {
-		return false
-	}
-
-	return r.StatefulSet.Generation == r.StatefulSet.Status.ObservedGeneration &&
-		r.StatefulSet.Status.UpdateRevision == r.StatefulSet.Status.CurrentRevision
+	Error  bool
+	Status serverStatus
 }
 
 func (r replicaState) Ready(replicaCount int) bool {
-	if r.StatefulSet == nil {
+	if r.STS == nil {
 		return false
 	}
 
-	stsReady := r.StatefulSet.Status.ReadyReplicas == 1 // Not reliable, but allows to wait until pod is `green`
+	stsReady := r.STS.Status.ReadyReplicas == 1 // Not reliable, but allows to wait until pod is `green`
 	if replicaCount == 1 {
 		return stsReady && r.Status.ServerState == ModeStandalone
 	}
@@ -54,11 +45,11 @@ func (r replicaState) Ready(replicaCount int) bool {
 }
 
 func (r replicaState) HasDiff(rev chctrl.RevisionState) bool {
-	return rev.ReplicaHasDiff(r.StatefulSet, r.PVC)
+	return rev.ReplicaHasDiff(r.ReplicaState)
 }
 
 func (r replicaState) UpdateStage(rev chctrl.RevisionState, replicaCount int) chctrl.ReplicaUpdateStage {
-	if r.StatefulSet == nil {
+	if r.STS == nil {
 		return chctrl.StageNotExists
 	}
 
@@ -185,12 +176,15 @@ func (r *keeperReconciler) reconcileClusterRevisions(ctx context.Context, log ct
 		return chctrl.StepResult{}, fmt.Errorf("get configuration revision: %w", err)
 	}
 
+	// For now keeper restarts on every config change.
+	r.revs.RestartConfigRevision = r.revs.ConfigurationRevision
+
 	if r.revs.ConfigurationRevision != r.Cluster.Status.ConfigurationRevision {
 		r.Cluster.Status.ConfigurationRevision = r.revs.ConfigurationRevision
 		log.Debug(fmt.Sprintf("observed new configuration revision %q", r.revs.ConfigurationRevision))
 	}
 
-	r.revs.StatefulSetRevision, err = getStatefulSetRevision(r.Cluster)
+	r.revs.StatefulSetRevision, err = getStatefulSetRevision(r.Cluster, r.revs.ConfigurationRevision)
 	if err != nil {
 		return chctrl.StepResult{}, fmt.Errorf("get StatefulSet revision: %w", err)
 	}
@@ -252,7 +246,10 @@ func (r *keeperReconciler) reconcileActiveReplicaStatus(ctx context.Context, log
 		return chctrl.StepResult{}, fmt.Errorf("list StatefulSets: %w", err)
 	}
 
-	tlsRequired := r.Cluster.Spec.Settings.TLS.Required
+	configMaps, err := chctrl.ListReplicaResources[v1.KeeperReplicaID, *corev1.ConfigMap, *corev1.ConfigMapList](ctx, &r.ResourceManager, v1.KeeperReplicaIDFromLabels)
+	if err != nil {
+		return chctrl.StepResult{}, fmt.Errorf("list ConfigMaps: %w", err)
+	}
 
 	execResults := ctrlutil.ExecuteParallel(statefulSets.Items, func(sts appsv1.StatefulSet) (v1.KeeperReplicaID, replicaState, error) {
 		id, err := v1.KeeperReplicaIDFromLabels(sts.Labels)
@@ -273,7 +270,8 @@ func (r *keeperReconciler) reconcileActiveReplicaStatus(ctx context.Context, log
 			ctx, cancel := context.WithTimeout(ctx, chctrl.LoadReplicaStateTimeout)
 			defer cancel()
 
-			status = getServerStatus(ctx, log.With("replica_id", id), r.Dialer, r.Cluster.HostnameByID(id), tlsRequired)
+			status = getServerStatus(ctx, log.With("replica_id", id), r.Dialer, r.Cluster.HostnameByID(id),
+				r.Cluster.Spec.Settings.TLS.Required)
 		}
 
 		var pvc *corev1.PersistentVolumeClaim
@@ -287,10 +285,14 @@ func (r *keeperReconciler) reconcileActiveReplicaStatus(ctx context.Context, log
 		log.Debug("load replica state done", "replica_id", id, "statefulset", sts.Name)
 
 		return id, replicaState{
-			StatefulSet: &sts,
-			PVC:         pvc,
-			Error:       hasError,
-			Status:      status,
+			Error:  hasError,
+			Status: status,
+
+			ReplicaState: chctrl.ReplicaState{
+				STS: &sts,
+				CFG: configMaps[id],
+				PVC: pvc,
+			},
 		}, nil
 	})
 	for id, res := range execResults {
@@ -302,8 +304,8 @@ func (r *keeperReconciler) reconcileActiveReplicaStatus(ctx context.Context, log
 		if _, ok := r.ReplicaState[id]; !ok {
 			r.ReplicaState[id] = res.Result
 		} else {
-			log.Debug(fmt.Sprintf("multiple StatefulSets for single replica %v", id),
-				"replica_id", id, "statefulset", res.Result.StatefulSet)
+			log.Debug(fmt.Sprintf("multiple StatefulSets for single replica %s, %s",
+				r.ReplicaState[id].STS.Name, res.Result.STS.Name), "replica_id", id)
 		}
 	}
 
@@ -318,9 +320,8 @@ func (r *keeperReconciler) reconcileActiveReplicaStatus(ctx context.Context, log
 			if _, exists := r.ReplicaState[id]; !exists {
 				log.Info("adding missing replica from quorum config", "replica_id", id)
 				r.ReplicaState[id] = replicaState{
-					Error:       false,
-					StatefulSet: nil,
-					Status:      serverStatus{},
+					Error:  false,
+					Status: serverStatus{},
 				}
 			}
 		}
@@ -552,51 +553,37 @@ func (r *keeperReconciler) reconcileReplicaResources(ctx context.Context, log ct
 }
 
 func (r *keeperReconciler) reconcileCleanUp(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	listOpts := ctrlutil.AppRequirements(r.Cluster.Namespace, r.Cluster.SpecificName())
-
-	var configMaps corev1.ConfigMapList
-	if err := r.GetClient().List(ctx, &configMaps, listOpts); err != nil {
+	configMaps, err := chctrl.ListReplicaResources[v1.KeeperReplicaID, *corev1.ConfigMap, *corev1.ConfigMapList](ctx, &r.ResourceManager, v1.KeeperReplicaIDFromLabels)
+	if err != nil {
 		return chctrl.StepResult{}, fmt.Errorf("list ConfigMaps: %w", err)
 	}
 
-	for _, configMap := range configMaps.Items {
-		if configMap.Name == r.Cluster.QuorumConfigMapName() {
+	for id, configMap := range configMaps {
+		if _, ok := r.ReplicaState[id]; ok {
 			continue
 		}
 
-		id, err := v1.KeeperReplicaIDFromLabels(configMap.Labels)
-		if err != nil {
-			log.Warn("parse ConfigMap replica ID", "configmap", configMap.Name, "err", err)
-			continue
-		}
+		log.Info("deleting stale ConfigMap", "replica_id", id, "configmap", configMap.Name)
 
-		if _, ok := r.ReplicaState[id]; !ok {
-			log.Info("deleting stale ConfigMap", "replica_id", id, "configmap", configMap.Name)
-
-			if err := r.Delete(ctx, &configMap, v1.EventActionReconciling); err != nil {
-				log.Error(err, "delete stale replica", "replica_id", id, "configmap", configMap.Name)
-			}
+		if err := r.Delete(ctx, configMap, v1.EventActionReconciling); err != nil {
+			log.Error(err, "delete stale replica", "replica_id", id, "configmap", configMap.Name)
 		}
 	}
 
-	var statefulSets appsv1.StatefulSetList
-	if err := r.GetClient().List(ctx, &statefulSets, listOpts); err != nil {
+	statefulSets, err := chctrl.ListReplicaResources[v1.KeeperReplicaID, *appsv1.StatefulSet, *appsv1.StatefulSetList](ctx, &r.ResourceManager, v1.KeeperReplicaIDFromLabels)
+	if err != nil {
 		return chctrl.StepResult{}, fmt.Errorf("list StatefulSets: %w", err)
 	}
 
-	for _, sts := range statefulSets.Items {
-		id, err := v1.KeeperReplicaIDFromLabels(sts.Labels)
-		if err != nil {
-			log.Warn("parse StatefulSet replica ID", "sts", sts.Name, "err", err)
+	for id, sts := range statefulSets {
+		if _, ok := r.ReplicaState[id]; ok {
 			continue
 		}
 
-		if _, ok := r.ReplicaState[id]; !ok {
-			log.Info("deleting stale StatefulSet", "replica_id", id, "statefulset", sts.Name)
+		log.Info("deleting stale StatefulSet", "replica_id", id, "statefulset", sts.Name)
 
-			if err := r.Delete(ctx, &sts, v1.EventActionReconciling); err != nil {
-				log.Error(err, "delete stale replica", "replica_id", id, "statefulset", sts.Name)
-			}
+		if err := r.Delete(ctx, sts, v1.EventActionReconciling); err != nil {
+			log.Error(err, "delete stale replica", "replica_id", id, "statefulset", sts.Name)
 		}
 	}
 
@@ -633,7 +620,7 @@ func (r *keeperReconciler) evaluateReplicaConditions() {
 
 	r.SetCondition(chctrl.ReplicaStartupCondition(errorIDs))
 	r.SetCondition(chctrl.HealthyCondition(notReadyIDs))
-	r.SetCondition(chctrl.ConfigSyncCondition(notUpdatedIDs))
+	r.SetCondition(chctrl.ConfigSyncCondition(nil, notUpdatedIDs, nil))
 	{
 		cond, event := chctrl.GetVersionSyncCondition(r.versionProbe, replicaVersions, len(notUpdatedIDs) > 0)
 		r.SetCondition(cond, event...)
@@ -725,25 +712,27 @@ func (r *keeperReconciler) updateReplica(ctx context.Context, log ctrlutil.Logge
 		return nil, fmt.Errorf("template replica %q ConfigMap: %w", replicaID, err)
 	}
 
-	statefulSet, err := templateStatefulSet(r.Cluster, replicaID)
+	statefulSet, err := templateStatefulSet(r.Cluster, replicaID, r.revs.RestartConfigRevision)
 	if err != nil {
 		return nil, fmt.Errorf("template replica %q StatefulSet: %w", replicaID, err)
+	}
+
+	var pvc *corev1.PersistentVolumeClaim
+	if r.Cluster.Spec.DataVolumeClaimSpec != nil {
+		pvc = &corev1.PersistentVolumeClaim{Spec: *r.Cluster.Spec.DataVolumeClaimSpec}
 	}
 
 	replica := r.ReplicaState[replicaID]
 
 	result, err := r.ReconcileReplicaResources(ctx, log, chctrl.ReplicaUpdateInput{
 		Revisions: r.revs,
-
-		DesiredConfigMap: configMap,
-
-		ExistingSTS:        replica.StatefulSet,
-		DesiredSTS:         statefulSet,
-		HasError:           replica.Error,
-		BreakingSTSVersion: breakingStatefulSetVersion,
-
-		ExistingPVC:    replica.PVC,
-		DesiredPVCSpec: r.Cluster.Spec.DataVolumeClaimSpec,
+		Existing:  replica.ReplicaState,
+		HasError:  replica.Error,
+		Desired: chctrl.ReplicaState{
+			CFG: configMap,
+			STS: statefulSet,
+			PVC: pvc,
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("reconcile replica %q resources: %w", replicaID, err)

--- a/internal/controller/keeper/sync_test.go
+++ b/internal/controller/keeper/sync_test.go
@@ -67,7 +67,7 @@ var _ = Describe("UpdateReplica", Ordered, func() {
 
 		Expect(configMap).ToNot(BeNil())
 		Expect(sts).ToNot(BeNil())
-		Expect(util.GetConfigHashFromObject(sts)).To(BeEquivalentTo(rec.revs.ConfigurationRevision))
+		Expect(sts.Spec.Template.Annotations[util.AnnotationConfigHash]).To(Equal(rec.revs.ConfigurationRevision))
 		Expect(util.GetSpecHashFromObject(sts)).To(BeEquivalentTo(rec.revs.StatefulSetRevision))
 	})
 
@@ -76,10 +76,13 @@ var _ = Describe("UpdateReplica", Ordered, func() {
 		sts.Status.ObservedGeneration = sts.Generation
 		sts.Status.ReadyReplicas = 1
 		rec.ReplicaState[replicaID] = replicaState{
-			Error:       false,
-			StatefulSet: sts,
+			Error: false,
 			Status: serverStatus{
 				ServerState: ModeStandalone,
+			},
+			ReplicaState: controller.ReplicaState{
+				STS: sts,
+				CFG: mustGet[*corev1.ConfigMap](ctx, rec.GetClient(), cfgKey),
 			},
 		}
 		result, err := rec.reconcileReplicaResources(ctx, log)
@@ -102,22 +105,29 @@ var _ = Describe("UpdateReplica", Ordered, func() {
 
 	It("should restart server on config changes", func(ctx context.Context) {
 		sts := mustGet[*appsv1.StatefulSet](ctx, rec.GetClient(), stsKey)
-		Expect(sts.Spec.Template.Annotations[util.AnnotationRestartedAt]).To(BeEmpty())
+		previousHash := sts.Spec.Template.Annotations[util.AnnotationConfigHash]
+		Expect(previousHash).ToNot(BeEmpty())
+
 		rec.ReplicaState[replicaID] = replicaState{
-			Error:       false,
-			StatefulSet: sts,
+			Error: false,
 			Status: serverStatus{
 				ServerState: ModeStandalone,
 			},
+			ReplicaState: controller.ReplicaState{STS: sts},
 		}
 		rec.Cluster.Spec.Settings.Logger.Level = "info"
 		rec.revs.ConfigurationRevision = "cfg-v2"
+		rec.revs.RestartConfigRevision = "cfg-v2"
+		newStsRevision, err := getStatefulSetRevision(rec.Cluster, "cfg-v2")
+		Expect(err).ToNot(HaveOccurred())
+
+		rec.revs.StatefulSetRevision = newStsRevision
 		result, err := rec.reconcileReplicaResources(ctx, log)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(result.IsZero()).To(BeFalse())
 
 		sts = mustGet[*appsv1.StatefulSet](ctx, rec.GetClient(), stsKey)
-		Expect(sts.Spec.Template.Annotations[util.AnnotationRestartedAt]).ToNot(BeEmpty())
+		Expect(sts.Spec.Template.Annotations[util.AnnotationConfigHash]).To(Equal(rec.revs.RestartConfigRevision))
 	})
 
 	It("should delete stuck pod in error state", func(ctx context.Context) {
@@ -150,8 +160,8 @@ var _ = Describe("UpdateReplica", Ordered, func() {
 		By("setting replica state with error and a spec diff")
 
 		rec.ReplicaState[replicaID] = replicaState{
-			Error:       true,
-			StatefulSet: sts,
+			Error:        true,
+			ReplicaState: controller.ReplicaState{STS: sts},
 		}
 
 		result, err := rec.reconcileReplicaResources(ctx, log)

--- a/internal/controller/keeper/templates.go
+++ b/internal/controller/keeper/templates.go
@@ -218,8 +218,8 @@ func getConfigurationRevision(cr *v1.KeeperCluster) (string, error) {
 	return hash, nil
 }
 
-func getStatefulSetRevision(cr *v1.KeeperCluster) (string, error) {
-	sts, err := templateStatefulSet(cr, 0)
+func getStatefulSetRevision(cr *v1.KeeperCluster, cfgRestartRevision string) (string, error) {
+	sts, err := templateStatefulSet(cr, 0, cfgRestartRevision)
 	if err != nil {
 		return "", fmt.Errorf("generate template StatefulSet: %w", err)
 	}
@@ -255,7 +255,7 @@ func templateConfigMap(cr *v1.KeeperCluster, id v1.KeeperReplicaID) (*corev1.Con
 	}, nil
 }
 
-func templateStatefulSet(cr *v1.KeeperCluster, id v1.KeeperReplicaID) (*appsv1.StatefulSet, error) {
+func templateStatefulSet(cr *v1.KeeperCluster, id v1.KeeperReplicaID, cfgRestartRevision string) (*appsv1.StatefulSet, error) {
 	podSpec, err := templatePodSpec(cr, id)
 	if err != nil {
 		return nil, fmt.Errorf("template pod spec: %w", err)
@@ -283,6 +283,7 @@ func templateStatefulSet(cr *v1.KeeperCluster, id v1.KeeperReplicaID) (*appsv1.S
 				GenerateName: cr.SpecificName(),
 				Labels:       resourceLabels,
 				Annotations: controllerutil.MergeMaps(cr.Spec.Annotations, map[string]string{
+					controllerutil.AnnotationConfigHash:       cfgRestartRevision,
 					"kubectl.kubernetes.io/default-container": ContainerName,
 				}),
 			},

--- a/internal/controller/keeper/templates_test.go
+++ b/internal/controller/keeper/templates_test.go
@@ -42,7 +42,7 @@ var _ = Describe("ServerRevision", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(baseCfgRevision).ToNot(BeEmpty())
 
-		baseStsRevision, err = getStatefulSetRevision(baseCR)
+		baseStsRevision, err = getStatefulSetRevision(baseCR, baseCfgRevision)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(baseStsRevision).ToNot(BeEmpty())
 	})
@@ -55,13 +55,13 @@ var _ = Describe("ServerRevision", func() {
 		Expect(baseCfgRevision).ToNot(BeEmpty())
 		Expect(cfgRevisionUpdated).To(Equal(baseCfgRevision), "server config revision shouldn't depend on replica count")
 
-		stsRevisionUpdated, err := getStatefulSetRevision(cr)
+		stsRevisionUpdated, err := getStatefulSetRevision(cr, cfgRevisionUpdated)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stsRevisionUpdated).ToNot(BeEmpty())
 		Expect(stsRevisionUpdated).To(Equal(baseStsRevision), "StatefulSet config revision shouldn't depend on replica count")
 	})
 
-	It("should not change sts revision if only config changes", func() {
+	It("should change sts revision when config changes", func() {
 		cr := baseCR.DeepCopy()
 		cr.Spec.Settings.Logger.Level = "warning"
 		cfgRevisionUpdated, err := getConfigurationRevision(cr)
@@ -69,10 +69,10 @@ var _ = Describe("ServerRevision", func() {
 		Expect(cfgRevisionUpdated).ToNot(BeEmpty())
 		Expect(cfgRevisionUpdated).ToNot(Equal(baseCfgRevision), "configuration change should update config revision")
 
-		stsRevisionUpdated, err := getStatefulSetRevision(cr)
+		stsRevisionUpdated, err := getStatefulSetRevision(cr, cfgRevisionUpdated)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(stsRevisionUpdated).ToNot(BeEmpty())
-		Expect(stsRevisionUpdated).To(Equal(baseStsRevision), "StatefulSet config revision shouldn't change with config")
+		Expect(stsRevisionUpdated).ToNot(Equal(baseStsRevision), "config change should trigger server restart")
 	})
 })
 
@@ -216,12 +216,12 @@ var _ = Describe("getStatefulSetRevision", func() {
 			},
 		}
 
-		rev, err := getStatefulSetRevision(cr)
+		rev, err := getStatefulSetRevision(cr, "fixed-cfg-rev")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(rev).ToNot(BeEmpty())
 
 		cr.Spec.DataVolumeClaimSpec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("20Gi")
-		rev2, err := getStatefulSetRevision(cr)
+		rev2, err := getStatefulSetRevision(cr, "fixed-cfg-rev")
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(rev2).To(Equal(rev), "StatefulSet revision should not change when data disk spec changes")
@@ -239,12 +239,12 @@ func FuzzClusterSpec(f *testing.F) {
 
 		crBefore := cr.DeepCopy()
 
-		stsFirst, err1 := templateStatefulSet(cr, id)
+		stsFirst, err1 := templateStatefulSet(cr, id, "fixed-cfg-rev")
 		if diff := cmp.Diff(crBefore.Spec, cr.Spec); diff != "" {
 			t.Errorf("ClusterSpec mutated:\n%s", diff)
 		}
 
-		stsSecond, err2 := templateStatefulSet(cr, id)
+		stsSecond, err2 := templateStatefulSet(cr, id, "fixed-cfg-rev")
 		if diff := cmp.Diff(crBefore.Spec, cr.Spec); diff != "" {
 			t.Errorf("ClusterSpec mutated:\n%s", diff)
 		}

--- a/internal/controller/replicastate.go
+++ b/internal/controller/replicastate.go
@@ -41,34 +41,65 @@ func (s ReplicaUpdateStage) String() string {
 }
 
 // RevisionState holds the target revision hashes for comparing replica state against desired state.
-// Constructed by the reconciler from cached revision fields and passed to replicaState methods.
+// Constructed by the reconciler and passed to replicaState methods.
 type RevisionState struct {
-	StatefulSetRevision   string
+	StatefulSetRevision string
+
 	ConfigurationRevision string
-	PVCRevision           string
-	HasPVCSpec            bool
+	// RestartConfigRevision is a partial revision of config that requires server restart.
+	RestartConfigRevision string
+	// ReloadConfigRevision is a partial revision of config that can be reloaded in runtime.
+	ReloadConfigRevision string
+
+	PVCRevision string
+	HasPVCSpec  bool
 }
 
-// ReplicaHasDiff checks whether a StatefulSet and optional PVC match the target revisions.
-func (rev RevisionState) ReplicaHasDiff(sts *appsv1.StatefulSet, pvc *corev1.PersistentVolumeClaim) bool {
-	if sts == nil {
+// ReplicaState holds resources owned by a single replica.
+type ReplicaState struct {
+	STS *appsv1.StatefulSet
+	CFG *corev1.ConfigMap
+	PVC *corev1.PersistentVolumeClaim
+}
+
+// Updated checks whether StatefulSet controller applied updates.
+func (s ReplicaState) Updated() bool {
+	if s.STS == nil {
+		return false
+	}
+
+	return s.STS.Generation == s.STS.Status.ObservedGeneration &&
+		s.STS.Status.UpdateRevision == s.STS.Status.CurrentRevision
+}
+
+// ReplicaHasDiff checks whether any replica resources should be updated.
+func (rev RevisionState) ReplicaHasDiff(state ReplicaState) bool {
+	if state.STS == nil {
 		return true
 	}
 
-	if util.GetSpecHashFromObject(sts) != rev.StatefulSetRevision {
+	if util.GetSpecHashFromObject(state.STS) != rev.StatefulSetRevision {
 		return true
 	}
 
-	if util.GetConfigHashFromObject(sts) != rev.ConfigurationRevision {
+	if state.STS.Spec.Template.Annotations[util.AnnotationConfigHash] != rev.RestartConfigRevision {
+		return true
+	}
+
+	if state.CFG == nil {
+		return true
+	}
+
+	if util.GetConfigHashFromObject(state.CFG) != rev.ConfigurationRevision {
 		return true
 	}
 
 	if rev.HasPVCSpec {
-		if pvc == nil {
+		if state.PVC == nil {
 			return true
 		}
 
-		if util.GetSpecHashFromObject(pvc) != rev.PVCRevision {
+		if util.GetSpecHashFromObject(state.PVC) != rev.PVCRevision {
 			return true
 		}
 	}

--- a/internal/controller/resourcemanager.go
+++ b/internal/controller/resourcemanager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"time"
 
 	"github.com/blang/semver/v4"
 	gcmp "github.com/google/go-cmp/cmp"
@@ -243,45 +242,38 @@ func (rm *ResourceManager) GetPVCByStatefulSet(
 // ReplicaUpdateInput contains the parameters needed to reconcile a StatefulSet for a replica.
 type ReplicaUpdateInput struct {
 	Revisions RevisionState
-
-	DesiredConfigMap *corev1.ConfigMap
-
-	ExistingSTS        *appsv1.StatefulSet
-	DesiredSTS         *appsv1.StatefulSet
-	HasError           bool
-	BreakingSTSVersion semver.Version
-
-	ExistingPVC    *corev1.PersistentVolumeClaim
-	DesiredPVCSpec *corev1.PersistentVolumeClaimSpec
+	Existing  ReplicaState
+	Desired   ReplicaState
+	HasError  bool
 }
 
 // UpdatePVC updates the PersistentVolumeClaim for the given replica ID if it exists and differs from the provided spec.
 func (rm *ResourceManager) UpdatePVC(ctx context.Context, log util.Logger, input ReplicaUpdateInput) error {
-	if input.DesiredPVCSpec == nil {
+	if input.Desired.PVC == nil {
 		return nil
 	}
 
-	if input.ExistingPVC == nil {
+	if input.Existing.PVC == nil {
 		log.Debug("replica PVC not found, skipping update")
 		return nil
 	}
 
-	log = log.With("pvc", input.ExistingPVC.Name)
+	log = log.With("pvc", input.Existing.PVC.Name)
 
-	if util.GetSpecHashFromObject(input.ExistingPVC) == input.Revisions.PVCRevision {
+	if util.GetSpecHashFromObject(input.Existing.PVC) == input.Revisions.PVCRevision {
 		log.Debug("PVC is up to date")
 		return nil
 	}
 
-	targetSpec := input.DesiredPVCSpec.DeepCopy()
-	if err := util.ApplyDefault(targetSpec, input.ExistingPVC.Spec); err != nil {
+	targetSpec := input.Desired.PVC.Spec.DeepCopy()
+	if err := util.ApplyDefault(targetSpec, input.Existing.PVC.Spec); err != nil {
 		return fmt.Errorf("patch PVC spec: %w", err)
 	}
 
-	log.Info("updating PVC", "diff", gcmp.Diff(input.ExistingPVC.Spec, *targetSpec))
+	log.Info("updating PVC", "diff", gcmp.Diff(input.Existing.PVC.Spec, *targetSpec))
 
 	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: *input.ExistingPVC.ObjectMeta.DeepCopy(),
+		ObjectMeta: *input.Existing.PVC.ObjectMeta.DeepCopy(),
 		Spec:       *targetSpec,
 	}
 
@@ -301,23 +293,31 @@ func (rm *ResourceManager) ReconcileReplicaResources(
 	log util.Logger,
 	input ReplicaUpdateInput,
 ) (*ctrlruntime.Result, error) {
-	configChanged, err := rm.ReconcileConfigMap(ctx, log, input.DesiredConfigMap, v1.EventActionReconciling)
+	util.AddObjectConfigHash(input.Desired.CFG, input.Revisions.ConfigurationRevision)
+	util.AddHashWithKeyToAnnotations(input.Desired.CFG, util.AnnotationReloadableConfigHash, input.Revisions.ReloadConfigRevision)
+
+	configChanged, err := rm.ReconcileConfigMap(ctx, log, input.Desired.CFG, v1.EventActionReconciling)
 	if err != nil {
 		return nil, fmt.Errorf("update replica ConfigMap: %w", err)
 	}
 
-	statefulSet := input.DesiredSTS
+	// PVC update failures are non-fatal: the next reconciliation will detect the mismatch
+	// via HasDiff and retry. This avoids blocking the STS update on transient PVC conflicts.
+	if err = rm.UpdatePVC(ctx, log, input); err != nil {
+		log.Warn("failed to update replica PVC", "error", err)
+	}
+
+	statefulSet := input.Desired.STS
 
 	if err = ctrlruntime.SetControllerReference(rm.owner, statefulSet, rm.ctrl.GetScheme()); err != nil {
 		return nil, fmt.Errorf("set replica StatefulSet controller reference: %w", err)
 	}
 
-	if input.ExistingSTS == nil {
+	if input.Existing.STS == nil {
 		log.Info("replica StatefulSet not found, creating", "statefulset", statefulSet.Name)
-		util.AddObjectConfigHash(statefulSet, input.Revisions.ConfigurationRevision)
 		util.AddSpecHashToObject(statefulSet, input.Revisions.StatefulSetRevision)
 
-		if input.DesiredPVCSpec != nil {
+		if input.Desired.PVC != nil {
 			util.AddSpecHashToObject(&statefulSet.Spec.VolumeClaimTemplates[0], input.Revisions.PVCRevision)
 		}
 
@@ -328,49 +328,30 @@ func (rm *ResourceManager) ReconcileReplicaResources(
 		return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
 	}
 
-	// PVC update failures are non-fatal: the next reconciliation will detect the mismatch
-	// via HasDiff and retry. This avoids blocking the STS update on transient PVC conflicts.
-	if err = rm.UpdatePVC(ctx, log, input); err != nil {
-		log.Warn("failed to update replica PVC", "error", err)
-	}
+	statefulSet.Spec.VolumeClaimTemplates = input.Existing.STS.Spec.VolumeClaimTemplates
 
-	statefulSet.Spec.VolumeClaimTemplates = input.ExistingSTS.Spec.VolumeClaimTemplates
-
-	// Check if the StatefulSet is outdated and needs to be recreated
-	v, err := semver.Parse(input.ExistingSTS.Annotations[util.AnnotationStatefulSetVersion])
-	if err != nil || input.BreakingSTSVersion.GT(v) {
-		log.Warn("removing StatefulSet because of a breaking change",
-			"found_version", input.ExistingSTS.Annotations[util.AnnotationStatefulSetVersion],
-			"expected_version", input.BreakingSTSVersion.String(),
-		)
-
-		if err := rm.Delete(ctx, input.ExistingSTS, v1.EventActionReconciling); err != nil {
-			return nil, fmt.Errorf("recreate replica: %w", err)
+	{
+		desiredVer, err := semver.Parse(input.Desired.STS.Annotations[util.AnnotationStatefulSetVersion])
+		if err != nil {
+			return nil, fmt.Errorf("unexpected desired STS version: %w", err)
 		}
 
-		return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
+		existingVer, err := semver.Parse(input.Existing.STS.Annotations[util.AnnotationStatefulSetVersion])
+		if err != nil || desiredVer.GT(existingVer) {
+			log.Warn("removing StatefulSet because of a breaking change",
+				"found_version", input.Existing.STS.Annotations[util.AnnotationStatefulSetVersion],
+				"expected_version", input.Desired.STS.Annotations[util.AnnotationStatefulSetVersion],
+			)
+
+			if err := rm.Delete(ctx, input.Existing.STS, v1.EventActionReconciling); err != nil {
+				return nil, fmt.Errorf("recreate replica: %w", err)
+			}
+
+			return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
+		}
 	}
 
-	stsNeedsUpdate := util.GetSpecHashFromObject(input.ExistingSTS) != input.Revisions.StatefulSetRevision
-
-	// Trigger Pod restart if config changed
-	// Always restarts on config changes, need to add check if it is needed.
-	if util.GetConfigHashFromObject(input.ExistingSTS) != input.Revisions.ConfigurationRevision {
-		// Use same way as Kubernetes for force restarting Pods one by one
-		// (https://github.com/kubernetes/kubernetes/blob/22a21f974f5c0798a611987405135ab7e62502da/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/objectrestarter.go#L41)
-		// Not included by default in the StatefulSet so that hash-diffs work correctly
-		log.Info("forcing Pod restart, because of config changes")
-
-		statefulSet.Spec.Template.Annotations[util.AnnotationRestartedAt] = time.Now().Format(time.RFC3339)
-
-		util.AddObjectConfigHash(statefulSet, input.Revisions.ConfigurationRevision)
-
-		stsNeedsUpdate = true
-	} else if restartedAt, ok := input.ExistingSTS.Spec.Template.Annotations[util.AnnotationRestartedAt]; ok {
-		statefulSet.Spec.Template.Annotations[util.AnnotationRestartedAt] = restartedAt
-	}
-
-	if !stsNeedsUpdate {
+	if util.GetSpecHashFromObject(input.Existing.STS) == input.Revisions.StatefulSetRevision {
 		log.Debug("StatefulSet is up to date", "statefulset", statefulSet.Name)
 
 		if configChanged {
@@ -379,10 +360,10 @@ func (rm *ResourceManager) ReconcileReplicaResources(
 
 		// Delete stuck pod if in error state so the StatefulSet controller can recreate it
 		if input.HasError {
-			podName := input.ExistingSTS.Name + "-0"
+			podName := input.Existing.STS.Name + "-0"
 			pod := &corev1.Pod{}
 
-			err = rm.ctrl.GetClient().Get(ctx, types.NamespacedName{Namespace: input.ExistingSTS.Namespace, Name: podName}, pod)
+			err = rm.ctrl.GetClient().Get(ctx, types.NamespacedName{Namespace: input.Existing.STS.Namespace, Name: podName}, pod)
 			if err != nil {
 				if k8serrors.IsNotFound(err) {
 					return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
@@ -393,7 +374,7 @@ func (rm *ResourceManager) ReconcileReplicaResources(
 				return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
 			}
 
-			if pod.Labels[appsv1.ControllerRevisionHashLabelKey] != input.ExistingSTS.Status.UpdateRevision {
+			if pod.Labels[appsv1.ControllerRevisionHashLabelKey] != input.Existing.STS.Status.UpdateRevision {
 				log.Info("deleting pod stuck in error state", "pod", podName)
 
 				if err = rm.ctrl.GetClient().Delete(ctx, pod); err != nil {
@@ -409,12 +390,12 @@ func (rm *ResourceManager) ReconcileReplicaResources(
 
 	log.Info("updating replica StatefulSet", "statefulset", statefulSet.Name)
 
-	updatedSTS := input.ExistingSTS.DeepCopy()
+	updatedSTS := input.Existing.STS.DeepCopy()
 	updatedSTS.Spec = statefulSet.Spec
 	updatedSTS.Annotations = util.MergeMaps(updatedSTS.Annotations, statefulSet.Annotations)
 	updatedSTS.Labels = util.MergeMaps(updatedSTS.Labels, statefulSet.Labels)
 	util.AddSpecHashToObject(updatedSTS, input.Revisions.StatefulSetRevision)
-	log.Debug("replica StatefulSet diff", "diff", gcmp.Diff(input.ExistingSTS, updatedSTS))
+	log.Debug("replica StatefulSet diff", "diff", gcmp.Diff(input.Existing.STS, updatedSTS))
 
 	if err = rm.Update(ctx, updatedSTS, v1.EventActionReconciling); err != nil {
 		return nil, fmt.Errorf("update replica: %w", err)
@@ -441,4 +422,39 @@ func diffFilter(specFields []string) gcmp.Option {
 
 		return false
 	}, gcmp.Ignore())
+}
+
+// ListReplicaResources lists the resources for replicas and maps them to replica IDs using the provided labelToID function.
+func ListReplicaResources[
+	ID comparable,
+	Res client.Object,
+	RList client.ObjectList,
+](ctx context.Context, rm *ResourceManager, labelToID func(map[string]string) (ID, error)) (map[ID]Res, error) {
+	list, ok := reflect.New(reflect.TypeOf((*RList)(nil)).Elem().Elem()).Interface().(RList)
+	if !ok {
+		return nil, fmt.Errorf("ListReplicaResources: unsupported RList type %T", list)
+	}
+
+	if err := rm.ctrl.GetClient().List(ctx, list, util.AppRequirements(rm.owner.GetNamespace(), rm.specificName)); err != nil {
+		return nil, fmt.Errorf("list resources: %w", err)
+	}
+
+	result := map[ID]Res{}
+
+	items := reflect.ValueOf(list).Elem().FieldByName("Items")
+	for i := range items.Len() {
+		item, ok := items.Index(i).Addr().Interface().(Res)
+		if !ok {
+			return nil, fmt.Errorf("not compatible list item type: %s", items.Index(i).Addr().Type().Name())
+		}
+
+		id, err := labelToID(item.GetLabels())
+		if err != nil {
+			continue
+		}
+
+		result[id] = item
+	}
+
+	return result, nil
 }

--- a/internal/controller/statusmanager.go
+++ b/internal/controller/statusmanager.go
@@ -220,9 +220,15 @@ func HealthyCondition(notReadyIDs []string) metav1.Condition {
 }
 
 // ConfigSyncCondition evaluates ConfigurationInSync.
-func ConfigSyncCondition(notUpdatedIDs []string) metav1.Condition {
-	return replicaCondition(v1.ConditionTypeConfigurationInSync, notUpdatedIDs,
-		v1.ConditionReasonConfigurationChanged, v1.ConditionReasonUpToDate, "Replicas have pending updates")
+func ConfigSyncCondition(reloadErr, notUpdated, notReloaded []string) metav1.Condition {
+	switch {
+	case len(reloadErr) > 0:
+		return replicaCondition(v1.ConditionTypeConfigurationInSync, reloadErr, v1.ConditionReasonConfigReloadFailed, v1.ConditionReasonUpToDate, "Replicas config reload failed")
+	case len(notUpdated) > 0:
+		return replicaCondition(v1.ConditionTypeConfigurationInSync, notUpdated, v1.ConditionReasonConfigurationChanged, v1.ConditionReasonUpToDate, "Replicas have pending updates")
+	}
+
+	return replicaCondition(v1.ConditionTypeConfigurationInSync, notReloaded, v1.ConditionReasonConfigReloadPending, v1.ConditionReasonUpToDate, "Replicas waiting to reload config")
 }
 
 // ClusterSizeCondition evaluates ClusterSizeAligned.

--- a/internal/controllerutil/annotations.go
+++ b/internal/controllerutil/annotations.go
@@ -5,12 +5,11 @@ import (
 )
 
 const (
-	AnnotationSpecHash    = "checksum/spec"
-	AnnotationConfigHash  = "checksum/configuration"
-	AnnotationRestartedAt = "kubectl.kubernetes.io/restartedAt"
+	AnnotationSpecHash             = "checksum/spec"
+	AnnotationConfigHash           = "checksum/configuration"
+	AnnotationReloadableConfigHash = "checksum/reloadable-configuration"
 
-	AnnotationStatefulSetVersion        = "clickhouse.com/statefulset-version"
-	AnnotationRestartRequiredConfigHash = "checksum/restart-required-config"
+	AnnotationStatefulSetVersion = "clickhouse.com/statefulset-version"
 )
 
 // AddHashWithKeyToAnnotations adds given spec hash to object's annotations with given key.
@@ -53,19 +52,4 @@ func GetConfigHashFromObject(found client.Object) string {
 // AddObjectConfigHash adds given config hash to object's annotations.
 func AddObjectConfigHash(obj client.Object, hash string) {
 	AddHashWithKeyToAnnotations(obj, AnnotationConfigHash, hash)
-}
-
-// GetRestartRequiredConfigHashFromObject retrieves restart-required config hash from object's annotations.
-func GetRestartRequiredConfigHashFromObject(found client.Object) string {
-	annotations := found.GetAnnotations()
-	if annotations == nil || annotations[AnnotationRestartRequiredConfigHash] == "" {
-		return ""
-	}
-
-	return annotations[AnnotationRestartRequiredConfigHash]
-}
-
-// AddObjectRestartRequiredConfigHash adds restart-required config hash to object's annotations.
-func AddObjectRestartRequiredConfigHash(obj client.Object, hash string) {
-	AddHashWithKeyToAnnotations(obj, AnnotationRestartRequiredConfigHash, hash)
 }

--- a/internal/controllerutil/annotations.go
+++ b/internal/controllerutil/annotations.go
@@ -9,7 +9,8 @@ const (
 	AnnotationConfigHash  = "checksum/configuration"
 	AnnotationRestartedAt = "kubectl.kubernetes.io/restartedAt"
 
-	AnnotationStatefulSetVersion = "clickhouse.com/statefulset-version"
+	AnnotationStatefulSetVersion        = "clickhouse.com/statefulset-version"
+	AnnotationRestartRequiredConfigHash = "checksum/restart-required-config"
 )
 
 // AddHashWithKeyToAnnotations adds given spec hash to object's annotations with given key.
@@ -52,4 +53,19 @@ func GetConfigHashFromObject(found client.Object) string {
 // AddObjectConfigHash adds given config hash to object's annotations.
 func AddObjectConfigHash(obj client.Object, hash string) {
 	AddHashWithKeyToAnnotations(obj, AnnotationConfigHash, hash)
+}
+
+// GetRestartRequiredConfigHashFromObject retrieves restart-required config hash from object's annotations.
+func GetRestartRequiredConfigHashFromObject(found client.Object) string {
+	annotations := found.GetAnnotations()
+	if annotations == nil || annotations[AnnotationRestartRequiredConfigHash] == "" {
+		return ""
+	}
+
+	return annotations[AnnotationRestartRequiredConfigHash]
+}
+
+// AddObjectRestartRequiredConfigHash adds restart-required config hash to object's annotations.
+func AddObjectRestartRequiredConfigHash(obj client.Object, hash string) {
+	AddHashWithKeyToAnnotations(obj, AnnotationRestartRequiredConfigHash, hash)
 }

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -113,84 +113,6 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			Entry("scale up to 2 replicas", v1.ClickHouseClusterSpec{Replicas: new(int32(2))}),
 		)
 
-		It("should not restart pods when only ExtraUsersConfig changes", func(ctx context.Context) {
-			cr := v1.ClickHouseCluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace(ctx),
-					Name:      fmt.Sprintf("test-%d", rand.Uint32()), //nolint:gosec
-				},
-				Spec: v1.ClickHouseClusterSpec{
-					Replicas: new(int32(1)),
-					ContainerTemplate: v1.ContainerTemplateSpec{
-						Image: v1.ContainerImage{Tag: BaseVersion},
-					},
-					DataVolumeClaimSpec: &defaultStorage,
-					KeeperClusterRef:    v1.KeeperClusterReference{Name: keeper.Name},
-					Settings: v1.ClickHouseSettings{
-						ExtraUsersConfig: runtime.RawExtension{Raw: []byte(`{}`)},
-					},
-				},
-			}
-			checks := 0
-
-			By("creating cluster CR")
-			Expect(k8sClient.Create(ctx, &cr)).To(Succeed())
-			DeferCleanup(func(ctx context.Context) {
-				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
-			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute, false)
-			ClickHouseRWChecks(ctx, &cr, &checks)
-
-			By("recording pod UIDs before config change")
-
-			var podsBefore corev1.PodList
-
-			Expect(k8sClient.List(ctx, &podsBefore, client.InNamespace(testNamespace(ctx)),
-				client.MatchingLabels{controllerutil.LabelAppKey: cr.SpecificName()})).To(Succeed())
-			Expect(podsBefore.Items).NotTo(BeEmpty())
-
-			uidByPodName := make(map[string]types.UID)
-			for _, p := range podsBefore.Items {
-				uidByPodName[p.Name] = p.UID
-			}
-
-			By("updating ExtraUsersConfig (reloadable, should not trigger restart)")
-			Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
-			cr.Spec.Settings.ExtraUsersConfig = runtime.RawExtension{
-				Raw: []byte(`{"users": {"e2e_test_user": {"password": "test", "profile": "default"}}}`),
-			}
-			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
-
-			By("waiting for configuration to sync")
-			EventuallyWithOffset(1, func() bool {
-				var cluster v1.ClickHouseCluster
-
-				ExpectWithOffset(1, k8sClient.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
-
-				for _, cond := range cluster.Status.Conditions {
-					if cond.Type == v1.ConditionTypeConfigurationInSync && cond.Status == metav1.ConditionTrue {
-						return true
-					}
-				}
-
-				return false
-			}, 2*time.Minute).Should(BeTrue())
-
-			By("verifying pods were not restarted (same UIDs)")
-
-			var podsAfter corev1.PodList
-
-			Expect(k8sClient.List(ctx, &podsAfter, client.InNamespace(testNamespace(ctx)),
-				client.MatchingLabels{controllerutil.LabelAppKey: cr.SpecificName()})).To(Succeed())
-
-			for _, p := range podsAfter.Items {
-				Expect(p.UID).To(Equal(uidByPodName[p.Name]),
-					"pod %s was restarted (UID changed)", p.Name)
-			}
-
-			ClickHouseRWChecks(ctx, &cr, &checks)
-		})
-
 		DescribeTable("ClickHouse cluster updates", func(
 			ctx context.Context,
 			baseReplicas int,
@@ -878,6 +800,118 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				controllerutil.AppRequirements(ns, cr.SpecificName()))).To(Succeed())
 			Expect(secretList.Items).To(BeEmpty())
 		})
+
+		It("should reload config without pod restart when possible", func(ctx context.Context) {
+			cr := v1.ClickHouseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace(ctx),
+					Name:      fmt.Sprintf("test-%d", rand.Uint32()), //nolint:gosec
+				},
+				Spec: v1.ClickHouseClusterSpec{
+					Replicas: new(int32(1)),
+					ContainerTemplate: v1.ContainerTemplateSpec{
+						Image: v1.ContainerImage{Tag: BaseVersion},
+					},
+					KeeperClusterRef: v1.KeeperClusterReference{Name: keeper.Name},
+					Settings: v1.ClickHouseSettings{
+						ExtraUsersConfig: runtime.RawExtension{Raw: []byte("{}")},
+					},
+				},
+			}
+			password := controllerutil.GeneratePassword()
+			checks := 0
+
+			By("creating cluster CR", func() {
+				Expect(k8sClient.Create(ctx, &cr)).To(Succeed())
+				DeferCleanup(func(ctx context.Context) {
+					Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
+				})
+				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute, false)
+				ClickHouseRWChecks(ctx, &cr, &checks)
+			})
+
+			uidBefore := podUIDsByName(ctx, &cr)
+			Expect(uidBefore).NotTo(BeEmpty())
+
+			By("updating ExtraUsersConfig with a new user", func() {
+				Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+
+				cr.Spec.Settings.ExtraUsersConfig.Raw = []byte(fmt.Sprintf(`{"users": {"e2e_test_user": {
+					"password_sha256_hex": "%s", "grants": [{"query": "GRANT ALL ON *.* WITH GRANT OPTION"}]}}}`,
+					controllerutil.Sha256Hash([]byte(password)),
+				))
+				Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
+
+				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2, false)
+
+				Expect(podUIDsByName(ctx, &cr)).To(Equal(uidBefore), "pod was restarted (UID changed)")
+				ClickHouseRWChecks(ctx, &cr, &checks)
+
+				ClickHouseRWChecks(ctx, &cr, &checks, clickhouse.Auth{
+					Username: "e2e_test_user",
+					Password: password,
+				})
+			})
+
+			By("scaling to 2 replicas (reload-safe)", func() {
+				Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+				*cr.Spec.Replicas = 2
+				Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
+
+				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2, false)
+				ClickHouseRWChecks(ctx, &cr, &checks)
+				uidAfter := podUIDsByName(ctx, &cr)
+
+				for pod, uid := range uidBefore {
+					Expect(uidAfter[pod]).To(Equal(uid), "pod %s was restarted (UID changed)", pod)
+				}
+
+				chClient, err := testutil.NewClickHouseClient(ctx, podDialer, &cr)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer chClient.Close()
+
+				var replicas int64
+				Expect(chClient.QueryRowReplica(ctx, v1.ClickHouseReplicaID{},
+					`SELECT COUNT(*)::Int64 FROM system.clusters WHERE cluster='default' AND internal_replication=1`,
+					&replicas,
+				)).To(Succeed())
+				Expect(replicas).To(Equal(int64(2)))
+			})
+
+			By("verifying that corrupted config is not propagated to every replica", func() {
+				Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+				cr.Spec.Settings.ExtraUsersConfig.Raw = []byte(`{"users": {"e2e_test_user": {}}}`)
+				Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
+
+				Eventually(func(g Gomega) {
+					var cluster v1.ClickHouseCluster
+					g.Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
+					cond := meta.FindStatusCondition(cluster.Status.Conditions, v1.ConditionTypeConfigurationInSync)
+					g.Expect(cond).ToNot(BeNil())
+					g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+					g.Expect(cond.Reason).To(Equal(v1.ConditionReasonConfigReloadFailed))
+				}).WithTimeout(time.Minute * 2).WithPolling(pollingInterval).To(Succeed())
+
+				Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+
+				var cfg corev1.ConfigMap
+
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: cr.Namespace,
+					Name:      cr.ConfigMapNameByReplicaID(v1.ClickHouseReplicaID{ShardID: 0, Index: 0}),
+				}, &cfg)).To(Succeed())
+				Expect(cfg.Annotations[controllerutil.AnnotationConfigHash]).
+					Should(Not(Equal(cr.Status.ConfigurationRevision)), "replica 0 should not be updated")
+
+				Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: cr.Namespace,
+					Name:      cr.ConfigMapNameByReplicaID(v1.ClickHouseReplicaID{ShardID: 0, Index: 1}),
+				}, &cfg)).To(Succeed())
+				Expect(cfg.Annotations[controllerutil.AnnotationConfigHash]).
+					Should(Equal(cr.Status.ConfigurationRevision), "replica 1 should be updated")
+			})
+		})
 	})
 
 	Describe("is handling TLS settings correctly", Ordered, func() {
@@ -1174,13 +1208,14 @@ func WaitClickHouseUpdatedAndReady(
 						controllerutil.LabelAppKey:            cluster.SpecificName(),
 						controllerutil.LabelClickHouseShardID: strconv.FormatInt(int64(shard), 10),
 					}),
-				}, controllerutil.LabelClickHouseReplicaID, cluster.Status.StatefulSetRevision,
-					cluster.Status.ConfigurationRevision)).To(Succeed())
+				}, controllerutil.LabelClickHouseReplicaID, cluster.Status.StatefulSetRevision)).To(Succeed())
 			}
 		}
 
-		g.Expect(cluster.Status.CurrentRevision).To(Equal(cluster.Status.UpdateRevision))
-		g.Expect(cluster.Status.ReadyReplicas).To(Equal(cluster.Replicas() * cluster.Shards()))
+		g.Expect(cluster.Status.CurrentRevision).
+			To(Equal(cluster.Status.UpdateRevision), "rollout should eventually complete")
+		g.Expect(cluster.Status.ReadyReplicas).
+			To(Equal(cluster.Replicas()*cluster.Shards()), "all replicas should be ready")
 
 		for _, conditionType := range []v1.ConditionType{
 			v1.ConditionTypeReady,
@@ -1239,4 +1274,17 @@ func ClickHouseRWChecks(ctx context.Context, cr *v1.ClickHouseCluster, checksDon
 	for i := range *checksDone {
 		ExpectWithOffset(1, chClient.CheckRead(ctx, i)).To(Succeed(), "check read %d failed", i)
 	}
+}
+
+func podUIDsByName(ctx context.Context, cr *v1.ClickHouseCluster) map[string]types.UID {
+	var pods corev1.PodList
+	ExpectWithOffset(1, k8sClient.List(ctx, &pods, client.InNamespace(cr.Namespace),
+		client.MatchingLabels{controllerutil.LabelAppKey: cr.SpecificName()})).To(Succeed())
+
+	out := make(map[string]types.UID, len(pods.Items))
+	for _, p := range pods.Items {
+		out[p.Name] = p.UID
+	}
+
+	return out
 }

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -113,6 +113,84 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			Entry("scale up to 2 replicas", v1.ClickHouseClusterSpec{Replicas: new(int32(2))}),
 		)
 
+		It("should not restart pods when only ExtraUsersConfig changes", func(ctx context.Context) {
+			cr := v1.ClickHouseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace(ctx),
+					Name:      fmt.Sprintf("test-%d", rand.Uint32()), //nolint:gosec
+				},
+				Spec: v1.ClickHouseClusterSpec{
+					Replicas: new(int32(1)),
+					ContainerTemplate: v1.ContainerTemplateSpec{
+						Image: v1.ContainerImage{Tag: BaseVersion},
+					},
+					DataVolumeClaimSpec: &defaultStorage,
+					KeeperClusterRef:    v1.KeeperClusterReference{Name: keeper.Name},
+					Settings: v1.ClickHouseSettings{
+						ExtraUsersConfig: runtime.RawExtension{Raw: []byte(`{}`)},
+					},
+				},
+			}
+			checks := 0
+
+			By("creating cluster CR")
+			Expect(k8sClient.Create(ctx, &cr)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
+			})
+			WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute, false)
+			ClickHouseRWChecks(ctx, &cr, &checks)
+
+			By("recording pod UIDs before config change")
+
+			var podsBefore corev1.PodList
+
+			Expect(k8sClient.List(ctx, &podsBefore, client.InNamespace(testNamespace(ctx)),
+				client.MatchingLabels{controllerutil.LabelAppKey: cr.SpecificName()})).To(Succeed())
+			Expect(podsBefore.Items).NotTo(BeEmpty())
+
+			uidByPodName := make(map[string]types.UID)
+			for _, p := range podsBefore.Items {
+				uidByPodName[p.Name] = p.UID
+			}
+
+			By("updating ExtraUsersConfig (reloadable, should not trigger restart)")
+			Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+			cr.Spec.Settings.ExtraUsersConfig = runtime.RawExtension{
+				Raw: []byte(`{"users": {"e2e_test_user": {"password": "test", "profile": "default"}}}`),
+			}
+			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
+
+			By("waiting for configuration to sync")
+			EventuallyWithOffset(1, func() bool {
+				var cluster v1.ClickHouseCluster
+
+				ExpectWithOffset(1, k8sClient.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
+
+				for _, cond := range cluster.Status.Conditions {
+					if cond.Type == v1.ConditionTypeConfigurationInSync && cond.Status == metav1.ConditionTrue {
+						return true
+					}
+				}
+
+				return false
+			}, 2*time.Minute).Should(BeTrue())
+
+			By("verifying pods were not restarted (same UIDs)")
+
+			var podsAfter corev1.PodList
+
+			Expect(k8sClient.List(ctx, &podsAfter, client.InNamespace(testNamespace(ctx)),
+				client.MatchingLabels{controllerutil.LabelAppKey: cr.SpecificName()})).To(Succeed())
+
+			for _, p := range podsAfter.Items {
+				Expect(p.UID).To(Equal(uidByPodName[p.Name]),
+					"pod %s was restarted (UID changed)", p.Name)
+			}
+
+			ClickHouseRWChecks(ctx, &cr, &checks)
+		})
+
 		DescribeTable("ClickHouse cluster updates", func(
 			ctx context.Context,
 			baseReplicas int,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -191,7 +191,7 @@ func CheckPodReady(pod *corev1.Pod) bool {
 // CheckUpdateOrder lists StatefulSets for the given app and validates rolling update invariants:
 // 1. Updated StatefulSets form a contiguous group from the highest replica ID
 // 2. At most one StatefulSet has zero ready replicas (the one currently being updated).
-func CheckUpdateOrder(ctx context.Context, selector *client.ListOptions, replicaLabel, stsRev, cfgRev string) error {
+func CheckUpdateOrder(ctx context.Context, selector *client.ListOptions, replicaLabel, stsRev string) error {
 	var stsList appsv1.StatefulSetList
 	Expect(k8sClient.List(ctx, &stsList, selector)).To(Succeed())
 
@@ -210,8 +210,7 @@ func CheckUpdateOrder(ctx context.Context, selector *client.ListOptions, replica
 			notReadyCount++
 		}
 
-		updated[index] = controllerutil.GetSpecHashFromObject(&sts) == stsRev &&
-			controllerutil.GetConfigHashFromObject(&sts) == cfgRev
+		updated[index] = controllerutil.GetSpecHashFromObject(&sts) == stsRev
 	}
 
 	if notReadyCount > 1 {

--- a/test/e2e/keeper_e2e_test.go
+++ b/test/e2e/keeper_e2e_test.go
@@ -307,8 +307,7 @@ func WaitKeeperUpdatedAndReady(ctx context.Context, cr *v1.KeeperCluster, timeou
 				LabelSelector: labels.SelectorFromSet(map[string]string{
 					controllerutil.LabelAppKey: cluster.SpecificName(),
 				}),
-			}, controllerutil.LabelKeeperReplicaID, cluster.Status.StatefulSetRevision,
-				cluster.Status.ConfigurationRevision)).To(Succeed())
+			}, controllerutil.LabelKeeperReplicaID, cluster.Status.StatefulSetRevision)).To(Succeed())
 		}
 
 		g.Expect(cluster.Status.CurrentRevision).To(Equal(cluster.Status.UpdateRevision))

--- a/test/testutil/clickhouse_client.go
+++ b/test/testutil/clickhouse_client.go
@@ -238,6 +238,31 @@ func (c *ClickHouseClient) QueryRow(ctx context.Context, query string, result an
 	return nil
 }
 
+// QueryRowReplica executes a query on one of the ClickHouse cluster nodes.
+// Scans the result into the provided result variable.
+func (c *ClickHouseClient) QueryRowReplica(
+	ctx context.Context,
+	id v1.ClickHouseReplicaID,
+	query string,
+	result any,
+) error {
+	conn, ok := c.clients[id]
+	if !ok {
+		return fmt.Errorf("replica %v not found", id)
+	}
+
+	row := conn.QueryRow(ctx, query)
+	if err := row.Err(); err != nil {
+		return fmt.Errorf("query row: %w", err)
+	}
+
+	if err := row.Scan(result); err != nil {
+		return fmt.Errorf("scan row: %w", err)
+	}
+
+	return nil
+}
+
 // Query executes a query on one of the ClickHouse cluster nodes.
 func (c *ClickHouseClient) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
 	if len(c.clients) == 0 {


### PR DESCRIPTION
## Why

Some configuration updates don't require a pod restart. This pull request improves that behavior.

## What

Annotate generated config files with RequiresRestart and split the config revision into reloadable and restartable parts.
Track config runtime reload with a reserved named collection key.

## Related Issues

Related to #15
