### PR TITLE
chore: make error and log messages more consistent, use query parameters, bump ch version for tests, pin e2e k8s version, add action linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
 env:
-  kind-version: 'v0.29.0'
+  kind-version: 'v0.31.0'
 permissions:
   contents: read
   statuses: write
@@ -44,6 +44,7 @@ jobs:
             make check-crd-compat CRD_BASE_REF=${{ github.event.before }}
           fi
 
+
       - name: Lint with golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
@@ -53,6 +54,11 @@ jobs:
         uses: codespell-project/actions-codespell@v2.2
         with:
           config: ci/.codespellrc
+
+      - name: actionlint
+        uses: raven-actions/actionlint@v2
+        with:
+          flags: '-config-file ci/actionlint.yaml'
 
   bundle:
     runs-on: ubuntu-latest
@@ -183,20 +189,20 @@ jobs:
           reporter: java-junit
 
   compat-e2e-test:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest]
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: "Minimal supported kubernetes with LTS ClickHouse release"
-            kind_version: v1.28.15
+            k8s_image: v1.28.15
             clickhouse_version: "25.8"
           - name: "Latest kubernetes version with LTS ClickHouse release"
-            kind_version: v1.35.1
+            k8s_image: v1.35.1
             clickhouse_version: "25.8"
           - name: "Supported ClickHouse versions"
-            kind_version: v1.30.13
-            clickhouse_version: "26.1,25.12,25.11,25.8,25.3"
+            k8s_image: v1.30.13
+            clickhouse_version: "26.2,26.1,25.12,25.8,25.3"
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -206,19 +212,19 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Go Mod
-        run: go mod download
-
-      - name: Build image
-        run: make docker-build IMG="clickhouse.com/clickhouse-operator:v0.0.1" BUILD_TIME=e2e
-
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1
         with:
           cluster_name: kind
           version: ${{ env.kind-version }}
           config: ci/kind-cluster.config
-          node_image: "kindest/node:${{ matrix.kind_version }}"
+          node_image: "kindest/node:${{ matrix.k8s_image }}"
+
+      - name: Go Mod
+        run: go mod download
+
+      - name: Build image
+        run: make docker-build IMG="clickhouse.com/clickhouse-operator:v0.0.1" BUILD_TIME=e2e
 
       - name: Run compatibility e2e tests
         run: make test-compat-e2e
@@ -262,6 +268,7 @@ jobs:
           cluster_name: kind
           version: ${{ env.kind-version }}
           config: ci/kind-cluster.config
