### PR TITLE
Unify replica resources logic. Delete Pod in error state if STS stuck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/sethvargo/go-envconfig v1.3.0
 	go.uber.org/zap v1.27.1
+	golang.org/x/net v0.50.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.35.1
 	k8s.io/apimachinery v0.35.1
@@ -99,7 +100,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/mod v0.33.0 // indirect
-	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -308,22 +308,16 @@ func (cmd *commander) CleanupDatabaseReplicas(
 	log controllerutil.Logger,
 	notInSync map[v1.ClickHouseReplicaID]struct{},
 ) error {
-	var anyID v1.ClickHouseReplicaID
-	for id := range cmd.cluster.ReplicaIDs() {
-		anyID = id
-		break
-	}
-
-	log = log.With("replica_id", anyID)
-
-	conn, err := cmd.getConn(anyID)
+	id, conn, err := cmd.getAnyConn()
 	if err != nil {
-		return fmt.Errorf("failed to get connection for replica %v: %w", anyID, err)
+		return err
 	}
+
+	log = log.With("replica_id", id)
 
 	rows, err := conn.Query(ctx, listStaleDatabaseReplicasQuery, cmd.cluster.Shards(), cmd.cluster.Replicas())
 	if err != nil {
-		return fmt.Errorf("failed to query stale database replicas %v: %w", anyID, err)
+		return fmt.Errorf("failed to query stale database replicas %v: %w", id, err)
 	}
 
 	defer func() {
@@ -427,4 +421,15 @@ func (cmd *commander) getConn(id v1.ClickHouseReplicaID) (clickhouse.Conn, error
 	cmd.conns[id] = conn
 
 	return conn, nil
+}
+
+func (cmd *commander) getAnyConn() (v1.ClickHouseReplicaID, clickhouse.Conn, error) {
+	cmd.lock.RLock()
+	defer cmd.lock.RUnlock()
+
+	for id, conn := range cmd.conns {
+		return id, conn, nil
+	}
+
+	return v1.ClickHouseReplicaID{}, nil, errors.New("no available connections")
 }

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -8,10 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/blang/semver/v4"
-	gcmp "github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -347,20 +344,30 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 	execResults := ctrlutil.ExecuteParallel(statefulSets.Items, func(sts appsv1.StatefulSet) (v1.ClickHouseReplicaID, replicaState, error) {
 		id, err := v1.ClickHouseIDFromLabels(sts.Labels)
 		if err != nil {
-			log.Error(err, "failed to get replica ID from StatefulSet labels", "stateful_set", sts.Name)
+			log.Error(err, "failed to get replica ID from StatefulSet labels", "statefulset", sts.Name)
 			return v1.ClickHouseReplicaID{}, replicaState{}, fmt.Errorf("get replica ID from StatefulSet labels: %w", err)
 		}
 
 		hasError, err := chctrl.CheckPodError(ctx, log, r.GetClient(), &sts)
 		if err != nil {
-			log.Warn("failed to check replica pod error", "stateful_set", sts.Name, "error", err)
+			log.Warn("failed to check replica pod error", "statefulset", sts.Name, "error", err)
 
 			hasError = true
 		}
 
-		version, versionErr := r.commander.Version(ctx, id)
-		if versionErr != nil {
-			log.Debug("failed to query version on replica", "replica_id", id, "error", versionErr)
+		pinged := false
+		version := ""
+
+		if !hasError {
+			ctx, cancel := context.WithTimeout(ctx, chctrl.LoadReplicaStateTimeout)
+			defer cancel()
+
+			version, err = r.commander.Version(ctx, id)
+			if err != nil {
+				log.Debug("failed to query version on replica", "replica_id", id, "error", err)
+			} else {
+				pinged = true
+			}
 		}
 
 		log.Debug("load replica state done", "replica_id", id, "statefulset", sts.Name)
@@ -368,7 +375,7 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 		return id, replicaState{
 			StatefulSet: &sts,
 			Error:       hasError,
-			Pinged:      versionErr == nil,
+			Pinged:      pinged,
 			Version:     version,
 		}, nil
 	})
@@ -794,95 +801,26 @@ func (r *clickhouseReconciler) updateReplica(ctx context.Context, log ctrlutil.L
 		return nil, fmt.Errorf("template replica %s ConfigMap: %w", id, err)
 	}
 
-	configChanged, err := r.ReconcileConfigMap(ctx, log, configMap, v1.EventActionReconciling)
-	if err != nil {
-		return nil, fmt.Errorf("update replica %s ConfigMap: %w", id, err)
-	}
-
 	statefulSet, err := templateStatefulSet(r, id)
 	if err != nil {
 		return nil, fmt.Errorf("template replica %s StatefulSet: %w", id, err)
 	}
 
-	if err := ctrl.SetControllerReference(r.Cluster, statefulSet, r.GetScheme()); err != nil {
-		return nil, fmt.Errorf("set replica %s StatefulSet controller reference: %w", id, err)
-	}
-
 	replica := r.Replica(id)
-	if replica.StatefulSet == nil {
-		log.Info("replica StatefulSet not found, creating", "stateful_set", statefulSet.Name)
-		ctrlutil.AddObjectConfigHash(statefulSet, r.Cluster.Status.ConfigurationRevision)
-		ctrlutil.AddHashWithKeyToAnnotations(statefulSet, ctrlutil.AnnotationSpecHash, r.Cluster.Status.StatefulSetRevision)
 
-		if err := r.Create(ctx, statefulSet, v1.EventActionReconciling); err != nil {
-			return nil, fmt.Errorf("create replica %s: %w", id, err)
-		}
-
-		return &ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
+	result, err := r.ReconcileReplicaResources(ctx, log, id, chctrl.ReplicaUpdateInput{
+		ExistingSTS:           replica.StatefulSet,
+		DesiredConfigMap:      configMap,
+		DesiredSTS:            statefulSet,
+		HasError:              replica.Error,
+		ConfigurationRevision: r.Cluster.Status.ConfigurationRevision,
+		StatefulSetRevision:   r.Cluster.Status.StatefulSetRevision,
+		BreakingSTSVersion:    breakingStatefulSetVersion,
+		DataVolumeClaimSpec:   r.Cluster.Spec.DataVolumeClaimSpec,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reconcile replica %s resources: %w", id, err)
 	}
 
-	// Check if the StatefulSet is outdated and needs to be recreated
-	v, err := semver.Parse(replica.StatefulSet.Annotations[ctrlutil.AnnotationStatefulSetVersion])
-	if err != nil || breakingStatefulSetVersion.GT(v) {
-		log.Warn(fmt.Sprintf("Removing the StatefulSet because of a breaking change. Found version: %v, expected version: %v", v, breakingStatefulSetVersion))
-
-		if err := r.Delete(ctx, replica.StatefulSet, v1.EventActionReconciling); err != nil {
-			return nil, fmt.Errorf("recreate replica %s: %w", id, err)
-		}
-
-		return &ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
-	}
-
-	stsNeedsUpdate := replica.HasStatefulSetDiff(r)
-
-	// Trigger Pod restart if config changed
-	if replica.HasConfigMapDiff(r) {
-		// Always restarts the Pod when ConfigMap changed. Need to add checks on whether restart is needed.
-		// Use same way as Kubernetes for force restarting Pods one by one
-		// (https://github.com/kubernetes/kubernetes/blob/22a21f974f5c0798a611987405135ab7e62502da/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/objectrestarter.go#L41)
-		// Not included by default in the StatefulSet so that hash-diffs work correctly
-		log.Info("forcing ClickHouse Pod restart, because of config changes")
-
-		statefulSet.Spec.Template.Annotations[ctrlutil.AnnotationRestartedAt] = time.Now().Format(time.RFC3339)
-
-		ctrlutil.AddObjectConfigHash(replica.StatefulSet, r.Cluster.Status.ConfigurationRevision)
-
-		stsNeedsUpdate = true
-	} else if restartedAt, ok := replica.StatefulSet.Spec.Template.Annotations[ctrlutil.AnnotationRestartedAt]; ok {
-		statefulSet.Spec.Template.Annotations[ctrlutil.AnnotationRestartedAt] = restartedAt
-	}
-
-	if !stsNeedsUpdate {
-		log.Debug("StatefulSet is up to date")
-
-		if configChanged {
-			return &ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
-		}
-
-		return nil, nil
-	}
-
-	if r.Cluster.Spec.DataVolumeClaimSpec != nil {
-		if !gcmp.Equal(replica.StatefulSet.Spec.VolumeClaimTemplates[0].Spec, r.Cluster.Spec.DataVolumeClaimSpec) {
-			if err = r.UpdatePVC(ctx, log, id, *r.Cluster.Spec.DataVolumeClaimSpec, v1.EventActionReconciling); err != nil {
-				//nolint:nilerr // Error is logged internally and event sent
-				return nil, nil
-			}
-
-			statefulSet.Spec.VolumeClaimTemplates = replica.StatefulSet.Spec.VolumeClaimTemplates
-		}
-	}
-
-	log.Info("updating replica StatefulSet", "stateful_set", statefulSet.Name)
-	log.Info("replica StatefulSet diff", "diff", gcmp.Diff(replica.StatefulSet.Spec, statefulSet.Spec))
-	replica.StatefulSet.Spec = statefulSet.Spec
-	replica.StatefulSet.Annotations = ctrlutil.MergeMaps(replica.StatefulSet.Annotations, statefulSet.Annotations)
-	replica.StatefulSet.Labels = ctrlutil.MergeMaps(replica.StatefulSet.Labels, statefulSet.Labels)
-	ctrlutil.AddHashWithKeyToAnnotations(replica.StatefulSet, ctrlutil.AnnotationSpecHash, r.Cluster.Status.StatefulSetRevision)
-
-	if err := r.Update(ctx, replica.StatefulSet, v1.EventActionReconciling); err != nil {
-		return nil, fmt.Errorf("update replica %s: %w", id, err)
-	}
-
-	return &ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
+	return result, nil
 }

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	RequeueOnRefreshTimeout       = time.Second
+	LoadReplicaStateTimeout       = 10 * time.Second
 	TLSFileMode             int32 = 0444
 )
 

--- a/internal/controller/keeper/commands.go
+++ b/internal/controller/keeper/commands.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/net/proxy"
+
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
 )
 
