### PR TITLE
feat: Add version upgrade availability checks

### DIFF
--- a/Dockerfile.tilt
+++ b/Dockerfile.tilt
@@ -1,3 +1,5 @@
 FROM ubuntu:latest
 
+RUN apt-get update && apt-get install -y ca-certificates
+
 ADD bin/manager_linux /manager

--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -72,6 +72,12 @@ type ClickHouseClusterSpec struct {
 	// +optional
 	// +kubebuilder:default:="cluster.local"
 	ClusterDomain string `json:"clusterDomain,omitempty"`
+
+	// UpgradeChannel specifies the release channel for major version upgrade checks.
+	// When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8).
+	// +optional
+	// +kubebuilder:validation:Pattern=`^(lts|stable|\d+\.\d+)?$`
+	UpgradeChannel string `json:"upgradeChannel,omitempty"`
 }
 
 // WithDefaults sets default values for ClickHouseClusterSpec fields.

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -45,6 +45,14 @@ const (
 	ConditionReasonVersionPending     ConditionReason = "VersionPending"
 	ConditionReasonVersionProbeFailed ConditionReason = "VersionProbeFailed"
 
+	// ConditionTypeVersionUpgraded indicates whether latest version within upgrade channel selected.
+	ConditionTypeVersionUpgraded        ConditionType   = "VersionUpgraded"
+	ConditionReasonWrongReleaseChannel  ConditionReason = "WrongReleaseChannel"
+	ConditionReasonMinorUpdateAvailable ConditionReason = "MinorUpdateAvailable"
+	ConditionReasonMajorUpdateAvailable ConditionReason = "MajorUpdateAvailable"
+	ConditionReasonVersionOutdated      ConditionReason = "VersionOutdated"
+	ConditionReasonUpgradeCheckFailed   ConditionReason = "UpgradeCheckFailed"
+
 	// ConditionTypeReady indicates that cluster is ready to serve client requests.
 	ConditionTypeReady                      ConditionType   = "Ready"
 	ClickHouseConditionAllShardsReady       ConditionReason = "AllShardsReady"
@@ -91,6 +99,7 @@ var (
 		ConditionTypeClusterSizeAligned,
 		ConditionTypeConfigurationInSync,
 		ConditionTypeVersionInSync,
+		ConditionTypeVersionUpgraded,
 		ConditionTypeReady,
 		ClickHouseConditionTypeSchemaInSync,
 	}
@@ -104,6 +113,7 @@ var (
 		ConditionTypeClusterSizeAligned,
 		ConditionTypeConfigurationInSync,
 		ConditionTypeVersionInSync,
+		ConditionTypeVersionUpgraded,
 		ConditionTypeReady,
 		KeeperConditionTypeScaleAllowed,
 	}

--- a/api/v1alpha1/events.go
+++ b/api/v1alpha1/events.go
@@ -29,6 +29,7 @@ const (
 const (
 	EventReasonVersionDiverge     EventReason = "VersionDiverge"
 	EventReasonVersionProbeFailed EventReason = "VersionProbeFailed"
+	EventReasonUpgradeAvailable   EventReason = "VersionUpgradeAvailable"
 )
 
 // EventAction represents the action associated with an event.

--- a/api/v1alpha1/keepercluster_types.go
+++ b/api/v1alpha1/keepercluster_types.go
@@ -59,6 +59,12 @@ type KeeperClusterSpec struct {
 	// +optional
 	// +kubebuilder:default:="cluster.local"
 	ClusterDomain string `json:"clusterDomain,omitempty"`
+
+	// UpgradeChannel specifies the release channel for major version upgrade checks.
+	// When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8).
+	// +optional
+	// +kubebuilder:validation:Pattern=`^(lts|stable|\d+\.\d+)?$`
+	UpgradeChannel string `json:"upgradeChannel,omitempty"`
 }
 
 // WithDefaults sets default values for KeeperClusterSpec fields.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,12 +6,14 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	clickhousecomv1alpha1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
 	"github.com/ClickHouse/clickhouse-operator/internal/controller/clickhouse"
 	"github.com/ClickHouse/clickhouse-operator/internal/controller/keeper"
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
 	"github.com/ClickHouse/clickhouse-operator/internal/environment"
+	"github.com/ClickHouse/clickhouse-operator/internal/upgrade"
 	"github.com/ClickHouse/clickhouse-operator/internal/version"
 	whchv1 "github.com/ClickHouse/clickhouse-operator/internal/webhook/v1alpha1"
 
@@ -30,6 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+const (
+	defaultVersionUpdateInterval = 24 * time.Hour
 )
 
 var (
@@ -60,6 +66,8 @@ func run() error {
 		secureMetrics                                    bool
 		enableHTTP2                                      bool
 		tlsOpts                                          []func(*tls.Config)
+		versionUpdateInterval                            time.Duration
+		disableVersionUpdateChecks                       bool
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
@@ -78,7 +86,11 @@ func run() error {
 	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
-		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+		"If set, HTTP/2 will be enabled for the metrics and webhook servers.")
+	flag.DurationVar(&versionUpdateInterval, "version-update-interval", defaultVersionUpdateInterval,
+		"Interval for updating ClickHouse versions list.")
+	flag.BoolVar(&disableVersionUpdateChecks, "disable-version-update-checks", false,
+		"If set, the operator will not check for ClickHouse updates and notify about outdated versions.")
 
 	opts := zap.Options{
 		Development: true,
@@ -173,11 +185,21 @@ func run() error {
 
 	zapLogger := controllerutil.NewLogger(logger)
 
-	if err = keeper.SetupWithManager(mgr, zapLogger); err != nil {
+	var upgradeChecker *upgrade.Checker
+	if !disableVersionUpdateChecks {
+		updater := upgrade.NewReleaseUpdater(upgrade.NewURLFetcher(), versionUpdateInterval, zapLogger)
+		if err = mgr.Add(updater); err != nil {
+			return fmt.Errorf("unable to add release updater to manager: %w", err)
+		}
+
+		upgradeChecker = upgrade.NewChecker(updater)
+	}
+
+	if err = keeper.SetupWithManager(mgr, zapLogger, upgradeChecker); err != nil {
 		return fmt.Errorf("unable to setup KeeperCluster controller: %w", err)
 	}
 
-	if err = clickhouse.SetupWithManager(mgr, zapLogger); err != nil {
+	if err = clickhouse.SetupWithManager(mgr, zapLogger, upgradeChecker); err != nil {
 		return fmt.Errorf("unable to setup ClickHouseCluster controller: %w", err)
 	}
 

--- a/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
+++ b/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
@@ -4363,6 +4363,12 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              upgradeChannel:
+                description: |-
+                  UpgradeChannel specifies the release channel for major version upgrade checks.
+                  When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8).
+                pattern: ^(lts|stable|\d+\.\d+)?$
+                type: string
             required:
             - keeperClusterRef
             type: object

--- a/config/crd/bases/clickhouse.com_keeperclusters.yaml
+++ b/config/crd/bases/clickhouse.com_keeperclusters.yaml
@@ -4298,6 +4298,12 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                 type: object
+              upgradeChannel:
+                description: |-
+                  UpgradeChannel specifies the release channel for major version upgrade checks.
+                  When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8).
+                pattern: ^(lts|stable|\d+\.\d+)?$
+                type: string
             type: object
           status:
             description: KeeperClusterStatus defines the observed state of KeeperCluster.

--- a/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
@@ -4173,6 +4173,12 @@ spec:
                                 format: int32
                                 minimum: 0
                                 type: integer
+                            upgradeChannel:
+                                description: |-
+                                    UpgradeChannel specifies the release channel for major version upgrade checks.
+                                    When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8).
+                                pattern: ^(lts|stable|\d+\.\d+)?$
+                                type: string
                         required:
                             - keeperClusterRef
                         type: object

--- a/dist/chart/templates/crd/keeperclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/keeperclusters.clickhouse.com.yaml
@@ -4116,6 +4116,12 @@ spec:
                                                 x-kubernetes-map-type: atomic
                                         type: object
                                 type: object
+                            upgradeChannel:
+                                description: |-
+                                    UpgradeChannel specifies the release channel for major version upgrade checks.
+                                    When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8).
+                                pattern: ^(lts|stable|\d+\.\d+)?$
+                                type: string
                         type: object
                     status:
                         description: KeeperClusterStatus defines the observed state of KeeperCluster.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -56,6 +56,7 @@ ClickHouseClusterSpec defines the desired state of ClickHouseCluster.
 | `podDisruptionBudget` | [PodDisruptionBudgetSpec](#poddisruptionbudgetspec) | PodDisruptionBudget configures the PDB created for each shard.<br />When unset, the operator defaults to maxUnavailable=1 for single-replica<br />shards and minAvailable=1 for multi-replica shards. | false |  |
 | `settings` | [ClickHouseSettings](#clickhousesettings) | Configuration parameters for ClickHouse server. | false |  |
 | `clusterDomain` | string | ClusterDomain is the Kubernetes cluster domain suffix used for DNS resolution. | false | cluster.local |
+| `upgradeChannel` | string | UpgradeChannel specifies the release channel for major version upgrade checks.<br />When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8). | false |  |
 
 Appears in:
 - [ClickHouseCluster](#clickhousecluster)
@@ -226,6 +227,7 @@ KeeperClusterSpec defines the desired state of KeeperCluster.
 | `podDisruptionBudget` | [PodDisruptionBudgetSpec](#poddisruptionbudgetspec) | PodDisruptionBudget configures the PDB created for the Keeper cluster.<br />When unset, the operator defaults to maxUnavailable=replicas/2<br />(preserving quorum for a 2F+1 cluster). | false |  |
 | `settings` | [KeeperSettings](#keepersettings) | Configuration parameters for ClickHouse Keeper server. | false |  |
 | `clusterDomain` | string | ClusterDomain is the Kubernetes cluster domain suffix used for DNS resolution. | false | cluster.local |
+| `upgradeChannel` | string | UpgradeChannel specifies the release channel for major version upgrade checks.<br />When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8). | false |  |
 
 Appears in:
 - [KeeperCluster](#keepercluster)

--- a/docs/styles/config/vocabularies/ClickHouse/accept.txt
+++ b/docs/styles/config/vocabularies/ClickHouse/accept.txt
@@ -14,3 +14,4 @@ CABundle
 Env
 ANDed
 boolean
+lts

--- a/internal/controller/clickhouse/controller.go
+++ b/internal/controller/clickhouse/controller.go
@@ -24,6 +24,7 @@ import (
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
 	chctrl "github.com/ClickHouse/clickhouse-operator/internal/controller"
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+	"github.com/ClickHouse/clickhouse-operator/internal/upgrade"
 	webhookv1 "github.com/ClickHouse/clickhouse-operator/internal/webhook/v1alpha1"
 )
 
@@ -35,6 +36,7 @@ type ClusterController struct {
 	Recorder events.EventRecorder
 	Logger   controllerutil.Logger
 	Webhook  webhookv1.ClickHouseClusterWebhook
+	Checker  *upgrade.Checker
 }
 
 // +kubebuilder:rbac:groups=clickhouse.com,resources=clickhouseclusters,verbs=get;list;watch;create;update;patch;delete
@@ -122,8 +124,13 @@ func (cc *ClusterController) GetRecorder() events.EventRecorder {
 	return cc.Recorder
 }
 
+// GetVersionChecker returns the version upgrade Checker.
+func (cc *ClusterController) GetVersionChecker() *upgrade.Checker {
+	return cc.Checker
+}
+
 // SetupWithManager sets up the controller with the Manager.
-func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger) error {
+func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker) error {
 	namedLogger := log.Named("clickhouse")
 
 	clickhouseController := &ClusterController{
@@ -132,6 +139,7 @@ func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger) error {
 		Recorder: mgr.GetEventRecorder("clickhouse-controller"),
 		Logger:   namedLogger,
 		Webhook:  webhookv1.ClickHouseClusterWebhook{Log: namedLogger},
+		Checker:  checker,
 	}
 
 	err := ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -729,6 +729,10 @@ func (r *clickhouseReconciler) reconcileConditions(ctx context.Context, log ctrl
 		return nil, fmt.Errorf("update VersionSync condition: %w", err)
 	}
 
+	if err := r.UpdateUpgradeCondition(ctx, log, r.versionProbe, r.Cluster.Spec.UpgradeChannel); err != nil {
+		return nil, fmt.Errorf("update VersionUpgraded condition: %w", err)
+	}
+
 	exists := len(r.ReplicaState)
 	expected := int(r.Cluster.Replicas() * r.Cluster.Shards())
 

--- a/internal/controller/keeper/controller.go
+++ b/internal/controller/keeper/controller.go
@@ -21,6 +21,7 @@ import (
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
 	chctrl "github.com/ClickHouse/clickhouse-operator/internal/controller"
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+	"github.com/ClickHouse/clickhouse-operator/internal/upgrade"
 	webhookv1 "github.com/ClickHouse/clickhouse-operator/internal/webhook/v1alpha1"
 )
 
@@ -32,6 +33,7 @@ type ClusterController struct {
 	Recorder events.EventRecorder
 	Logger   controllerutil.Logger
 	Webhook  webhookv1.KeeperClusterWebhook
+	Checker  *upgrade.Checker
 }
 
 // +kubebuilder:rbac:groups=clickhouse.com,resources=keeperclusters,verbs=get;list;watch;create;update;patch;delete
@@ -120,8 +122,13 @@ func (cc *ClusterController) GetRecorder() events.EventRecorder {
 	return cc.Recorder
 }
 
+// GetVersionChecker returns the version upgrade Checker.
+func (cc *ClusterController) GetVersionChecker() *upgrade.Checker {
+	return cc.Checker
+}
+
 // SetupWithManager sets up the controller with the Manager.
-func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger) error {
+func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker) error {
 	namedLogger := log.Named("keeper")
 
 	keeperController := &ClusterController{
@@ -130,6 +137,7 @@ func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger) error {
 		Recorder: mgr.GetEventRecorder("keeper-controller"),
 		Logger:   namedLogger,
 		Webhook:  webhookv1.KeeperClusterWebhook{Log: namedLogger},
+		Checker:  checker,
 	}
 
 	err := ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -149,6 +149,7 @@ func (r *keeperReconciler) sync(ctx context.Context, log ctrlutil.Logger) (ctrl.
 				r.NewCondition(v1.ConditionTypeReplicaStartupSucceeded, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 				r.NewCondition(v1.ConditionTypeConfigurationInSync, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 				r.NewCondition(v1.ConditionTypeVersionInSync, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
+				r.NewCondition(v1.ConditionTypeVersionUpgraded, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 				r.NewCondition(v1.ConditionTypeClusterSizeAligned, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 				r.NewCondition(v1.KeeperConditionTypeScaleAllowed, metav1.ConditionUnknown, v1.ConditionReasonStepFailed, errMsg),
 			})
@@ -641,6 +642,10 @@ func (r *keeperReconciler) reconcileConditions(ctx context.Context, log ctrlutil
 
 	if err := r.UpdateVersionSyncCondition(ctx, log, r.versionProbe, replicaVersions, len(notUpdatedReplicas) > 0); err != nil {
 		return nil, fmt.Errorf("update VersionSync condition: %w", err)
+	}
+
+	if err := r.UpdateUpgradeCondition(ctx, log, r.versionProbe, r.Cluster.Spec.UpgradeChannel); err != nil {
+		return nil, fmt.Errorf("update VersionUpgraded condition: %w", err)
 	}
 
 	exists := len(r.ReplicaState)

--- a/internal/controller/reconcilerbase.go
+++ b/internal/controller/reconcilerbase.go
@@ -6,6 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ClickHouse/clickhouse-operator/internal/upgrade"
 )
 
 type clusterObject[Status any] interface {
@@ -26,6 +28,7 @@ type controller interface {
 	GetClient() client.Client
 	GetScheme() *k8sruntime.Scheme
 	GetRecorder() events.EventRecorder
+	GetVersionChecker() *upgrade.Checker
 }
 
 // ResourceReconcilerBase provides a base class for cluster reconcilers.

--- a/internal/controller/upgradecheck.go
+++ b/internal/controller/upgradecheck.go
@@ -1,0 +1,79 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+// UpdateUpgradeCondition checks for available upgrades and sets the VersionUpgraded condition.
+func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) UpdateUpgradeCondition(
+	ctx context.Context,
+	log controllerutil.Logger,
+	probe VersionProbeResult,
+	upgradeChannel string,
+) error {
+	if r.GetVersionChecker() == nil {
+		meta.RemoveStatusCondition(r.Cluster.Conditions(), string(v1.ConditionTypeVersionUpgraded))
+		return nil
+	}
+
+	if probe.Pending {
+		r.SetCondition(log, r.NewCondition(v1.ConditionTypeVersionUpgraded, metav1.ConditionUnknown, v1.ConditionReasonVersionPending, "Version probe has not completed yet"))
+		return nil
+	}
+
+	if probe.Err != nil {
+		r.SetCondition(log, r.NewCondition(v1.ConditionTypeVersionUpgraded, metav1.ConditionUnknown, v1.ConditionReasonVersionProbeFailed, "Version probe failed"))
+		return nil //nolint:nilerr
+	}
+
+	result, err := r.GetVersionChecker().CheckUpdates(probe.Version, upgradeChannel)
+	if err != nil {
+		r.SetCondition(log, r.NewCondition(v1.ConditionTypeVersionUpgraded, metav1.ConditionUnknown, v1.ConditionReasonUpgradeCheckFailed, fmt.Sprintf("Upgrade check failed: %v", err)))
+		return nil
+	}
+
+	var (
+		reason  v1.ConditionReason
+		message string
+	)
+
+	switch {
+	case !result.OnChannel:
+		reason = v1.ConditionReasonWrongReleaseChannel
+		message = "Current version is not in the selected upgrade channel"
+	case result.MinorUpdate != nil:
+		reason = v1.ConditionReasonMinorUpdateAvailable
+		message = "Minor upgrade available: " + result.MinorUpdate.Version()
+	case len(result.MajorUpdates) > 0:
+		versions := make([]string, len(result.MajorUpdates))
+		for i, v := range result.MajorUpdates {
+			versions[i] = v.Version()
+		}
+
+		reason = v1.ConditionReasonMajorUpdateAvailable
+		message = "Major upgrades available: " + strings.Join(versions, ", ")
+
+	case result.Outdated:
+		reason = v1.ConditionReasonVersionOutdated
+		message = "Current version " + probe.Version + " is out of support"
+	default:
+		r.SetCondition(log, r.NewCondition(v1.ConditionTypeVersionUpgraded, metav1.ConditionTrue, v1.ConditionReasonUpToDate, ""))
+		return nil
+	}
+
+	cond := r.NewCondition(v1.ConditionTypeVersionUpgraded, metav1.ConditionFalse, reason, message)
+	if _, err = r.UpsertConditionAndSendEvent(ctx, log, cond, corev1.EventTypeWarning, v1.EventReasonUpgradeAvailable, v1.EventActionVersionCheck, cond.Message); err != nil {
+		return fmt.Errorf("update VersionUpgraded condition: %w", err)
+	}
+
+	return nil
+}

--- a/internal/upgrade/checker.go
+++ b/internal/upgrade/checker.go
@@ -1,0 +1,300 @@
+package upgrade
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+)
+
+const (
+	versionRegexpRaw     = `^v?(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Patch>\d+)(\.(?P<Build>\d+))?-(?P<Channel>\w+)$`
+	bareVersionRegexpRaw = `^(?P<Major>\d+)\.(?P<Minor>\d+)\.(?P<Patch>\d+)(\.(?P<Build>\d+))?$`
+	channelStable        = "stable"
+	channelLTS           = "lts"
+	stableReleases       = 3
+	ltsReleases          = 2
+)
+
+var (
+	versionRegexp = regexp.MustCompile(versionRegexpRaw)
+	majorIndex    = versionRegexp.SubexpIndex("Major")
+	minorIndex    = versionRegexp.SubexpIndex("Minor")
+	patchIndex    = versionRegexp.SubexpIndex("Patch")
+	buildIndex    = versionRegexp.SubexpIndex("Build")
+	channelIndex  = versionRegexp.SubexpIndex("Channel")
+
+	bareVersionRegexp = regexp.MustCompile(bareVersionRegexpRaw)
+	bareMajorIndex    = bareVersionRegexp.SubexpIndex("Major")
+	bareMinorIndex    = bareVersionRegexp.SubexpIndex("Minor")
+	barePatchIndex    = bareVersionRegexp.SubexpIndex("Patch")
+	bareBuildIndex    = bareVersionRegexp.SubexpIndex("Build")
+)
+
+// ClickHouseRelease represents a ClickHouse release, identified by its year and month of release (e.g. 26.1).
+type ClickHouseRelease struct {
+	Major int32
+	Minor int32
+}
+
+// ClickHouseVersion represents a ClickHouse version.
+type ClickHouseVersion struct {
+	// Major is release year (the first component of the version string).
+	Major int32
+	// Minor is the release month within the year (the second component of the version string).
+	Minor int32
+	// Patch is the patch version number (the third component of the version string).
+	Patch int32
+	// Build is the build number (the fourth component of the version string, optional).
+	Build int32
+}
+
+// Version returns the string representation of the ClickHouse version.
+func (ch ClickHouseVersion) Version() string {
+	if ch.Build == 0 {
+		return fmt.Sprintf("%d.%d.%d", ch.Major, ch.Minor, ch.Patch)
+	}
+
+	return fmt.Sprintf("%d.%d.%d.%d", ch.Major, ch.Minor, ch.Patch, ch.Build)
+}
+
+// Release returns the ClickHouseRelease corresponding to the major and minor version of the ClickHouseVersion.
+func (ch ClickHouseVersion) Release() ClickHouseRelease {
+	return ClickHouseRelease{
+		Major: ch.Major,
+		Minor: ch.Minor,
+	}
+}
+
+func compareVersions(a, b ClickHouseVersion) int {
+	if c := cmp.Compare(a.Major, b.Major); c != 0 {
+		return c
+	}
+
+	if c := cmp.Compare(a.Minor, b.Minor); c != 0 {
+		return c
+	}
+
+	if c := cmp.Compare(a.Patch, b.Patch); c != 0 {
+		return c
+	}
+
+	return cmp.Compare(a.Build, b.Build)
+}
+
+// ParseVersion parses a raw version string into a ClickHouseVersion struct.
+func ParseVersion(raw string) (ClickHouseVersion, string, error) {
+	submatches := versionRegexp.FindStringSubmatch(raw)
+	if submatches == nil {
+		return ClickHouseVersion{}, "", fmt.Errorf("invalid version format: %s", raw)
+	}
+
+	var (
+		channel = submatches[channelIndex]
+	)
+
+	major, err := strconv.ParseInt(submatches[majorIndex], 10, 32)
+	if err != nil {
+		return ClickHouseVersion{}, "", fmt.Errorf("parse major version: %w", err)
+	}
+
+	minor, err := strconv.ParseInt(submatches[minorIndex], 10, 32)
+	if err != nil {
+		return ClickHouseVersion{}, "", fmt.Errorf("parse minor version: %w", err)
+	}
+
+	patch, err := strconv.ParseInt(submatches[patchIndex], 10, 32)
+	if err != nil {
+		return ClickHouseVersion{}, "", fmt.Errorf("parse patch version: %w", err)
+	}
+
+	var build int32
+	if submatches[buildIndex] != "" {
+		buildTmp, err := strconv.ParseInt(submatches[buildIndex], 10, 32)
+		if err != nil {
+			return ClickHouseVersion{}, "", fmt.Errorf("parse build version: %w", err)
+		}
+
+		build = int32(buildTmp)
+	}
+
+	return ClickHouseVersion{
+		Major: int32(major),
+		Minor: int32(minor),
+		Patch: int32(patch),
+		Build: build,
+	}, channel, nil
+}
+
+// ParseBareVersion parses a bare numeric version string (e.g. "25.8.2.1") without a channel suffix.
+// This is used for version strings returned by the version probe.
+func ParseBareVersion(raw string) (ClickHouseVersion, error) {
+	submatches := bareVersionRegexp.FindStringSubmatch(raw)
+	if submatches == nil {
+		return ClickHouseVersion{}, fmt.Errorf("invalid bare version format: %s", raw)
+	}
+
+	major, err := strconv.ParseInt(submatches[bareMajorIndex], 10, 32)
+	if err != nil {
+		return ClickHouseVersion{}, fmt.Errorf("parse major version: %w", err)
+	}
+
+	minor, err := strconv.ParseInt(submatches[bareMinorIndex], 10, 32)
+	if err != nil {
+		return ClickHouseVersion{}, fmt.Errorf("parse minor version: %w", err)
+	}
+
+	patch, err := strconv.ParseInt(submatches[barePatchIndex], 10, 32)
+	if err != nil {
+		return ClickHouseVersion{}, fmt.Errorf("parse patch version: %w", err)
+	}
+
+	var build int32
+	if submatches[bareBuildIndex] != "" {
+		buildTmp, err := strconv.ParseInt(submatches[bareBuildIndex], 10, 32)
+		if err != nil {
+			return ClickHouseVersion{}, fmt.Errorf("parse build version: %w", err)
+		}
+
+		build = int32(buildTmp)
+	}
+
+	return ClickHouseVersion{
+		Major: int32(major),
+		Minor: int32(minor),
+		Patch: int32(patch),
+		Build: build,
+	}, nil
+}
+
+// Checker is responsible for checking for available upgrades.
+type Checker struct {
+	updater *ReleaseUpdater
+}
+
+// NewChecker creates a new Checker.
+func NewChecker(updater *ReleaseUpdater) *Checker {
+	return &Checker{updater: updater}
+}
+
+// CheckResult represents the result of checking for updates.
+type CheckResult struct {
+	// MinorUpdate contains the latest minor upgrade if exists.
+	MinorUpdate *ClickHouseVersion
+	// MajorUpdates contains latest minor upgrades from each major release after current. Within selected channel.
+	MajorUpdates []ClickHouseVersion
+	// Outdated is true if current release is out of support.
+	Outdated bool
+	// OnChannel is true if current release belongs to selected channel.
+	OnChannel bool
+}
+
+// CheckUpdates returns a list of ClickHouse versions that are newer than the current version and belong to the specified channel.
+func (t *Checker) CheckUpdates(currentRaw string, channel string) (CheckResult, error) {
+	current, err := ParseBareVersion(currentRaw)
+	if err != nil {
+		return CheckResult{}, fmt.Errorf("parse current version: %w", err)
+	}
+
+	releases := t.updater.GetReleasesData()
+	if releases == nil {
+		return CheckResult{}, errors.New("no release data loaded")
+	}
+
+	result := CheckResult{
+		MajorUpdates: getMajorUpdates(releases, current, channel),
+		Outdated:     !releases.Supported[current.Release()],
+	}
+
+	if minorUpdate, hasUpdate := getMinorUpdate(releases, current); hasUpdate {
+		result.MinorUpdate = &minorUpdate
+	}
+
+	onChannel, err := isOnChannel(releases, current.Release(), channel)
+	if err != nil {
+		return CheckResult{}, err
+	}
+
+	result.OnChannel = onChannel
+
+	return result, nil
+}
+
+// getMinorUpdate returns the latest minor upgrade for the current release if exists.
+func getMinorUpdate(releases *ReleaseData, current ClickHouseVersion) (ClickHouseVersion, bool) {
+	for _, vers := range releases.Releases {
+		if latest, ok := vers[current.Release()]; ok {
+			if compareVersions(latest, current) > 0 {
+				return latest, true
+			}
+		}
+	}
+
+	return current, false
+}
+
+// getMajorUpdates returns all latest versions of supported major releases newer than current. Within selected channel.
+func getMajorUpdates(releases *ReleaseData, current ClickHouseVersion, channel string) []ClickHouseVersion {
+	// No major updates for specific release channel (e.g. 26.1) or empty channel.
+	if channel != channelStable && channel != channelLTS {
+		return nil
+	}
+
+	var majorUpdates []ClickHouseVersion
+
+	findUpgrades := func(c string) {
+		for release, version := range releases.Releases[c] {
+			if release == current.Release() {
+				continue
+			}
+
+			if !releases.Supported[release] {
+				continue
+			}
+
+			if compareVersions(version, current) > 0 {
+				majorUpdates = append(majorUpdates, version)
+			}
+		}
+	}
+
+	// lts releases considered stable, but has distinct versions, check for newer versions in lts channel as well
+	findUpgrades(channelLTS)
+
+	if channel == channelStable {
+		findUpgrades(channelStable)
+	}
+
+	slices.SortFunc(majorUpdates, compareVersions)
+
+	return majorUpdates
+}
+
+// isOnChannel checks if the given release belongs to the specified channel.
+func isOnChannel(releases *ReleaseData, release ClickHouseRelease, channel string) (bool, error) {
+	switch channel {
+	case "":
+		return true, nil
+	case channelStable:
+		if _, ok := releases.Releases[channelStable][release]; ok {
+			return true, nil
+		}
+		fallthrough // lts releases considered stable, but has distinct versions, check lts versions as well
+
+	case channelLTS:
+		if _, ok := releases.Releases[channelLTS][release]; ok {
+			return true, nil
+		}
+		return false, nil
+
+	default:
+		var channelBase ClickHouseRelease
+		if _, err := fmt.Sscanf(channel, "%d.%d", &channelBase.Major, &channelBase.Minor); err != nil {
+			return false, fmt.Errorf("parse release channel: %w", err)
+		}
+
+		return release == channelBase, nil
+	}
+}

--- a/internal/upgrade/fetcher.go
+++ b/internal/upgrade/fetcher.go
@@ -1,0 +1,262 @@
+package upgrade
+
+import (
+	"cmp"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"slices"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+	"github.com/ClickHouse/clickhouse-operator/internal/version"
+)
+
+const (
+	defaultRequestTimeout = 5 * time.Second
+	defaultVersionsURL    = "https://clickhouse.com/data/version_date.tsv"
+
+	backoffSteps  = 10
+	backoffFactor = 2.0
+	backoffJitter = 0.2
+)
+
+var (
+	updateRetryBackoff = wait.Backoff{
+		Steps:    backoffSteps,
+		Duration: time.Second,
+		Factor:   backoffFactor,
+		Jitter:   backoffJitter,
+	}
+)
+
+// Fetcher is an interface for fetching ClickHouse releases from a source.
+type Fetcher interface {
+	FetchReleases(ctx context.Context) (map[string][]ClickHouseVersion, error)
+}
+
+// StaticFetcher is a simple implementation of Fetcher that returns a predefined list of releases.
+// Used for testing.
+type StaticFetcher struct {
+	Releases map[string][]ClickHouseVersion
+}
+
+var _ Fetcher = (*StaticFetcher)(nil)
+
+// FetchReleases returns the predefined list of releases.
+func (s *StaticFetcher) FetchReleases(context.Context) (map[string][]ClickHouseVersion, error) {
+	return s.Releases, nil
+}
+
+// URLFetcher is an implementation of Fetcher that fetches ClickHouse releases from a URL in TSV format.
+type URLFetcher struct {
+	RequestTimeout time.Duration
+	HTTPClient     *http.Client
+	VersionsURL    string
+}
+
+var _ Fetcher = (*URLFetcher)(nil)
+
+// NewURLFetcher creates a new URLFetcher.
+func NewURLFetcher() *URLFetcher {
+	return &URLFetcher{
+		RequestTimeout: defaultRequestTimeout,
+		HTTPClient:     &http.Client{},
+		VersionsURL:    defaultVersionsURL,
+	}
+}
+
+// FetchReleases queries the list of ClickHouse releases.
+func (f *URLFetcher) FetchReleases(ctx context.Context) (map[string][]ClickHouseVersion, error) {
+	ctx, cancel := context.WithTimeout(ctx, f.RequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, f.VersionsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create versions request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", version.BuildUserAgent())
+
+	resp, err := f.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request version from URL: %w", err)
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
+	}
+
+	return parseVersions(resp.Body)
+}
+
+type releaseMap map[string]map[ClickHouseRelease]ClickHouseVersion
+
+// ReleaseData contains preprocessed release data: all versions by channel and supported releases.
+type ReleaseData struct {
+	// Releases maps channel to a map from release to the latest minor version.
+	Releases releaseMap
+	// Supported contains the map of supported major releases.
+	Supported map[ClickHouseRelease]bool
+}
+
+// ReleaseUpdater periodically fetches and updates ClickHouse release data,
+// maintaining a cache of the latest preprocessed information.
+type ReleaseUpdater struct {
+	fetcher  Fetcher
+	interval time.Duration
+	l        controllerutil.Logger
+
+	cached atomic.Pointer[ReleaseData]
+}
+
+var _ manager.Runnable = (*ReleaseUpdater)(nil)
+
+// NewReleaseUpdater creates a new ReleaseUpdater.
+func NewReleaseUpdater(fetcher Fetcher, interval time.Duration, log controllerutil.Logger) *ReleaseUpdater {
+	return &ReleaseUpdater{
+		fetcher:  fetcher,
+		interval: interval,
+		l:        log.Named("release-updater"),
+	}
+}
+
+// GetReleasesData returns the latest cached release data. It may return nil if no data has been fetched yet.
+func (u *ReleaseUpdater) GetReleasesData() *ReleaseData {
+	return u.cached.Load()
+}
+
+// Start the release updater loop, which periodically fetches and updates release data.
+// Blocks until the context is canceled. It implements the manager.Runnable interface.
+func (u *ReleaseUpdater) Start(ctx context.Context) error {
+	u.l.Info("Starting release updater loop")
+
+	backoff := updateRetryBackoff
+	updateTimer := time.After(0) // trigger immediate update on start
+
+	for {
+		select {
+		case <-ctx.Done():
+			u.l.Info("Release updater stopped")
+			return nil
+		case <-updateTimer:
+			if u.updateReleases(ctx) {
+				updateTimer = time.After(u.interval)
+				backoff = updateRetryBackoff // reset backoff on success
+				continue
+			}
+
+			step := backoff.Step()
+			u.l.Info("Scheduling next update attempt", "backoff", step)
+			updateTimer = time.After(step)
+		}
+	}
+}
+
+func (u *ReleaseUpdater) updateReleases(ctx context.Context) bool {
+	u.l.Debug("updating releases list")
+
+	allReleases, err := u.fetcher.FetchReleases(ctx)
+	if err != nil {
+		u.l.Error(err, "fetch releases")
+		return false
+	}
+
+	latestReleases := filterLatestVersions(allReleases)
+	supported := buildSupportedMap(latestReleases)
+	u.cached.Store(&ReleaseData{
+		Releases:  latestReleases,
+		Supported: supported,
+	})
+
+	return true
+}
+
+func filterLatestVersions(versions map[string][]ClickHouseVersion) releaseMap {
+	latest := map[string]map[ClickHouseRelease]ClickHouseVersion{}
+	for channel, vers := range versions {
+		latest[channel] = map[ClickHouseRelease]ClickHouseVersion{}
+		for _, v := range vers {
+			if s, ok := latest[channel][v.Release()]; ok {
+				if compareVersions(s, v) < 0 {
+					latest[channel][v.Release()] = v
+				}
+			} else {
+				latest[channel][v.Release()] = v
+			}
+		}
+	}
+
+	return latest
+}
+
+// buildSupportedMap builds the supported releases map.
+// Should follow the same logic as https://raw.githubusercontent.com/ClickHouse/ClickHouse/master/utils/security-generator/generate_security.py
+func buildSupportedMap(allReleases releaseMap) map[ClickHouseRelease]bool {
+	supported := map[ClickHouseRelease]bool{}
+	for channel, maxReleases := range map[string]int{
+		channelStable: stableReleases,
+		channelLTS:    ltsReleases,
+	} {
+		releases := allReleases[channel]
+
+		releasesLeft := maxReleases
+		for _, release := range slices.SortedFunc(maps.Keys(releases), func(i ClickHouseRelease, j ClickHouseRelease) int {
+			if c := cmp.Compare(i.Major, j.Major); c != 0 {
+				return -c
+			}
+			return -cmp.Compare(i.Minor, j.Minor)
+		}) {
+			supported[release] = true
+
+			releasesLeft--
+			if releasesLeft == 0 {
+				break
+			}
+		}
+	}
+
+	return supported
+}
+
+func parseVersions(stream io.Reader) (map[string][]ClickHouseVersion, error) {
+	tsvReader := csv.NewReader(stream)
+	tsvReader.Comma = '\t'
+	tsvReader.FieldsPerRecord = 2
+	tsvReader.ReuseRecord = true
+
+	var (
+		versions  = map[string][]ClickHouseVersion{}
+		tsvRecord []string
+		readErr   error
+	)
+	for tsvRecord, readErr = tsvReader.Read(); readErr == nil; tsvRecord, readErr = tsvReader.Read() {
+		if len(tsvRecord) != 2 {
+			return nil, fmt.Errorf("unexpected field count: expected 2, got %d. data: %v", len(tsvRecord), tsvRecord)
+		}
+
+		chVer, channel, err := ParseVersion(tsvRecord[0])
+		if err != nil {
+			return nil, fmt.Errorf("parse version: %w", err)
+		}
+
+		versions[channel] = append(versions[channel], chVer)
+	}
+
+	if readErr != io.EOF {
+		return nil, fmt.Errorf("parse versions: %w", readErr)
+	}
+
+	return versions, nil
+}

--- a/internal/upgrade/upgrade_test.go
+++ b/internal/upgrade/upgrade_test.go
@@ -1,0 +1,258 @@
+package upgrade
+
+import (
+	"context"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/zapr"
+	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+func TestVersionUpgradeUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Version upgrade utils")
+}
+
+var _ = DescribeTable("Parse version", func(raw string, version ClickHouseVersion, channel string) {
+	parsedVersion, parsedChannel, err := ParseVersion(raw)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(parsedVersion).To(Equal(version))
+	Expect(parsedChannel).To(Equal(channel))
+
+	numericPart := strings.Split(raw, "-")[0][1:]
+	Expect(parsedVersion.Version()).To(Equal(numericPart))
+},
+	Entry("lts version", "v25.8.16.34-lts", ClickHouseVersion{25, 8, 16, 34}, channelLTS),
+	Entry("stable version", "v25.12.5.44-stable", ClickHouseVersion{25, 12, 5, 44}, channelStable),
+	Entry("without build info", "v19.3.6-stable", ClickHouseVersion{19, 3, 6, 0}, channelStable),
+	Entry("before date semantics", "v1.1.54011-stable", ClickHouseVersion{1, 1, 54011, 0}, channelStable),
+)
+
+var _ = DescribeTable("Parse bare version", func(raw string, expected ClickHouseVersion) {
+	parsedVersion, err := ParseBareVersion(raw)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(parsedVersion).To(Equal(expected))
+	Expect(parsedVersion.Version()).To(Equal(raw))
+},
+	Entry("four components", "25.8.2.1", ClickHouseVersion{25, 8, 2, 1}),
+	Entry("three components", "25.8.2", ClickHouseVersion{25, 8, 2, 0}),
+	Entry("large build number", "26.3.1.100", ClickHouseVersion{26, 3, 1, 100}),
+)
+
+var _ = DescribeTable("Parse bare version errors", func(raw string) {
+	_, err := ParseBareVersion(raw)
+	Expect(err).To(HaveOccurred())
+},
+	Entry("with channel suffix", "v25.8.2.1-lts"),
+	Entry("with v prefix", "v25.8.2.1"),
+	Entry("too few components", "25.8"),
+	Entry("empty string", ""),
+)
+
+var _ = Describe("URL version fetcher", func() {
+	const sampleTSV = "v25.8.3.16-lts\t2025-03-01\n" +
+		"v25.8.2.15-lts\t2025-02-15\n" +
+		"v26.1.2.42-stable\t2026-02-01\n" +
+		"v26.2.1.3-stable\t2026-03-01\n"
+
+	It("should parse fetched releases", func(ctx context.Context) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(sampleTSV))
+		}))
+		defer srv.Close()
+
+		fetcher := NewURLFetcher()
+		fetcher.VersionsURL = srv.URL
+
+		releases, err := fetcher.FetchReleases(ctx)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(slices.Collect(maps.Keys(releases))).To(ContainElements(channelLTS, channelStable))
+		Expect(releases[channelLTS]).To(ConsistOf(
+			ClickHouseVersion{25, 8, 3, 16},
+			ClickHouseVersion{25, 8, 2, 15},
+		))
+		Expect(releases[channelStable]).To(ConsistOf(
+			ClickHouseVersion{26, 1, 2, 42},
+			ClickHouseVersion{26, 2, 1, 3},
+		))
+	})
+
+	It("should return error on non-200 status", func(ctx context.Context) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		fetcher := NewURLFetcher()
+		fetcher.VersionsURL = srv.URL
+
+		_, err := fetcher.FetchReleases(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("500"))
+	})
+})
+
+var _ = Describe("Version Checker", func() {
+	fetcher := &StaticFetcher{Releases: map[string][]ClickHouseVersion{
+		channelStable: {
+			{25, 1, 2, 3},
+			{25, 2, 1, 21},
+			{25, 10, 5, 12},
+			{26, 1, 1, 7},
+			{26, 1, 2, 42},
+			{26, 2, 1, 3},
+		},
+		channelLTS: {
+			{25, 3, 4, 11},
+			{25, 8, 1, 5},
+			{25, 8, 2, 15},
+			{25, 8, 3, 16},
+			{26, 3, 1, 1},
+		},
+	}}
+
+	logger := zap.NewRaw(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))
+	logf.SetLogger(zapr.NewLogger(logger))
+	updater := NewReleaseUpdater(fetcher, time.Hour*24, controllerutil.NewLogger(logger))
+	checker := NewChecker(updater)
+
+	BeforeEach(func(ctx context.Context) {
+		// Run update loop for the first test and use cached data for the following.
+		if updater.cached.Load() != nil {
+			return
+		}
+
+		updCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		go func() {
+			defer GinkgoRecover()
+
+			Expect(updater.Start(updCtx)).To(Succeed())
+		}()
+
+		Eventually(updater.GetReleasesData).ShouldNot(BeNil())
+	})
+
+	It("should cache latest supported releases", func() {
+		_, err := checker.CheckUpdates("25.8.2.1", "25.8")
+		Expect(err).ToNot(HaveOccurred())
+
+		data := updater.GetReleasesData()
+		Expect(data).ToNot(BeNil())
+
+		releases := releaseMap{
+			channelStable: {
+				{25, 1}:  {25, 1, 2, 3},
+				{25, 2}:  {25, 2, 1, 21},
+				{25, 10}: {25, 10, 5, 12},
+				{26, 1}:  {26, 1, 2, 42},
+				{26, 2}:  {26, 2, 1, 3},
+			},
+			channelLTS: {
+				{25, 3}: {25, 3, 4, 11},
+				{25, 8}: {25, 8, 3, 16},
+				{26, 3}: {26, 3, 1, 1},
+			},
+		}
+		Expect(data.Releases).To(Equal(releases), "diff:\n"+cmp.Diff(data.Releases, releases))
+
+		supported := map[ClickHouseRelease]bool{
+			{26, 3}:  true,
+			{25, 8}:  true,
+			{26, 2}:  true,
+			{26, 1}:  true,
+			{25, 10}: true,
+		}
+		Expect(data.Supported).To(Equal(supported), "diff:\n"+cmp.Diff(data.Supported, supported))
+	})
+
+	DescribeTable("expected result", func(current string, channel string, expected CheckResult) {
+		result, err := checker.CheckUpdates(current, channel)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(expected), "diff:\n"+cmp.Diff(result, expected))
+	},
+		Entry("minor updates", "25.8.2.1", "25.8",
+			CheckResult{
+				MinorUpdate: &ClickHouseVersion{25, 8, 3, 16},
+				Outdated:    false,
+				OnChannel:   true,
+			},
+		),
+		Entry("minor updates without channel", "25.8.2.1", "",
+			CheckResult{
+				MinorUpdate: &ClickHouseVersion{25, 8, 3, 16},
+				Outdated:    false,
+				OnChannel:   true,
+			},
+		),
+		Entry("stable and lts updates on stable channel", "25.10.5.12", channelStable,
+			CheckResult{
+				MajorUpdates: []ClickHouseVersion{
+					{26, 1, 2, 42},
+					{26, 2, 1, 3},
+					{26, 3, 1, 1},
+				},
+				Outdated:  false,
+				OnChannel: true,
+			},
+		),
+		Entry("lts updates on lts channel", "25.3.4.11", channelLTS,
+			CheckResult{
+				MajorUpdates: []ClickHouseVersion{
+					{25, 8, 3, 16},
+					{26, 3, 1, 1},
+				},
+				Outdated:  true,
+				OnChannel: true,
+			},
+		),
+		Entry("mark old versions outdated", "25.1.2.3", "25.1",
+			CheckResult{
+				Outdated:  true,
+				OnChannel: true,
+			},
+		),
+		Entry("outdated checks without channel", "25.1.2.3", "",
+			CheckResult{
+				Outdated:  true,
+				OnChannel: true,
+			},
+		),
+		Entry("not on lts channel if stable version", "26.1.2.42", channelLTS,
+			CheckResult{
+				MajorUpdates: []ClickHouseVersion{
+					{26, 3, 1, 1},
+				},
+				Outdated:  false,
+				OnChannel: false,
+			},
+		),
+		Entry("on stable channel if lts version", "26.3.1.1", channelStable,
+			CheckResult{
+				Outdated:  false,
+				OnChannel: true,
+			},
+		),
+		Entry("not on release channel if release differs", "26.3.1.1", "26.2",
+			CheckResult{
+				Outdated:  false,
+				OnChannel: false,
+			},
+		),
+	)
+})


### PR DESCRIPTION
## Why

Provide info about the new available releases for the cluster

## What

Added methods to check updates and the new API field UpgradeChannel to choose the upgrade channel to track upgrades on
Updated versions in tests