### PR TITLE
Add server version in the Status. Add warnings on replica version divergence.

### DIFF
--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -182,6 +182,10 @@ type ClickHouseClusterStatus struct {
 	// ObservedGeneration indicates latest generation observed by controller.
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Version indicates the version reported by the container image.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	Version string `json:"version,omitempty"`
 }
 
 // ClickHouseCluster is the Schema for the `clickhouseclusters` API.
@@ -192,6 +196,7 @@ type ClickHouseClusterStatus struct {
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message"
 // +kubebuilder:printcolumn:name="ReadyReplicas",type="number",JSONPath=".status.readyReplicas"
 // +kubebuilder:printcolumn:name="Replicas",type="number",JSONPath=".spec.replicas"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +operator-sdk:csv:customresourcedefinitions:displayName="ClickHouse Cluster"
 // +operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1}}

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -38,6 +38,13 @@ const (
 	ConditionTypeConfigurationInSync    ConditionType   = "ConfigurationInSync"
 	ConditionReasonConfigurationChanged ConditionReason = "ConfigurationChanged"
 
+	// ConditionTypeVersionInSync indicates that all replicas report the same version as the image.
+	ConditionTypeVersionInSync        ConditionType   = "VersionInSync"
+	ConditionReasonVersionMatch       ConditionReason = "VersionMatch"
+	ConditionReasonVersionMismatch    ConditionReason = "VersionMismatch"
+	ConditionReasonVersionPending     ConditionReason = "VersionPending"
+	ConditionReasonVersionProbeFailed ConditionReason = "VersionProbeFailed"
+
 	// ConditionTypeReady indicates that cluster is ready to serve client requests.
 	ConditionTypeReady                      ConditionType   = "Ready"
 	ClickHouseConditionAllShardsReady       ConditionReason = "AllShardsReady"
@@ -83,6 +90,7 @@ var (
 		ConditionTypeHealthy,
 		ConditionTypeClusterSizeAligned,
 		ConditionTypeConfigurationInSync,
+		ConditionTypeVersionInSync,
 		ConditionTypeReady,
 		ClickHouseConditionTypeSchemaInSync,
 	}
@@ -95,6 +103,7 @@ var (
 		ConditionTypeHealthy,
 		ConditionTypeClusterSizeAligned,
 		ConditionTypeConfigurationInSync,
+		ConditionTypeVersionInSync,
 		ConditionTypeReady,
 		KeeperConditionTypeScaleAllowed,
 	}

--- a/api/v1alpha1/events.go
+++ b/api/v1alpha1/events.go
@@ -25,6 +25,12 @@ const (
 	EventReasonClusterNotReady EventReason = "ClusterNotReady"
 )
 
+// Event reasons for version checks.
+const (
+	EventReasonVersionDiverge     EventReason = "VersionDiverge"
+	EventReasonVersionProbeFailed EventReason = "VersionProbeFailed"
+)
+
 // EventAction represents the action associated with an event.
 type EventAction = string
 
@@ -33,4 +39,5 @@ const (
 	EventActionScaling        EventAction = "Scaling"
 	EventActionBecameReady    EventAction = "BecameReady"
 	EventActionBecameNotReady EventAction = "BecameNotReady"
+	EventActionVersionCheck   EventAction = "VersionCheck"
 )

--- a/api/v1alpha1/keepercluster_types.go
+++ b/api/v1alpha1/keepercluster_types.go
@@ -147,6 +147,10 @@ type KeeperClusterStatus struct {
 	// ObservedGeneration indicates latest generation observed by controller.
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// Version indicates the version reported by the container image.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	Version string `json:"version,omitempty"`
 }
 
 // KeeperCluster is the Schema for the `keeperclusters` API.
@@ -157,6 +161,7 @@ type KeeperClusterStatus struct {
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message"
 // +kubebuilder:printcolumn:name="ReadyReplicas",type="number",JSONPath=".status.readyReplicas"
 // +kubebuilder:printcolumn:name="Replicas",type="number",JSONPath=".spec.replicas"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1}}
 // +operator-sdk:csv:customresourcedefinitions:resources={{PersistentVolumeClaim,v1}}

--- a/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
+++ b/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
@@ -30,6 +30,9 @@ spec:
     - jsonPath: .spec.replicas
       name: Replicas
       type: number
+    - jsonPath: .status.version
+      name: Version
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -4450,6 +4453,10 @@ spec:
               updateRevision:
                 description: UpdateRevision indicates latest requested ClickHouseCluster
                   spec revision.
+                type: string
+              version:
+                description: Version indicates the version reported by the container
+                  image.
                 type: string
             type: object
         type: object

--- a/config/crd/bases/clickhouse.com_keeperclusters.yaml
+++ b/config/crd/bases/clickhouse.com_keeperclusters.yaml
@@ -30,6 +30,9 @@ spec:
     - jsonPath: .spec.replicas
       name: Replicas
       type: number
+    - jsonPath: .status.version
+      name: Version
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -4383,6 +4386,10 @@ spec:
               updateRevision:
                 description: CurrentRevision indicates latest requested KeeperCluster
                   spec revision.
+                type: string
+              version:
+                description: Version indicates the version reported by the container
+                  image.
                 type: string
             type: object
         type: object

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -37,6 +37,16 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - clickhouse.com
   resources:
   - clickhouseclusters

--- a/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
@@ -33,6 +33,9 @@ spec:
             - jsonPath: .spec.replicas
               name: Replicas
               type: number
+            - jsonPath: .status.version
+              name: Version
+              type: string
             - jsonPath: .metadata.creationTimestamp
               name: Age
               type: date
@@ -4253,6 +4256,9 @@ spec:
                                 type: string
                             updateRevision:
                                 description: UpdateRevision indicates latest requested ClickHouseCluster spec revision.
+                                type: string
+                            version:
+                                description: Version indicates the version reported by the container image.
                                 type: string
                         type: object
                 type: object

--- a/dist/chart/templates/crd/keeperclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/keeperclusters.clickhouse.com.yaml
@@ -33,6 +33,9 @@ spec:
             - jsonPath: .spec.replicas
               name: Replicas
               type: number
+            - jsonPath: .status.version
+              name: Version
+              type: string
             - jsonPath: .metadata.creationTimestamp
               name: Age
               type: date
@@ -4194,6 +4197,9 @@ spec:
                                 type: string
                             updateRevision:
                                 description: CurrentRevision indicates latest requested KeeperCluster spec revision.
+                                type: string
+                            version:
+                                description: Version indicates the version reported by the container image.
                                 type: string
                         type: object
                 type: object

--- a/dist/chart/templates/rbac/manager-role.yaml
+++ b/dist/chart/templates/rbac/manager-role.yaml
@@ -36,6 +36,16 @@ rules:
       verbs:
         - get
     - apiGroups:
+        - batch
+      resources:
+        - jobs
+      verbs:
+        - create
+        - delete
+        - get
+        - list
+        - watch
+    - apiGroups:
         - clickhouse.com
       resources:
         - clickhouseclusters

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -74,6 +74,7 @@ ClickHouseClusterStatus defines the observed state of ClickHouseCluster.
 | `currentRevision` | string | CurrentRevision indicates latest applied ClickHouseCluster spec revision. | true |  |
 | `updateRevision` | string | UpdateRevision indicates latest requested ClickHouseCluster spec revision. | true |  |
 | `observedGeneration` | integer | ObservedGeneration indicates latest generation observed by controller. | true |  |
+| `version` | string | Version indicates the version reported by the container image. | false |  |
 
 Appears in:
 - [ClickHouseCluster](#clickhousecluster)
@@ -243,6 +244,7 @@ KeeperClusterStatus defines the observed state of KeeperCluster.
 | `currentRevision` | string | CurrentRevision indicates latest applied KeeperCluster spec revision. | true |  |
 | `updateRevision` | string | CurrentRevision indicates latest requested KeeperCluster spec revision. | true |  |
 | `observedGeneration` | integer | ObservedGeneration indicates latest generation observed by controller. | true |  |
+| `version` | string | Version indicates the version reported by the container image. | false |  |
 
 Appears in:
 - [KeeperCluster](#keepercluster)

--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -90,17 +90,23 @@ func (cmd *commander) Close() {
 	cmd.conns = map[v1.ClickHouseReplicaID]clickhouse.Conn{}
 }
 
-func (cmd *commander) Ping(ctx context.Context, id v1.ClickHouseReplicaID) error {
+func (cmd *commander) Version(ctx context.Context, id v1.ClickHouseReplicaID) (string, error) {
 	conn, err := cmd.getConn(id)
 	if err != nil {
-		return fmt.Errorf("failed to get connection for replica %s: %w", id, err)
+		return "", fmt.Errorf("failed to get connection for replica %s: %w", id, err)
 	}
 
-	if err := conn.Ping(ctx); err != nil {
-		return fmt.Errorf("ping replica %s: %w", id, err)
+	var version string
+	if err := conn.QueryRow(ctx, "SELECT version()").Scan(&version); err != nil {
+		return "", fmt.Errorf("query version on replica %s: %w", id, err)
 	}
 
-	return nil
+	version, err = controllerutil.ParseVersion(version)
+	if err != nil {
+		return "", fmt.Errorf("parse version from replica %s response: %w", id, err)
+	}
+
+	return version, nil
 }
 
 func (cmd *commander) Databases(ctx context.Context, id v1.ClickHouseReplicaID) (map[string]databaseDescriptor, error) {

--- a/internal/controller/clickhouse/controller.go
+++ b/internal/controller/clickhouse/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -40,7 +41,13 @@ type ClusterController struct {
 // +kubebuilder:rbac:groups=clickhouse.com,resources=clickhouseclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=clickhouse.com,resources=clickhouseclusters/finalizers,verbs=update
 
+// +kubebuilder:rbac:groups="",resources=configmaps;services;pods,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=secrets;persistentvolumeclaims,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -139,6 +146,7 @@ func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger) error {
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&corev1.Pod{}).
+		Owns(&batchv1.Job{}).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
 		Complete(clickhouseController)
 	if err != nil {

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -41,6 +42,7 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 		secrets      corev1.SecretList
 		configs      corev1.ConfigMapList
 		statefulsets appsv1.StatefulSetList
+		jobs         batchv1.JobList
 		cr           = &v1.ClickHouseCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standalone",
@@ -129,6 +131,10 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 
 		Expect(suite.Client.List(ctx, &statefulsets, listOpts)).To(Succeed())
 		Expect(statefulsets.Items).To(HaveLen(4))
+
+		Expect(suite.Client.List(ctx, &jobs, listOpts)).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1))
+		Expect(jobs.Items[0].Labels[controllerutil.LabelRoleKey]).To(Equal(controllerutil.LabelVersionProbe))
 
 		testutil.AssertEvents(recorder.Events, map[string]int{
 			"ClusterNotReady": 1,

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -38,6 +38,7 @@ type replicaState struct {
 	Error       bool `json:"error"`
 	StatefulSet *appsv1.StatefulSet
 	Pinged      bool
+	Version     string
 }
 
 func (r replicaState) Updated() bool {
@@ -108,6 +109,7 @@ type clickhouseReconciler struct {
 	secret    corev1.Secret
 	commander *commander
 
+	versionProbe           chctrl.VersionProbeResult
 	databasesInSync        bool
 	staleReplicasCleanedUp bool
 }
@@ -317,6 +319,20 @@ func (r *clickhouseReconciler) reconcileClusterRevisions(ctx context.Context, lo
 		log.Debug(fmt.Sprintf("observed new StatefulSet revision %q", stsRevision))
 	}
 
+	probeResult, err := r.VersionProbe(ctx, log, chctrl.VersionProbeConfig{
+		Binary:            "clickhouse-server",
+		Labels:            r.Cluster.Spec.Labels,
+		Annotations:       r.Cluster.Spec.Annotations,
+		PodTemplate:       r.Cluster.Spec.PodTemplate,
+		ContainerTemplate: r.Cluster.Spec.ContainerTemplate,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("run version probe: %w", err)
+	}
+
+	r.versionProbe = probeResult
+	r.Cluster.Status.Version = r.versionProbe.Version
+
 	return nil, nil
 }
 
@@ -342,9 +358,9 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 			hasError = true
 		}
 
-		pingErr := r.commander.Ping(ctx, id)
-		if pingErr != nil {
-			log.Debug("failed to ping replica", "replica_id", id, "error", pingErr)
+		version, versionErr := r.commander.Version(ctx, id)
+		if versionErr != nil {
+			log.Debug("failed to query version on replica", "replica_id", id, "error", versionErr)
 		}
 
 		log.Debug("load replica state done", "replica_id", id, "statefulset", sts.Name)
@@ -352,7 +368,8 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 		return id, replicaState{
 			StatefulSet: &sts,
 			Error:       hasError,
-			Pinged:      pingErr == nil,
+			Pinged:      versionErr == nil,
+			Version:     version,
 		}, nil
 	})
 
@@ -694,6 +711,15 @@ func (r *clickhouseReconciler) reconcileConditions(ctx context.Context, log ctrl
 		r.SetCondition(log, r.NewCondition(v1.ConditionTypeConfigurationInSync, metav1.ConditionFalse, v1.ConditionReasonConfigurationChanged, message))
 	} else {
 		r.SetCondition(log, r.NewCondition(v1.ConditionTypeConfigurationInSync, metav1.ConditionTrue, v1.ConditionReasonUpToDate, ""))
+	}
+
+	replicaVersions := make(map[string]string, len(r.ReplicaState))
+	for id, replica := range r.ReplicaState {
+		replicaVersions[id.String()] = replica.Version
+	}
+
+	if err := r.UpdateVersionSyncCondition(ctx, log, r.versionProbe, replicaVersions, len(notUpdatedReplicas) > 0); err != nil {
+		return nil, fmt.Errorf("update VersionSync condition: %w", err)
 	}
 
 	exists := len(r.ReplicaState)

--- a/internal/controller/keeper/commands.go
+++ b/internal/controller/keeper/commands.go
@@ -29,6 +29,7 @@ var (
 type serverStatus struct {
 	ServerState string
 	Followers   int
+	Version     string
 }
 
 type dialer interface {
@@ -100,6 +101,14 @@ func queryKeeper(ctx context.Context, log controllerutil.Logger, conn net.Conn) 
 	result := serverStatus{
 		ServerState: statMap["zk_server_state"],
 	}
+
+	version, err := controllerutil.ParseVersion(statMap["zk_version"])
+	if err != nil {
+		log.Warn("failed to parse keeper version", "raw", statMap["zk_version"], "error", err)
+	} else {
+		result.Version = version
+	}
+
 	if result.ServerState == "" {
 		return serverStatus{}, fmt.Errorf("response missing required field 'Mode': %q", string(data))
 	}

--- a/internal/controller/keeper/controller.go
+++ b/internal/controller/keeper/controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,10 +39,12 @@ type ClusterController struct {
 // +kubebuilder:rbac:groups=clickhouse.com,resources=keeperclusters/finalizers,verbs=update
 
 // +kubebuilder:rbac:groups="",resources=configmaps;services;pods,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -136,6 +139,7 @@ func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger) error {
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&corev1.Pod{}).
+		Owns(&batchv1.Job{}).
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
 		Complete(keeperController)
 	if err != nil {

--- a/internal/controller/keeper/controller_test.go
+++ b/internal/controller/keeper/controller_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,6 +40,7 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 		pdbs         policyv1.PodDisruptionBudgetList
 		configs      corev1.ConfigMapList
 		statefulsets appsv1.StatefulSetList
+		jobs         batchv1.JobList
 		cr           = &v1.KeeperCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standalone",
@@ -107,6 +109,10 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 
 		Expect(suite.Client.List(ctx, &statefulsets, listOpts)).To(Succeed())
 		Expect(statefulsets.Items).To(HaveLen(1))
+
+		Expect(suite.Client.List(ctx, &jobs, listOpts)).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1))
+		Expect(jobs.Items[0].Labels[controllerutil.LabelRoleKey]).To(Equal(controllerutil.LabelVersionProbe))
 
 		testutil.AssertEvents(recorder.Events, map[string]int{
 			"ReplicaCreated":  1,

--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -100,6 +100,7 @@ type reconcilerBase = chctrl.ResourceReconcilerBase[v1.KeeperClusterStatus, *v1.
 type keeperReconciler struct {
 	reconcilerBase
 
+	versionProbe chctrl.VersionProbeResult
 	// Should be populated after reconcileClusterRevisions with parsed extra config.
 	ExtraConfig map[string]any
 	// Computed by reconcileActiveReplicaStatus
@@ -150,6 +151,7 @@ func (r *keeperReconciler) sync(ctx context.Context, log ctrlutil.Logger) (ctrl.
 				r.NewCondition(v1.ConditionTypeHealthy, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 				r.NewCondition(v1.ConditionTypeReplicaStartupSucceeded, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 				r.NewCondition(v1.ConditionTypeConfigurationInSync, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
+				r.NewCondition(v1.ConditionTypeVersionInSync, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 				r.NewCondition(v1.ConditionTypeClusterSizeAligned, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 				r.NewCondition(v1.KeeperConditionTypeScaleAllowed, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 			})
@@ -179,7 +181,7 @@ func (r *keeperReconciler) sync(ctx context.Context, log ctrlutil.Logger) (ctrl.
 	return result, nil
 }
 
-func (r *keeperReconciler) reconcileClusterRevisions(_ context.Context, log ctrlutil.Logger) (*ctrl.Result, error) {
+func (r *keeperReconciler) reconcileClusterRevisions(ctx context.Context, log ctrlutil.Logger) (*ctrl.Result, error) {
 	if r.Cluster.Status.ObservedGeneration != r.Cluster.Generation {
 		r.Cluster.Status.ObservedGeneration = r.Cluster.Generation
 		log.Debug(fmt.Sprintf("observed new CR generation %d", r.Cluster.Generation))
@@ -223,6 +225,20 @@ func (r *keeperReconciler) reconcileClusterRevisions(_ context.Context, log ctrl
 		r.Cluster.Status.StatefulSetRevision = stsRevision
 		log.Debug(fmt.Sprintf("observed new StatefulSet revision %q", stsRevision))
 	}
+
+	probeResult, err := r.VersionProbe(ctx, log, chctrl.VersionProbeConfig{
+		Binary:            "clickhouse-keeper",
+		Labels:            r.Cluster.Spec.Labels,
+		Annotations:       r.Cluster.Spec.Annotations,
+		PodTemplate:       r.Cluster.Spec.PodTemplate,
+		ContainerTemplate: r.Cluster.Spec.ContainerTemplate,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("run version probe: %w", err)
+	}
+
+	r.versionProbe = probeResult
+	r.Cluster.Status.Version = r.versionProbe.Version
 
 	return nil, nil
 }
@@ -613,6 +629,15 @@ func (r *keeperReconciler) reconcileConditions(ctx context.Context, log ctrlutil
 		r.SetCondition(log, r.NewCondition(v1.ConditionTypeConfigurationInSync, metav1.ConditionFalse, v1.ConditionReasonConfigurationChanged, message))
 	} else {
 		r.SetCondition(log, r.NewCondition(v1.ConditionTypeConfigurationInSync, metav1.ConditionTrue, v1.ConditionReasonUpToDate, ""))
+	}
+
+	replicaVersions := make(map[string]string, len(r.ReplicaState))
+	for id, replica := range r.ReplicaState {
+		replicaVersions[fmt.Sprintf("%d", id)] = replica.Status.Version
+	}
+
+	if err := r.UpdateVersionSyncCondition(ctx, log, r.versionProbe, replicaVersions, len(notUpdatedReplicas) > 0); err != nil {
+		return nil, fmt.Errorf("update VersionSync condition: %w", err)
 	}
 
 	exists := len(r.ReplicaState)

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -160,7 +160,7 @@ func setStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Cond
 		return true
 	}
 
-	changed := existingCondition.Status != newCondition.Status
+	changed := existingCondition.Status != newCondition.Status || existingCondition.Reason != newCondition.Reason
 	if changed {
 		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
 	} else {

--- a/internal/controller/versionprobe.go
+++ b/internal/controller/versionprobe.go
@@ -1,0 +1,274 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+const (
+	versionProbeContainerName = "version-probe"
+)
+
+// VersionProbeConfig holds parameters for the version probe Job.
+type VersionProbeConfig struct {
+	// Name of the binary to run.
+	Binary string
+	// Labels to apply to the Job, inherited from the cluster spec.
+	Labels map[string]string
+	// Annotations to apply to the Job, inherited from the cluster spec.
+	Annotations map[string]string
+	// PodTemplate to apply to the Job, inherited from the cluster spec.
+	PodTemplate v1.PodTemplateSpec
+	// ContainerTemplate to apply to the Job, inherited from the cluster spec.
+	ContainerTemplate v1.ContainerTemplateSpec
+}
+
+// VersionProbeResult holds the outcome of a version probe reconciliation.
+type VersionProbeResult struct {
+	// Version is the detected version string, empty if not yet available.
+	Version string
+	// Pending is true when the Job is still running or being created.
+	Pending bool
+	// Err if version probe failed it contains the error.
+	Err error
+}
+
+// VersionProbe manages a one-time Job to detect the version from a container image.
+// Returns the version string when available, or empty string if the Job is pending/running.
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) VersionProbe(
+	ctx context.Context,
+	log controllerutil.Logger,
+	cfg VersionProbeConfig,
+) (VersionProbeResult, error) {
+	job, err := r.buildVersionProbeJob(cfg)
+	if err != nil {
+		return VersionProbeResult{}, fmt.Errorf("build version probe job: %w", err)
+	}
+
+	r.cleanupVersionProbeJobs(ctx, log, &job)
+
+	cli := r.GetClient()
+	log = log.With("job", job.Name)
+
+	var existingJob batchv1.Job
+	if err = cli.Get(ctx, types.NamespacedName{Namespace: r.Cluster.GetNamespace(), Name: job.Name}, &existingJob); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return VersionProbeResult{}, fmt.Errorf("get version probe job: %w", err)
+		}
+
+		log.Debug("creating version probe job")
+
+		if err = r.Create(ctx, &job, v1.EventActionVersionCheck); err != nil {
+			return VersionProbeResult{}, fmt.Errorf("create version probe job: %w", err)
+		}
+
+		return VersionProbeResult{Pending: true}, nil
+	}
+
+	if c, ok := getJobCondition(&existingJob, batchv1.JobFailed); ok && c.Status == corev1.ConditionTrue {
+		log.Warn("version probe job failed")
+		return VersionProbeResult{Err: errors.New(c.Message)}, nil
+	}
+
+	if c, ok := getJobCondition(&existingJob, batchv1.JobComplete); !ok || c.Status != corev1.ConditionTrue {
+		log.Debug("version probe is not complete yet")
+		return VersionProbeResult{Pending: true}, nil
+	}
+
+	version, err := readVersionFromJob(ctx, log, cli, &existingJob)
+	if err != nil {
+		log.Warn("failed to read version from completed job, retrying", "error", err)
+		return VersionProbeResult{Err: err}, nil
+	}
+
+	return VersionProbeResult{Version: version}, nil
+}
+
+// UpdateVersionSyncCondition sets the VersionInSync condition based on the probe result and replica versions.
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) UpdateVersionSyncCondition(
+	ctx context.Context,
+	log controllerutil.Logger,
+	probe VersionProbeResult,
+	replicaVersions map[string]string,
+	isUpdating bool,
+) error {
+	if probe.Err != nil {
+		message := fmt.Sprintf("Version probe failed: %v", probe.Err)
+		cond := r.NewCondition(v1.ConditionTypeVersionInSync, metav1.ConditionUnknown, v1.ConditionReasonVersionProbeFailed, message)
+
+		_, err := r.UpsertConditionAndSendEvent(ctx, log, cond, corev1.EventTypeWarning, v1.EventReasonVersionProbeFailed, v1.EventActionVersionCheck, message)
+		if err != nil {
+			return fmt.Errorf("update VersionInSync condition: %w", err)
+		}
+
+		return nil
+	}
+
+	if probe.Pending {
+		r.SetCondition(log, r.NewCondition(v1.ConditionTypeVersionInSync, metav1.ConditionUnknown, v1.ConditionReasonVersionPending, "Version probe has not completed yet"))
+		return nil
+	}
+
+	var mismatched []string
+	for id, version := range replicaVersions {
+		if version != "" && version != probe.Version {
+			mismatched = append(mismatched, fmt.Sprintf("%s: %s", id, version))
+		}
+	}
+
+	if len(mismatched) == 0 {
+		r.SetCondition(log, r.NewCondition(v1.ConditionTypeVersionInSync, metav1.ConditionTrue, v1.ConditionReasonVersionMatch, ""))
+		return nil
+	}
+
+	slices.Sort(mismatched)
+	cond := r.NewCondition(v1.ConditionTypeVersionInSync, metav1.ConditionFalse, v1.ConditionReasonVersionMismatch,
+		fmt.Sprintf("Replica version doesn't match version probe %s: %s", probe.Version, strings.Join(mismatched, ", ")))
+
+	if isUpdating {
+		r.SetCondition(log, cond)
+		return nil
+	}
+
+	_, err := r.UpsertConditionAndSendEvent(ctx, log, cond, corev1.EventTypeWarning,
+		v1.EventReasonVersionDiverge, v1.EventActionVersionCheck, cond.Message)
+	if err != nil {
+		return fmt.Errorf("update VersionInSync condition: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) cleanupVersionProbeJobs(ctx context.Context, log controllerutil.Logger, job *batchv1.Job) {
+	cli := r.GetClient()
+
+	var jobs batchv1.JobList
+
+	if err := cli.List(ctx, &jobs, client.InNamespace(r.Cluster.GetNamespace()), client.MatchingLabels(map[string]string{
+		controllerutil.LabelAppKey:  r.Cluster.SpecificName(),
+		controllerutil.LabelRoleKey: controllerutil.LabelVersionProbe,
+	})); err != nil {
+		log.Warn("failed to list obsolete version probe jobs", "error", err)
+		return
+	}
+
+	for _, j := range jobs.Items {
+		if j.Name != job.Name {
+			log.Debug("deleting obsolete version probe job", "job", j.Name)
+
+			if err := cli.Delete(ctx, &j, client.PropagationPolicy(metav1.DeletePropagationBackground)); err != nil {
+				log.Warn("failed to delete obsolete version probe job", "job", j.Name, "error", err)
+			}
+		}
+	}
+}
+
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) buildVersionProbeJob(cfg VersionProbeConfig) (batchv1.Job, error) {
+	job := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: r.Cluster.GetNamespace(),
+			Labels: controllerutil.MergeMaps(cfg.Labels, map[string]string{
+				controllerutil.LabelAppKey:  r.Cluster.SpecificName(),
+				controllerutil.LabelRoleKey: controllerutil.LabelVersionProbe,
+			}),
+			Annotations: cfg.Annotations,
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: ptr.To[int32](0),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      cfg.Labels,
+					Annotations: cfg.Annotations,
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy:    corev1.RestartPolicyNever,
+					ImagePullSecrets: cfg.PodTemplate.ImagePullSecrets,
+					SecurityContext:  cfg.PodTemplate.SecurityContext,
+					Containers: []corev1.Container{
+						{
+							Name:            versionProbeContainerName,
+							Image:           cfg.ContainerTemplate.Image.String(),
+							ImagePullPolicy: cfg.ContainerTemplate.ImagePullPolicy,
+							SecurityContext: cfg.ContainerTemplate.SecurityContext,
+							Command:         []string{"sh", "-c", cfg.Binary + " --version > /dev/termination-log 2>&1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := ctrl.SetControllerReference(r.Cluster, &job, r.GetScheme()); err != nil {
+		return batchv1.Job{}, fmt.Errorf("set version probe job controller reference: %w", err)
+	}
+
+	specHash, err := controllerutil.DeepHashObject(job.Spec)
+	if err != nil {
+		return batchv1.Job{}, fmt.Errorf("hash version probe job spec: %w", err)
+	}
+
+	job.Name = fmt.Sprintf("%s-version-probe-%s", r.Cluster.SpecificName(), specHash[:8])
+
+	return job, nil
+}
+
+func getJobCondition(job *batchv1.Job, conditionType batchv1.JobConditionType) (batchv1.JobCondition, bool) {
+	for _, c := range job.Status.Conditions {
+		if c.Type == conditionType {
+			return c, true
+		}
+	}
+
+	return batchv1.JobCondition{}, false
+}
+
+func readVersionFromJob(ctx context.Context, log controllerutil.Logger, cli client.Client, job *batchv1.Job) (string, error) {
+	// Find the pod created by this Job.
+	var podList corev1.PodList
+	if err := cli.List(ctx, &podList,
+		client.InNamespace(job.Namespace),
+		client.MatchingLabels{
+			batchv1.ControllerUidLabel: string(job.UID),
+			batchv1.JobNameLabel:       job.Name,
+		},
+	); err != nil {
+		return "", fmt.Errorf("list pods for version probe job: %w", err)
+	}
+
+	if len(podList.Items) == 0 {
+		return "", fmt.Errorf("no pods found for version probe job %s", job.Name)
+	}
+
+	if len(podList.Items) > 1 {
+		log.Warn("more than one pods found for version probe job")
+	}
+
+	for _, pod := range podList.Items {
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name == versionProbeContainerName && cs.State.Terminated != nil {
+				version, err := controllerutil.ParseVersion(cs.State.Terminated.Message)
+				if err != nil {
+					return "", fmt.Errorf("parse version probe from job container output: %w", err)
+				}
+
+				return version, nil
+			}
+		}
+	}
+
+	return "", errors.New("no termination message found in version probe job pods")
+}

--- a/internal/controllerutil/common.go
+++ b/internal/controllerutil/common.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"maps"
 	"reflect"
+	"regexp"
 	"runtime"
 	"slices"
 	"strings"
@@ -281,4 +282,16 @@ func ShouldEmitEvent(err error) bool {
 	}
 
 	return false
+}
+
+var versionRegex = regexp.MustCompile(`\d+(\.\d+){2,3}`)
+
+// ParseVersion extracts a version string from the given raw input.
+func ParseVersion(raw string) (string, error) {
+	version := versionRegex.FindAllString(raw, -1)
+	if len(version) != 1 {
+		return "", fmt.Errorf("failed to parse version: %q", raw)
+	}
+
+	return version[0], nil
 }

--- a/internal/controllerutil/common_test.go
+++ b/internal/controllerutil/common_test.go
@@ -157,3 +157,15 @@ var _ = Describe("ExecuteParallel", func() {
 		}))
 	})
 })
+
+var _ = DescribeTable("ParseVersion", func(in, out string, isErr bool) {
+	result, err := ParseVersion(in)
+	Expect(result).To(Equal(out))
+	Expect(err != nil).To(Equal(isErr))
+},
+	Entry("from keeper mntr", "v26.1.3.52-stable-5549f2acae95c6d627654f50e212a85d059a55f9", "26.1.3.52", false),
+	Entry("from --version", "ClickHouse local version 25.4.1.1.", "25.4.1.1", false),
+	Entry("exact match", "25.4.1.1", "25.4.1.1", false),
+	Entry("error", "command not found: clickhouse", "", true),
+	Entry("empty result", "", "", true),
+)

--- a/internal/controllerutil/labels.go
+++ b/internal/controllerutil/labels.go
@@ -23,8 +23,8 @@ const (
 const (
 	LabelKeeperValue       = "clickhouse-keeper"
 	LabelKeeperAllReplicas = "all-replicas"
-
-	LabelClickHouseValue = "clickhouse-server"
+	LabelClickHouseValue   = "clickhouse-server"
+	LabelVersionProbe      = "version-probe"
 )
 
 // AppRequirements returns ListOptions to list resources of the given app.

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -95,6 +95,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
 			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute, true)
+			ExpectWithOffset(1, k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+			Expect(cr.Status.Version).To(HavePrefix(cr.Spec.ContainerTemplate.Image.Tag))
 			ClickHouseRWChecks(ctx, &cr, &checks)
 		},
 			Entry("update log level", v1.ClickHouseClusterSpec{Settings: v1.ClickHouseSettings{

--- a/test/e2e/keeper_e2e_test.go
+++ b/test/e2e/keeper_e2e_test.go
@@ -61,6 +61,8 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 		Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
 		WaitKeeperUpdatedAndReady(ctx, &cr, 3*time.Minute, true)
+		ExpectWithOffset(1, k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+		Expect(cr.Status.Version).To(HavePrefix(cr.Spec.ContainerTemplate.Image.Tag))
 		KeeperRWChecks(ctx, &cr, &checks)
 	},
 		Entry("update log level", v1.KeeperClusterSpec{Settings: v1.KeeperSettings{


### PR DESCRIPTION
## Why

Other features, such as #111, named collection configuration, or available version upgrade tracking, require knowledge of the version in the specified image.
Tags like `latest` or major releases `26.1` may end up with different versions between replicas.

## What

Add a helper job that runs the specified image with `--version` and stores the result in the Status.
Add the status condition and event to warn on version drift.