@@ -32,12 +34,8 @@ type serverStatus struct {
 	Version     string
 }
 
-type dialer interface {
-	DialContext(ctx context.Context, network, address string) (net.Conn, error)
-}
-
 func getConnection(ctx context.Context, hostname string, tlsRequired bool) (net.Conn, error) {
-	var d dialer = &net.Dialer{}
+	var d proxy.ContextDialer = &net.Dialer{}
 
 	port := PortNative
 	if tlsRequired {

--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -9,10 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/blang/semver/v4"
-	gcmp "github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -261,18 +258,24 @@ func (r *keeperReconciler) reconcileActiveReplicaStatus(ctx context.Context, log
 	execResults := ctrlutil.ExecuteParallel(statefulSets.Items, func(sts appsv1.StatefulSet) (v1.KeeperReplicaID, replicaState, error) {
 		id, err := v1.KeeperReplicaIDFromLabels(sts.Labels)
 		if err != nil {
-			log.Error(err, "get replica ID from StatefulSet labels", "stateful_set", sts.Name)
+			log.Error(err, "get replica ID from StatefulSet labels", "statefulset", sts.Name)
 			return -1, replicaState{}, fmt.Errorf("get StatefulSet replica ID: %w", err)
 		}
 
 		hasError, err := chctrl.CheckPodError(ctx, log, r.GetClient(), &sts)
 		if err != nil {
-			log.Warn("failed to check replica pod error", "stateful_set", sts.Name, "error", err)
+			log.Warn("failed to check replica pod error", "statefulset", sts.Name, "error", err)
 
 			hasError = true
 		}
 
-		status := getServerStatus(ctx, log.With("replica_id", id), r.Cluster.HostnameByID(id), tlsRequired)
+		var status serverStatus
+		if !hasError {
+			ctx, cancel := context.WithTimeout(ctx, chctrl.LoadReplicaStateTimeout)
+			defer cancel()
+
+			status = getServerStatus(ctx, log.With("replica_id", id), r.Cluster.HostnameByID(id), tlsRequired)
+		}
 
 		log.Debug("load replica state done", "replica_id", id, "statefulset", sts.Name)
 
@@ -730,95 +733,28 @@ func (r *keeperReconciler) updateReplica(ctx context.Context, log ctrlutil.Logge
 		return nil, fmt.Errorf("template replica %q ConfigMap: %w", replicaID, err)
 	}
 
-	configChanged, err := r.ReconcileConfigMap(ctx, log, configMap, v1.EventActionReconciling)
-	if err != nil {
-		return nil, fmt.Errorf("update replica %q ConfigMap: %w", replicaID, err)
-	}
-
 	statefulSet, err := templateStatefulSet(r.Cluster, replicaID)
 	if err != nil {
 		return nil, fmt.Errorf("template replica %q StatefulSet: %w", replicaID, err)
 	}
 
-	if err := ctrl.SetControllerReference(r.Cluster, statefulSet, r.GetScheme()); err != nil {
-		return nil, fmt.Errorf("set replica %q StatefulSet controller reference: %w", replicaID, err)
-	}
-
 	replica := r.Replica(replicaID)
-	if replica.StatefulSet == nil {
-		log.Info("replica StatefulSet not found, creating", "stateful_set", statefulSet.Name)
-		ctrlutil.AddObjectConfigHash(statefulSet, r.Cluster.Status.ConfigurationRevision)
-		ctrlutil.AddHashWithKeyToAnnotations(statefulSet, ctrlutil.AnnotationSpecHash, r.Cluster.Status.StatefulSetRevision)
 
-		if err := r.Create(ctx, statefulSet, v1.EventActionReconciling); err != nil {
-			return nil, fmt.Errorf("create replica %q: %w", replicaID, err)
-		}
-
-		return &ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
+	result, err := r.ReconcileReplicaResources(ctx, log, replicaID, chctrl.ReplicaUpdateInput{
+		ExistingSTS:           replica.StatefulSet,
+		DesiredConfigMap:      configMap,
+		DesiredSTS:            statefulSet,
+		HasError:              replica.Error,
+		ConfigurationRevision: r.Cluster.Status.ConfigurationRevision,
+		StatefulSetRevision:   r.Cluster.Status.StatefulSetRevision,
+		BreakingSTSVersion:    breakingStatefulSetVersion,
+		DataVolumeClaimSpec:   r.Cluster.Spec.DataVolumeClaimSpec,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("reconcile replica %q resources: %w", replicaID, err)
 	}
 
-	// Check if the StatefulSet is outdated and needs to be recreated
-	v, err := semver.Parse(replica.StatefulSet.Annotations[ctrlutil.AnnotationStatefulSetVersion])
-	if err != nil || breakingStatefulSetVersion.GT(v) {
-		log.Warn(fmt.Sprintf("Removing the StatefulSet because of a breaking change. Found version: %v, expected version: %v", v, breakingStatefulSetVersion))
-
-		if err := r.Delete(ctx, replica.StatefulSet, v1.EventActionReconciling); err != nil {
-			return nil, fmt.Errorf("recreate replica %d: %w", replicaID, err)
-		}
-
-		return &ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
-	}
-
-	stsNeedsUpdate := replica.HasStatefulSetDiff(r)
-
-	// Trigger Pod restart if config changed
-	if replica.HasConfigMapDiff(r) {
-		// Use same way as Kubernetes for force restarting Pods one by one
-		// (https://github.com/kubernetes/kubernetes/blob/22a21f974f5c0798a611987405135ab7e62502da/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/objectrestarter.go#L41)
-		// Not included by default in the StatefulSet so that hash-diffs work correctly
-		log.Info("forcing keeper Pod restart, because of config changes")
-
-		statefulSet.Spec.Template.Annotations[ctrlutil.AnnotationRestartedAt] = time.Now().Format(time.RFC3339)
-
-		ctrlutil.AddObjectConfigHash(replica.StatefulSet, r.Cluster.Status.ConfigurationRevision)
-
-		stsNeedsUpdate = true
-	} else if restartedAt, ok := replica.StatefulSet.Spec.Template.Annotations[ctrlutil.AnnotationRestartedAt]; ok {
-		statefulSet.Spec.Template.Annotations[ctrlutil.AnnotationRestartedAt] = restartedAt
-	}
-
-	if !stsNeedsUpdate {
-		log.Debug("StatefulSet is up to date")
-
-		if configChanged {
-			return &ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
-		}
-
-		return nil, nil
-	}
-
-	if r.Cluster.Spec.DataVolumeClaimSpec != nil {
-		if !gcmp.Equal(replica.StatefulSet.Spec.VolumeClaimTemplates[0].Spec, r.Cluster.Spec.DataVolumeClaimSpec) {
-			if err = r.UpdatePVC(ctx, log, replicaID, *r.Cluster.Spec.DataVolumeClaimSpec, v1.EventActionReconciling); err != nil {
-				//nolint:nilerr // Error is logged internally and event sent
-				return nil, nil
-			}
-
-			statefulSet.Spec.VolumeClaimTemplates = replica.StatefulSet.Spec.VolumeClaimTemplates
-		}
-	}
-
-	log.Info("updating replica StatefulSet", "stateful_set", statefulSet.Name)
-	replica.StatefulSet.Spec = statefulSet.Spec
-	replica.StatefulSet.Annotations = ctrlutil.MergeMaps(replica.StatefulSet.Annotations, statefulSet.Annotations)
-	replica.StatefulSet.Labels = ctrlutil.MergeMaps(replica.StatefulSet.Labels, statefulSet.Labels)
-	ctrlutil.AddHashWithKeyToAnnotations(replica.StatefulSet, ctrlutil.AnnotationSpecHash, r.Cluster.Status.StatefulSetRevision)
-
-	if err := r.Update(ctx, replica.StatefulSet, v1.EventActionReconciling); err != nil {
-		return nil, fmt.Errorf("update replica %q: %w", replicaID, err)
-	}
-
-	return &ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
+	return result, nil
 }
 
 func (r *keeperReconciler) loadQuorumReplicas(ctx context.Context) (map[v1.KeeperReplicaID]struct{}, error) {

--- a/internal/controller/keeper/sync_test.go
+++ b/internal/controller/keeper/sync_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -104,6 +105,50 @@ var _ = Describe("UpdateReplica", Ordered, func() {
 
 		sts = mustGet[*appsv1.StatefulSet](ctx, rec.GetClient(), stsKey)
 		Expect(sts.Spec.Template.Annotations[util.AnnotationRestartedAt]).ToNot(BeEmpty())
+	})
+
+	It("should delete stuck pod in error state", func(ctx context.Context) {
+		sts := mustGet[*appsv1.StatefulSet](ctx, rec.GetClient(), stsKey)
+
+		podKey := types.NamespacedName{
+			Namespace: rec.Cluster.Namespace,
+			Name:      sts.Name + "-0",
+		}
+
+		By("creating a pod that simulates a stuck state")
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: podKey.Namespace,
+				Name:      podKey.Name,
+				Annotations: map[string]string{
+					appsv1.ControllerRevisionHashLabelKey: "outdated",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "clickhouse-keeper",
+					Image: "custom-keeper:latest",
+				}},
+			},
+		}
+		Expect(rec.GetClient().Create(ctx, pod)).To(Succeed())
+
+		By("setting replica state with error and a spec diff")
+
+		rec.ReplicaState[replicaID] = replicaState{
+			Error:       true,
+			StatefulSet: sts,
+		}
+
+		result, err := rec.reconcileReplicaResources(ctx, log)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.IsZero()).To(BeFalse())
+
+		By("verifying the stuck pod was deleted")
+
+		err = rec.GetClient().Get(ctx, podKey, &corev1.Pod{})
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "stuck pod should have been deleted")
 	})
 })
 

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"time"
 
