### PR TITLE
fix: image tag in installer, changelog categories, main build images versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,8 @@ jobs:
 
   bundle:
     runs-on: ubuntu-latest
+    env:
+      VERSION: 0.0.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -5,7 +5,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_REPO: ghcr.io/clickhouse
-  VERSION: latest
 
 jobs:
   release-main:
@@ -18,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-tags: true
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -29,4 +30,4 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build operator image
-        run: make docker-buildx
+        run: make docker-buildx-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set VERSION
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
       - name: Build operator image
-        run: make docker-buildx
+        run: make docker-buildx-latest
 
   release-operator-olm-images:
     runs-on: ubuntu-latest
@@ -92,12 +92,9 @@ jobs:
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
       - name: Kustomize Build
-        uses: karancode/kustomize-github-action@master
-        with:
-          token: ${{ github.token }}
-          kustomize_version: 5.7.1
-          kustomize_build_dir: "config/default"
-          kustomize_output_file: "dist/clickhouse-operator.yaml"
+        run: |
+          make build-installer
+          mv dist/install.yaml dist/clickhouse-operator.yaml
       - name: Install Helm
         run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       - name: Verify Helm installation
@@ -121,6 +118,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           toTag: ${{ github.ref_name }}
+          configurationJson: |
+            {
+              "categories": [{
+                  "title": "## 🚀 Features",
+                  "labels": ["feature", "feat"]
+                },{
+                  "title": "## 🐛 Fixes",
+                  "labels": ["fix", "bug"]
+                }, {
+                  "title": "## 🧪 Tests",
+                  "labels": ["test"]
+                }, {
+                  "title": "## 🧹 Chores",
+                  "labels": ["chore"]
+                }, {
+                  "title": "## 📦 Uncategorized",
+                  "labels": []
+                }]
+            }
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY internal/ internal/
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a \
-    -ldflags "-X ${VERSION_PKG}.Version=v${VERSION} -X ${VERSION_PKG}.GitCommitHash=${GIT_COMMIT} -X ${VERSION_PKG}.BuildTime=${BUILD_TIME}" -o manager cmd/main.go
+    -ldflags "-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.GitCommitHash=${GIT_COMMIT} -X ${VERSION_PKG}.BuildTime=${BUILD_TIME}" -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,16 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
-ifeq ($(VERSION),latest)
-FULL_VERSION := latest
+ifeq ($(VERSION),)
+VERSION := $(shell git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n1 | cut -c 2-)
+ifeq ($(VERSION),)
+VERSION := 0.0.0
+endif
+FULL_VERSION := v$(VERSION)-$(shell git rev-parse --short HEAD)
 else
 FULL_VERSION := v$(VERSION)
 endif
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -207,7 +211,7 @@ push-helmchart: package-helmchart ## Push helm image. It will be pushed to the $
 GIT_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME ?= $(shell date "+%FT%T")
 VERSION_PKG = github.com/ClickHouse/clickhouse-operator/internal/version
-GO_LDFLAGS = -ldflags "-X $(VERSION_PKG).Version=v$(VERSION) -X $(VERSION_PKG).GitCommitHash=$(GIT_COMMIT) -X $(VERSION_PKG).BuildTime=$(BUILD_TIME)"
+GO_LDFLAGS = -ldflags "-X $(VERSION_PKG).Version=$(FULL_VERSION) -X $(VERSION_PKG).GitCommitHash=$(GIT_COMMIT) -X $(VERSION_PKG).BuildTime=$(BUILD_TIME)"
 
 .PHONY: build
 build: manifests generate fmt vet ## Build manager binary.
@@ -227,7 +231,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
 	$(CONTAINER_TOOL) build \
-		--build-arg VERSION=$(VERSION) \
+		--build-arg VERSION=$(FULL_VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_TIME=$(BUILD_TIME) \
 		-t ${IMG} .
@@ -250,12 +254,15 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 	- $(CONTAINER_TOOL) buildx create --name clickhouse-operator-builder
 	$(CONTAINER_TOOL) buildx use clickhouse-operator-builder
 	- $(CONTAINER_TOOL) buildx build --push --platform=$(PLATFORMS) \
-		--build-arg VERSION=$(VERSION) \
+		--build-arg VERSION=$(FULL_VERSION) \
 		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
 		--build-arg BUILD_TIME=$(BUILD_TIME) \
 		--tag ${IMG} -f Dockerfile.cross .
 	- $(CONTAINER_TOOL) buildx rm clickhouse-operator-builder
 	rm Dockerfile.cross
+
+docker-buildx-latest: docker-buildx ## Build and push docker image and tag it as latest
+	$(CONTAINER_TOOL) buildx imagetools create -t $(IMAGE_TAG_BASE):latest $(IMG)
 
 PLATFORMS_SPLITTED = $(shell echo $(PLATFORMS) | tr "," " ")
 .PHONY: docker-save


### PR DESCRIPTION
## Why

Current behavior builds an installer with a hardcoded v0.0.1 tag.
Default config matches only `feature`, `fix` and `test` labels
Main build result on images with version '**v**latest'
The release image is not tagged as the latest

## What

Call the correct script to generate the installer
Add explicit configuration for changelog builder
Generate version for main branch builds