### PR TITLE
ci: package and push helm chart in release-main workflow

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,4 +1,4 @@
-name: Build and push docker image with latest tag
+name: Publish main branch artifact
 on:
   push:
     branches: [ main ]
@@ -33,3 +33,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build operator image
         run: make docker-buildx-latest
+      - name: Install Helm
+        run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - name: Set VERSION
+        run: |
+          FULL_VER=$(make -s print-full-version)
+          echo "VERSION=${FULL_VER#v}" >> "$GITHUB_ENV" # strips 'v' → 0.0.3-d33b34f
+      - name: Package and push helm chart
+        run: |
+          helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          make push-helmchart

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ else
 FULL_VERSION := v$(VERSION)
 endif
 
+.PHONY: print-full-version
+print-full-version: ## Print the computed full version
+	@echo $(FULL_VERSION)
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:


### PR DESCRIPTION
## Why

We push docker images but not the latest helm charts for 'latest' changes, both are needed to be on the edge :)