+	"github.com/blang/semver/v4"
 	gcmp "github.com/google/go-cmp/cmp"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -46,7 +48,7 @@ func (s ReplicaUpdateStage) String() string {
 	return mapStatusText[s]
 }
 
-var podErrorStatuses = []string{"ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff"}
+var podErrorStatuses = []string{"ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff", "CreateContainerError", "CreateContainerConfigError", "InvalidImageName"}
 
 // CheckPodError checks if the pod of the given StatefulSet have permanent errors preventing it from starting.
 func CheckPodError(ctx context.Context, log util.Logger, client client.Client, sts *appsv1.StatefulSet) (bool, error) {
@@ -305,4 +307,140 @@ func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) UpdatePVC(
 	}
 
 	return nil
+}
+
+// ReplicaUpdateInput contains the parameters needed to reconcile a StatefulSet for a replica.
+type ReplicaUpdateInput struct {
+	ExistingSTS           *appsv1.StatefulSet
+	DesiredConfigMap      *corev1.ConfigMap
+	DesiredSTS            *appsv1.StatefulSet
+	HasError              bool
+	ConfigurationRevision string
+	StatefulSetRevision   string
+	BreakingSTSVersion    semver.Version
+	DataVolumeClaimSpec   *corev1.PersistentVolumeClaimSpec
+}
+
+// ReconcileReplicaResources reconciles a replica's ConfigMap, StatefulSet and PVC.
+// Handling Pod restarts on config changes.
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) ReconcileReplicaResources(
+	ctx context.Context,
+	log util.Logger,
+	replicaID ReplicaID,
+	input ReplicaUpdateInput,
+) (*ctrlruntime.Result, error) {
+	configChanged, err := r.ReconcileConfigMap(ctx, log, input.DesiredConfigMap, v1.EventActionReconciling)
+	if err != nil {
+		return nil, fmt.Errorf("update replica ConfigMap: %w", err)
+	}
+
+	statefulSet := input.DesiredSTS
+
+	if err := ctrlruntime.SetControllerReference(r.Cluster, statefulSet, r.GetScheme()); err != nil {
+		return nil, fmt.Errorf("set replica StatefulSet controller reference: %w", err)
+	}
+
+	if input.ExistingSTS == nil {
+		log.Info("replica StatefulSet not found, creating", "stateful_set", statefulSet.Name)
+		util.AddObjectConfigHash(statefulSet, input.ConfigurationRevision)
+		util.AddHashWithKeyToAnnotations(statefulSet, util.AnnotationSpecHash, input.StatefulSetRevision)
+
+		if err := r.Create(ctx, statefulSet, v1.EventActionReconciling); err != nil {
+			return nil, fmt.Errorf("create replica: %w", err)
+		}
+
+		return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
+	}
+
+	// Check if the StatefulSet is outdated and needs to be recreated
+	v, err := semver.Parse(input.ExistingSTS.Annotations[util.AnnotationStatefulSetVersion])
+	if err != nil || input.BreakingSTSVersion.GT(v) {
+		log.Warn(fmt.Sprintf("Removing the StatefulSet because of a breaking change. Found version: %v, expected version: %v", v, input.BreakingSTSVersion))
+
+		if err := r.Delete(ctx, input.ExistingSTS, v1.EventActionReconciling); err != nil {
+			return nil, fmt.Errorf("recreate replica: %w", err)
+		}
+
+		return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
+	}
+
+	stsNeedsUpdate := util.GetSpecHashFromObject(input.ExistingSTS) != input.StatefulSetRevision
+
+	// Trigger Pod restart if config changed
+	// Always restarts on config changes, need to add check if it is needed.
+	if util.GetConfigHashFromObject(input.ExistingSTS) != input.ConfigurationRevision {
+		// Use same way as Kubernetes for force restarting Pods one by one
+		// (https://github.com/kubernetes/kubernetes/blob/22a21f974f5c0798a611987405135ab7e62502da/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/objectrestarter.go#L41)
+		// Not included by default in the StatefulSet so that hash-diffs work correctly
+		log.Info("forcing Pod restart, because of config changes")
+
+		statefulSet.Spec.Template.Annotations[util.AnnotationRestartedAt] = time.Now().Format(time.RFC3339)
+
+		util.AddObjectConfigHash(input.ExistingSTS, input.ConfigurationRevision)
+
+		stsNeedsUpdate = true
+	} else if restartedAt, ok := input.ExistingSTS.Spec.Template.Annotations[util.AnnotationRestartedAt]; ok {
+		statefulSet.Spec.Template.Annotations[util.AnnotationRestartedAt] = restartedAt
+	}
+
+	if !stsNeedsUpdate {
+		log.Debug("StatefulSet is up to date", "stateful_set", statefulSet.Name)
+
+		if configChanged {
+			return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
+		}
+
+		// Delete stuck pod if in error state so the StatefulSet controller can recreate it
+		if input.HasError {
+			podName := input.ExistingSTS.Name + "-0"
+			pod := &corev1.Pod{}
+
+			err = r.GetClient().Get(ctx, types.NamespacedName{Namespace: input.ExistingSTS.Namespace, Name: podName}, pod)
+			if err != nil {
+				if k8serrors.IsNotFound(err) {
+					return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
+				}
+
+				log.Info("failed to get error pod", "pod", podName)
+
+				return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
+			}
+
+			if pod.Annotations[appsv1.ControllerRevisionHashLabelKey] != input.ExistingSTS.Status.UpdateRevision {
+				log.Info("deleting pod stuck in error state", "pod", podName)
+
+				if err = r.GetClient().Delete(ctx, pod); err != nil {
+					log.Warn("failed to delete stuck pod", "pod", podName, "error", err)
+				}
+
+				return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
+			}
+		}
+
+		return nil, nil
+	}
+
+	if input.DataVolumeClaimSpec != nil {
+		if !gcmp.Equal(input.ExistingSTS.Spec.VolumeClaimTemplates[0].Spec, input.DataVolumeClaimSpec) {
+			if err = r.UpdatePVC(ctx, log, replicaID, *input.DataVolumeClaimSpec, v1.EventActionReconciling); err != nil {
+				//nolint:nilerr // Error is logged internally and event sent
+				return nil, nil
+			}
+
+			statefulSet.Spec.VolumeClaimTemplates = input.ExistingSTS.Spec.VolumeClaimTemplates
+		}
+	}
+
+	log.Info("updating replica StatefulSet", "stateful_set", statefulSet.Name)
+	log.Debug("replica StatefulSet diff", "diff", gcmp.Diff(input.ExistingSTS.Spec, statefulSet.Spec))
+	input.ExistingSTS.Spec = statefulSet.Spec
+	input.ExistingSTS.Annotations = util.MergeMaps(input.ExistingSTS.Annotations, statefulSet.Annotations)
+	input.ExistingSTS.Labels = util.MergeMaps(input.ExistingSTS.Labels, statefulSet.Labels)
+	util.AddHashWithKeyToAnnotations(input.ExistingSTS, util.AnnotationSpecHash, input.StatefulSetRevision)
+
+	if err = r.Update(ctx, input.ExistingSTS, v1.EventActionReconciling); err != nil {
+		return nil, fmt.Errorf("update replica: %w", err)
+	}
+
+	return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
 }

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -208,6 +209,41 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 
 			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
 			ClickHouseRWChecks(ctx, &cr, ptr.To(0))