+          node_image: "kindest/node:v1.34.3" # Can't use newer node image as self-hosted runners use cgroups v1
 
       - name: Run e2e tests
         run:  make ${{ matrix.scope }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set VERSION
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
       - name: Build operator image
         run: make docker-buildx
 
@@ -47,7 +47,7 @@ jobs:
       - name: Install jq
         uses: dcarbone/install-jq-action@v3.2.0
       - name: Set VERSION
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
       - name: Build operator bundle image
         run: make bundle bundle-buildx
       - name: Build catalog
@@ -67,7 +67,7 @@ jobs:
       - name: Verify Helm installation
         run: helm version
       - name: Set VERSION
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
       - name: Package helm chart
         run: make package-helmchart
       - name: Build and push helm OCI image
@@ -89,7 +89,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Set VERSION
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
       - name: Kustomize Build
         uses: karancode/kustomize-github-action@master
@@ -122,7 +122,7 @@ jobs:
         with:
           toTag: ${{ github.ref_name }}
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -158,13 +158,18 @@ test-helm: ginkgo ## Run helm chart tests
 	$(GINKGO) run --nodes 4 -p -v --junit-report=report/junit-report.xml test/helm
 
 .PHONY: lint
-lint: golangci-lint codespell ## Run golangci-lint linter and codespell
+lint: golangci-lint codespell actionlint ## Run golangci-lint linter, codespell, and actionlint
 	$(GOLANGCI_LINT) run
 	$(CODESPELL) --config ci/.codespellrc
+	$(ACTIONLINT) -config-file ci/actionlint.yaml
 
 .PHONY: golangci-fmt
 golangci-fmt: golangci-lint ## Run golangci-lint fmt
 	$(GOLANGCI_LINT) fmt
+
+.PHONY: lint-actions
+lint-actions: actionlint ## Lint GitHub Actions workflow files
+	$(ACTIONLINT) -config-file ci/actionlint.yaml -shellcheck "$(shell which shellcheck)"
 
 .PHONY: lint-fix
 lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
@@ -307,6 +312,7 @@ KUBEBUILDER ?= $(LOCALBIN)/kubebuilder
 CODESPELL ?= $(LOCALBIN)/codespell
 CRD_SCHEMA_CHECKER ?= $(LOCALBIN)/crd-schema-checker
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
+ACTIONLINT ?= $(LOCALBIN)/actionlint
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
@@ -318,6 +324,7 @@ KUBEBUILDER_VERSION ?= v4.12.0
 CODESPELL_VERSION ?= 2.4.1
 CRD_SCHEMA_CHECKER_VERSION ?= latest
 CRD_REF_DOCS_VERSION ?= v0.3.0
+ACTIONLINT_VERSION ?= v1.7.7
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
@@ -369,6 +376,11 @@ $(CODESPELL): $(LOCALBIN)
 crd-schema-checker: $(CRD_SCHEMA_CHECKER) ## Download crd-schema-checker locally if necessary.
 $(CRD_SCHEMA_CHECKER): $(LOCALBIN)
 	$(call go-install-tool,$(CRD_SCHEMA_CHECKER),github.com/openshift/crd-schema-checker/cmd/crd-schema-checker,$(CRD_SCHEMA_CHECKER_VERSION))
+
+.PHONY: actionlint
+actionlint: $(ACTIONLINT) ## Download actionlint locally if necessary.
+$(ACTIONLINT): $(LOCALBIN)
+	$(call go-install-tool,$(ACTIONLINT),github.com/rhysd/actionlint/cmd/actionlint,$(ACTIONLINT_VERSION))
 
 CRD_BASE_REF ?= origin/main
 .PHONY: check-crd-compat

--- a/Tiltfile
+++ b/Tiltfile
@@ -87,6 +87,12 @@ else:
     k8s_yaml('examples/minimal.yaml')
 
 k8s_resource(
+    new_name='clickhouse-operator-namespace',
+    objects=['clickhouse-operator-system:Namespace'],
+    labels=['operator'],
+)
+
+k8s_resource(
     new_name='keeper',
     objects=['sample:KeeperCluster:default'],
     labels=['test'],

--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -314,6 +314,10 @@ func (v *ClickHouseCluster) GetStatus() *ClickHouseClusterStatus {
 
 // Conditions returns pointer to the conditions slice.
 func (v *ClickHouseCluster) Conditions() *[]metav1.Condition {
+	if v.Status.Conditions == nil {
+		v.Status.Conditions = []metav1.Condition{}
+	}
+
 	return &v.Status.Conditions
 }
 

--- a/api/v1alpha1/keepercluster_types.go
+++ b/api/v1alpha1/keepercluster_types.go
@@ -219,6 +219,10 @@ func (v *KeeperCluster) GetStatus() *KeeperClusterStatus {
 
 // Conditions returns pointer to the conditions slice.
 func (v *KeeperCluster) Conditions() *[]metav1.Condition {
+	if v.Status.Conditions == nil {
+		v.Status.Conditions = []metav1.Condition{}
+	}
+
 	return &v.Status.Conditions
 }
 

--- a/ci/actionlint.yaml
+++ b/ci/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - func-tester

--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -148,13 +148,18 @@ func (cmd *commander) CreateDatabases(ctx context.Context, id v1.ClickHouseRepli
 	}
 
 	for name, desc := range databases {
-		query := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s` UUID '%s' ENGINE = %s", name, desc.UUID, desc.EngineFull)
-		if err = conn.Exec(ctx, query); err != nil {
+		dbCtx := clickhouse.Context(ctx, clickhouse.WithParameters(clickhouse.Parameters{"database": name}))
+
+		if err = conn.Exec(dbCtx, fmt.Sprintf(
+			"CREATE DATABASE IF NOT EXISTS {database:Identifier} UUID '%s' ENGINE = %s",
+			desc.UUID, desc.EngineFull,
+		),
+		); err != nil {
 			return fmt.Errorf("failed to create database %s on replica %s: %w", name, id, err)
 		}
 
 		if desc.IsReplicated {
-			if err = conn.Exec(ctx, fmt.Sprintf("SYSTEM SYNC DATABASE REPLICA `%s`", name)); err != nil {
+			if err = conn.Exec(dbCtx, "SYSTEM SYNC DATABASE REPLICA {database:Identifier}"); err != nil {
 				return fmt.Errorf("failed to sync replica for database %s on replica %s: %w", name, id, err)
 			}
 		}
@@ -259,13 +264,19 @@ func (cmd *commander) SyncReplica(ctx context.Context, log controllerutil.Logger
 		if desc.IsReplicated {
 			log.Debug("syncing database replica", "database", name)
 
-			if err = conn.Exec(ctx, fmt.Sprintf("SYSTEM SYNC DATABASE REPLICA `%s`", name)); err != nil {
+			syncCtx := clickhouse.Context(ctx, clickhouse.WithParameters(clickhouse.Parameters{"database": name}))
+			if err = conn.Exec(syncCtx, "SYSTEM SYNC DATABASE REPLICA {database:Identifier}"); err != nil {
 				errs = append(errs, fmt.Errorf("sync database %s: %w", name, err))
 			}
 		}
 	}
 
-	var replicatedTables []string
+	type replicatedTable struct {
+		database string
+		name     string
+	}
+
+	var replicatedTables []replicatedTable
 
 	rows, err := conn.Query(ctx, `SELECT database, name FROM system.tables WHERE engine LIKE 'Replicated%'`)
 	if err != nil {
@@ -284,7 +295,7 @@ func (cmd *commander) SyncReplica(ctx context.Context, log controllerutil.Logger
 			continue
 		}
 
-		replicatedTables = append(replicatedTables, fmt.Sprintf("`%s`.`%s`", dbName, tableName))
+		replicatedTables = append(replicatedTables, replicatedTable{database: dbName, name: tableName})
 	}
 
 	if err := rows.Err(); err != nil {
@@ -292,10 +303,14 @@ func (cmd *commander) SyncReplica(ctx context.Context, log controllerutil.Logger
 	}
 
 	for _, table := range replicatedTables {
-		log.Debug("syncing table replica", "table", table)
+		log.Debug("syncing table replica", "database", table.database, "table", table.name)
 
-		if err = conn.Exec(ctx, fmt.Sprintf("SYSTEM SYNC REPLICA %s LIGHTWEIGHT", table)); err != nil {
-			errs = append(errs, fmt.Errorf("sync replica %s: %w", table, err))
+		syncCtx := clickhouse.Context(ctx, clickhouse.WithParameters(clickhouse.Parameters{
+			"database": table.database,
+			"table":    table.name,
+		}))
+		if err = conn.Exec(syncCtx, "SYSTEM SYNC REPLICA {database:Identifier}.{table:Identifier} LIGHTWEIGHT"); err != nil {
+			errs = append(errs, fmt.Errorf("sync replica %s.%s: %w", table.database, table.name, err))
 		}
 	}
 
@@ -317,7 +332,7 @@ func (cmd *commander) CleanupDatabaseReplicas(
 
 	rows, err := conn.Query(ctx, listStaleDatabaseReplicasQuery, cmd.cluster.Shards(), cmd.cluster.Replicas())
 	if err != nil {
-		return fmt.Errorf("failed to query stale database replicas %v: %w", id, err)
+		return fmt.Errorf("query stale database replicas %v: %w", id, err)
 	}
 
 	defer func() {
@@ -366,6 +381,7 @@ func (cmd *commander) CleanupDatabaseReplicas(
 
 		log.Debug("deleting stale database replica", "database", database, "replica_id", toDrop)
 
+		// Both parameters don't support query parameters, and arg binding doesn't support identifiers
 		err = execConn.Exec(ctx, fmt.Sprintf("SYSTEM DROP DATABASE REPLICA '%d|%d' FROM DATABASE `%s`", toDrop.ShardID, toDrop.Index, database))
 		if err != nil {
 			log.Info("failed to drop stale database replica", "replica_id", toDrop, "error", err)

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -344,7 +344,7 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 	execResults := ctrlutil.ExecuteParallel(statefulSets.Items, func(sts appsv1.StatefulSet) (v1.ClickHouseReplicaID, replicaState, error) {
 		id, err := v1.ClickHouseIDFromLabels(sts.Labels)
 		if err != nil {
-			log.Error(err, "failed to get replica ID from StatefulSet labels", "statefulset", sts.Name)
+			log.Error(err, "get replica ID from StatefulSet labels", "statefulset", sts.Name)
 			return v1.ClickHouseReplicaID{}, replicaState{}, fmt.Errorf("get replica ID from StatefulSet labels: %w", err)
 		}
 
@@ -393,7 +393,7 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 	for id, state := range states {
 		if exists := r.SetReplica(id, state); exists {
 			log.Debug(fmt.Sprintf("multiple StatefulSets for single replica %v", id),
-				"replica_id", id, "statefuleset", state.StatefulSet.Name)
+				"replica_id", id, "statefulset", state.StatefulSet.Name)
 		}
 	}
 

--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -572,10 +572,10 @@ func (r *keeperReconciler) reconcileCleanUp(ctx context.Context, log ctrlutil.Lo
 		}
 
 		if _, ok := r.ReplicaState[id]; !ok {
-			log.Info("deleting stale StatefulSet", "replica_id", id, "statefuleset", sts.Name)
+			log.Info("deleting stale StatefulSet", "replica_id", id, "statefulset", sts.Name)
 
 			if err := r.Delete(ctx, &sts, v1.EventActionReconciling); err != nil {
-				log.Error(err, "delete stale replica", "replica_id", id, "statefuleset", sts.Name)
+				log.Error(err, "delete stale replica", "replica_id", id, "statefulset", sts.Name)
 			}
 		}
 	}

--- a/internal/controller/keeper/sync_test.go
+++ b/internal/controller/keeper/sync_test.go
@@ -121,7 +121,7 @@ var _ = Describe("UpdateReplica", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: podKey.Namespace,
 				Name:      podKey.Name,
-				Annotations: map[string]string{
+				Labels: map[string]string{
 					appsv1.ControllerRevisionHashLabelKey: "outdated",
 				},
 			},

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -64,7 +64,7 @@ func CheckPodError(ctx context.Context, log util.Logger, client client.Client, s
 			return false, fmt.Errorf("get clickhouse pod %q: %w", podName, err)
 		}
 
-		log.Info("pod is not exists", "pod", podName, "stateful_set", sts.Name)
+		log.Info("pod does not exist", "pod", podName, "statefulset", sts.Name)
 
 		return false, nil
 	}
@@ -341,7 +341,7 @@ func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) ReconcileReplicaResour
 	}
 
 	if input.ExistingSTS == nil {
-		log.Info("replica StatefulSet not found, creating", "stateful_set", statefulSet.Name)
+		log.Info("replica StatefulSet not found, creating", "statefulset", statefulSet.Name)
 		util.AddObjectConfigHash(statefulSet, input.ConfigurationRevision)
 		util.AddHashWithKeyToAnnotations(statefulSet, util.AnnotationSpecHash, input.StatefulSetRevision)
 
@@ -355,7 +355,7 @@ func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) ReconcileReplicaResour
 	// Check if the StatefulSet is outdated and needs to be recreated
 	v, err := semver.Parse(input.ExistingSTS.Annotations[util.AnnotationStatefulSetVersion])
 	if err != nil || input.BreakingSTSVersion.GT(v) {
-		log.Warn(fmt.Sprintf("Removing the StatefulSet because of a breaking change. Found version: %v, expected version: %v", v, input.BreakingSTSVersion))
+		log.Warn("removing StatefulSet because of a breaking change", "found_version", v.String(), "expected_version", input.BreakingSTSVersion.String())
 
 		if err := r.Delete(ctx, input.ExistingSTS, v1.EventActionReconciling); err != nil {
 			return nil, fmt.Errorf("recreate replica: %w", err)
@@ -384,7 +384,7 @@ func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) ReconcileReplicaResour
 	}
 
 	if !stsNeedsUpdate {
-		log.Debug("StatefulSet is up to date", "stateful_set", statefulSet.Name)
+		log.Debug("StatefulSet is up to date", "statefulset", statefulSet.Name)
 
 		if configChanged {
 			return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
@@ -401,12 +401,12 @@ func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) ReconcileReplicaResour
 					return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
 				}
 
-				log.Info("failed to get error pod", "pod", podName)
+				log.Warn("failed to get error pod", "pod", podName, "error", err)
 
 				return &ctrlruntime.Result{RequeueAfter: RequeueOnRefreshTimeout}, nil
 			}
 
-			if pod.Annotations[appsv1.ControllerRevisionHashLabelKey] != input.ExistingSTS.Status.UpdateRevision {
+			if pod.Labels[appsv1.ControllerRevisionHashLabelKey] != input.ExistingSTS.Status.UpdateRevision {
 				log.Info("deleting pod stuck in error state", "pod", podName)
 
 				if err = r.GetClient().Delete(ctx, pod); err != nil {
@@ -431,7 +431,7 @@ func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) ReconcileReplicaResour
 		}
 	}
 
-	log.Info("updating replica StatefulSet", "stateful_set", statefulSet.Name)
+	log.Info("updating replica StatefulSet", "statefulset", statefulSet.Name)
 	log.Debug("replica StatefulSet diff", "diff", gcmp.Diff(input.ExistingSTS.Spec, statefulSet.Spec))
 	input.ExistingSTS.Spec = statefulSet.Spec
 	input.ExistingSTS.Annotations = util.MergeMaps(input.ExistingSTS.Annotations, statefulSet.Annotations)

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -37,9 +37,6 @@ func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) SetConditions(
 	conditions []metav1.Condition,
 ) bool {
 	clusterCond := r.Cluster.Conditions()
-	if *clusterCond == nil {
-		*clusterCond = make([]metav1.Condition, 0, len(conditions))
-	}
 
 	hasChanges := false
 	for _, condition := range conditions {
@@ -124,7 +121,7 @@ func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) UpsertStatus(
 
 		crdInstance := r.Cluster.DeepCopyObject().(clusterObject[Status]) //nolint:forcetypeassert // safe cast
 		if err := cli.Get(ctx, r.Cluster.NamespacedName(), crdInstance); err != nil {
-			return fmt.Errorf("upsert status: get resource %s: %w", r.Cluster.GetName(), err)
+			return fmt.Errorf("get resource %s: %w", r.Cluster.GetName(), err)
 		}
 
 		preStatus := crdInstance.GetStatus()
@@ -134,10 +131,16 @@ func (r *ResourceReconcilerBase[Status, T, ReplicaID, S]) UpsertStatus(
 			return nil
 		}
 
-		log.Debug("status difference:\n" + gcmp.Diff(*preStatus, *r.Cluster.GetStatus()))
-		*crdInstance.GetStatus() = *r.Cluster.GetStatus()
+		diff := gcmp.Diff(*preStatus, *r.Cluster.GetStatus())
 
-		return cli.Status().Update(ctx, crdInstance)
+		*crdInstance.GetStatus() = *r.Cluster.GetStatus()
+		if err := cli.Status().Update(ctx, crdInstance); err != nil {
+			return fmt.Errorf("update resource %s: %w", r.Cluster.GetName(), err)
+		}
+
+		log.Debug("status difference:\n" + diff)
+
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("upsert status: %w", err)

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	ClickHouseBaseVersion   = "25.12"
-	ClickHouseUpdateVersion = "26.1"
+	ClickHouseBaseVersion   = "26.1"
+	ClickHouseUpdateVersion = "26.2"
 )
 
 var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {

--- a/test/e2e/keeper_e2e_test.go
+++ b/test/e2e/keeper_e2e_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	KeeperBaseVersion   = "25.3"
-	KeeperUpdateVersion = "25.5"
+	KeeperBaseVersion   = "26.1"
+	KeeperUpdateVersion = "26.2"
 )
 
 var _ = Describe("Keeper controller", Label("keeper"), func() {


### PR DESCRIPTION
## What

- Make log and error messages more consistent
- Use query parameters in CH queries
- Update test ch versions
- Add actionslinter and fix the found issues
- Update kind version and pin e2e k8s version as 1.35 can't start on self hosted runners
