### PR TITLE
chore: add CI runner disk space cleanup, fix flaky tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -190,6 +190,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.0
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -233,7 +236,7 @@ jobs:
           overwrite: true
 
   e2e-test:
-    needs: [ lint, build_and_test ]
+    needs: [ lint ]
     strategy:
       fail-fast: false
       matrix:
@@ -277,13 +280,13 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       - name: Download all compat test reports
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: compat-e2e-report-*
 
 
       - name: Download all e2e test reports
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: e2e-report-*
 

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-tags: true
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.0
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.0
       - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.0
       - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:

--- a/internal/controller/clickhouse/commands_test.go
+++ b/internal/controller/clickhouse/commands_test.go
@@ -140,6 +140,7 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 		})
 
 		chPort := strconv.FormatInt(PortNative, 10) + "/tcp"
+		chHTTPPort := strconv.FormatInt(PortHTTP, 10) + "/tcp"
 		conns := map[v1.ClickHouseReplicaID]clickhouse.Conn{}
 
 		for i := range testReplicas {
@@ -164,8 +165,8 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 							FileMode:          0o644,
 						},
 					},
-					ExposedPorts: []string{chPort},
-					WaitingFor:   wait.ForListeningPort(nat.Port(chPort)),
+					ExposedPorts: []string{chPort, chHTTPPort},
+					WaitingFor:   wait.ForHTTP("/").WithPort(nat.Port(chHTTPPort)).WithStartupTimeout(2 * time.Minute),
 				},
 				Started: true,
 			})

--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -223,9 +223,31 @@ var _ = Describe("OLM deployment", Ordered, Label("olm"), func() {
 			_ = testutil.UninstallCRDs(ctx)
 		})
 
+		DeferCleanup(func(ctx context.Context) {
+			if !CurrentSpecReport().Failed() {
+				return
+			}
+
+			By("dumping OLM state for debugging")
+
+			for _, resource := range []string{"catalogsources", "subscriptions", "installplans", "clusterserviceversions"} {
+				out, _ := testutil.Run(exec.CommandContext(ctx, "kubectl", "get", resource,
+					"-n", namespace, "-o", "wide"))
+				AddReportEntry("=== OLM "+resource, string(out))
+			}
+		})
+
 		By("waiting for catalog server to be ready")
 		runCmd(ctx, "kubectl", "wait", "-n", namespace, "--timeout=120s",
 			"--for=condition=Ready", "pod/test-catalog-server")
+
+		By("waiting for ClusterServiceVersion to succeed")
+		Eventually(func(g Gomega) {
+			out, err := testutil.Run(exec.CommandContext(ctx, "kubectl", "get", "csv",
+				"-n", namespace, "--no-headers", "-o", "custom-columns=PHASE:.status.phase"))
+			g.Expect(err).ToNot(HaveOccurred(), string(out))
+			g.Expect(strings.TrimSpace(string(out))).To(Equal("Succeeded"), "CSV phase: %s", strings.TrimSpace(string(out)))
+		}, "5m", "5s").Should(Succeed())
 
 		By("Waiting controller to be ready")
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
## Why

Faced some CI failures because the runners were running out of disk space
Flaky test in CI because of the wrong wait condition
OLM tests are flaky, but need more logging to debug

## What

Add free-disk-space action in some workflows
Fixed ch wait condition
Add more diagnostics for OLM tests
Bump to download-artifact action version