+		})
+
+		It("should recreate stuck pods", func(ctx context.Context) {
+			cr := v1.ClickHouseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      fmt.Sprintf("custom-disk-%d", rand.Uint32()), //nolint:gosec
+				},
+				Spec: v1.ClickHouseClusterSpec{
+					Replicas:            new(int32(1)),
+					DataVolumeClaimSpec: nil, // Diskless configuration
+					KeeperClusterRef: &corev1.LocalObjectReference{
+						Name: keeper.Name,
+					},
+					ContainerTemplate: v1.ContainerTemplateSpec{
+						Image: v1.ContainerImage{
+							Repository: "invalid",
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, &cr)).To(Succeed())
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+				cond := meta.FindStatusCondition(cr.Status.Conditions, string(v1.ConditionTypeReplicaStartupSucceeded))
+				return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == string(v1.ConditionReasonReplicaError)
+			}).WithPolling(pollingInterval).WithTimeout(time.Minute).Should(BeTrue())
+
+			cr.Spec.ContainerTemplate.Image = v1.ContainerImage{
+				Tag: ClickHouseBaseVersion,
+			}
+			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, true)
+			ClickHouseRWChecks(ctx, &cr, new(0))
 		})
 	})
 
@@ -854,7 +890,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				"0": 20,
 				"1": 25,
 			})
-		}, "10s").Should(BeEmpty())
+		}, "10s").WithPolling(pollingInterval).Should(BeEmpty())
 	})
 })
 
@@ -888,7 +924,7 @@ func WaitClickHouseUpdatedAndReady(
 		}
 
 		return true
-	}, timeout).Should(BeTrue())
+	}, timeout).WithPolling(pollingInterval).Should(BeTrue())
 	// Needed for replica deletion to not forward deleting pods.
 	By(fmt.Sprintf("waiting for cluster %s replicas count match", cr.Name))
 	count := int(cr.Replicas() * cr.Shards())
@@ -906,7 +942,7 @@ func WaitClickHouseUpdatedAndReady(
 		}
 
 		return true
-	}).Should(BeTrue())
+	}).WithPolling(pollingInterval).Should(BeTrue())
 }
 
 func ClickHouseRWChecks(ctx context.Context, cr *v1.ClickHouseCluster, checksDone *int, auth ...clickhouse.Auth) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -32,8 +32,9 @@ import (
 )
 
 const (
-	namespace     = "clickhouse-operator-system"
-	testNamespace = "clickhouse-operator-test"
+	namespace       = "clickhouse-operator-system"
+	testNamespace   = "clickhouse-operator-test"
+	pollingInterval = time.Millisecond * 100
 )
 
 var (

--- a/test/e2e/keeper_e2e_test.go
+++ b/test/e2e/keeper_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -250,6 +251,36 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 		By("verifying keeper is functional with basic read/write")
 		KeeperRWChecks(ctx, &cr, ptr.To(0))
 	})
+
+	It("should recreate stuck pods", func(ctx context.Context) {
+		cr := v1.KeeperCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testNamespace,
+				Name:      fmt.Sprintf("stuck-pod-%d", rand.Uint32()), //nolint:gosec
+			},
+			Spec: v1.KeeperClusterSpec{
+				Replicas: new(int32(1)),
+				ContainerTemplate: v1.ContainerTemplateSpec{
+					Image: v1.ContainerImage{
+						Repository: "invalid",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, &cr)).To(Succeed())
+		Eventually(func() bool {
+			Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+			cond := meta.FindStatusCondition(cr.Status.Conditions, string(v1.ConditionTypeReplicaStartupSucceeded))
+			return cond != nil && cond.Status == metav1.ConditionFalse && cond.Reason == string(v1.ConditionReasonReplicaError)
+		}).WithPolling(pollingInterval).WithTimeout(time.Minute).Should(BeTrue())
+
+		cr.Spec.ContainerTemplate.Image = v1.ContainerImage{
+			Tag: KeeperBaseVersion,
+		}
+		Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
+		WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, true)
+		KeeperRWChecks(ctx, &cr, ptr.To(0))
+	})
 })
 
 func WaitKeeperUpdatedAndReady(ctx context.Context, cr *v1.KeeperCluster, timeout time.Duration, isUpdate bool) {
@@ -278,7 +309,7 @@ func WaitKeeperUpdatedAndReady(ctx context.Context, cr *v1.KeeperCluster, timeou
 		}
 
 		return true
-	}, timeout).Should(BeTrue())
+	}, timeout).WithPolling(pollingInterval).Should(BeTrue())
 	// Needed for replica deletion to not forward deleting pods.
 	By(fmt.Sprintf("waiting for cluster %s replicas count match", cr.Name))
 	count := int(cr.Replicas())


### PR DESCRIPTION
## Why

With some errors STS controller won't recreate the Pod even after changes.
If the container fails to start up, it is safe to delete and let the STS controller recreate it with a new template.

## What

Unified replica STS/Configmap/PVC update logic for keeper/ch, added stuck Pod deletion.
To speed up reconciliation, added timeouts on replica requests and skipped replica requests if they have not responded on ping.
