### PR TITLE
feat: allow to disable PDB management

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -195,11 +195,11 @@ func run() error {
 		upgradeChecker = upgrade.NewChecker(updater)
 	}
 
-	if err = keeper.SetupWithManager(mgr, zapLogger, upgradeChecker, nil); err != nil {
+	if err = keeper.SetupWithManager(mgr, zapLogger, upgradeChecker, nil, env.EnablePDB); err != nil {
 		return fmt.Errorf("unable to setup KeeperCluster controller: %w", err)
 	}
 
-	if err = clickhouse.SetupWithManager(mgr, zapLogger, upgradeChecker, nil); err != nil {
+	if err = clickhouse.SetupWithManager(mgr, zapLogger, upgradeChecker, nil, env.EnablePDB); err != nil {
 		return fmt.Errorf("unable to setup ClickHouseCluster controller: %w", err)
 	}
 

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -61,6 +61,7 @@ spec:
           command:
             - /manager
           {{- $env := append .Values.manager.env (dict "name" "ENABLE_WEBHOOKS" "value" (printf "%t" .Values.webhook.enable)) }}
+          {{- $env = append $env (dict "name" "ENABLE_PDB" "value" (printf "%t" .Values.pdbManagement.enable)) }}
           {{- if not (empty .Values.watchNamespaces) }}
           {{-   $env = append $env (dict "name" "WATCH_NAMESPACE" "value" (join "," .Values.watchNamespaces)) }}
           {{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -140,6 +140,13 @@ cert-manager:
     crds:
         enabled: true
 
+## Controls whether the operator creates and manages PodDisruptionBudgets
+## for ClickHouseCluster and KeeperCluster resources.
+## Disable means operator will not call any PDB related API.
+##
+pdbManagement:
+    enable: true
+
 ## Webhook server configuration
 ##
 webhook:

--- a/internal/controller/clickhouse/controller.go
+++ b/internal/controller/clickhouse/controller.go
@@ -31,12 +31,13 @@ import (
 type ClusterController struct {
 	client.Client
 
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
-	Logger   controllerutil.Logger
-	Webhook  webhookv1.ClickHouseClusterWebhook
-	Checker  *upgrade.Checker
-	Dialer   controllerutil.DialContextFunc
+	Scheme    *runtime.Scheme
+	Recorder  events.EventRecorder
+	Logger    controllerutil.Logger
+	Webhook   webhookv1.ClickHouseClusterWebhook
+	Checker   *upgrade.Checker
+	Dialer    controllerutil.DialContextFunc
+	EnablePDB bool
 }
 
 // +kubebuilder:rbac:groups=clickhouse.com,resources=clickhouseclusters,verbs=get;list;watch;create;update;patch;delete
@@ -102,8 +103,9 @@ func (cc *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (c
 		statusManager:   chctrl.NewStatusManager(cc, cluster),
 		ResourceManager: chctrl.NewResourceManager(cc, cluster),
 
-		Dialer:  cc.Dialer,
-		Checker: cc.Checker,
+		Dialer:    cc.Dialer,
+		Checker:   cc.Checker,
+		EnablePDB: cc.EnablePDB,
 
 		Cluster:      cluster,
 		ReplicaState: map[v1.ClickHouseReplicaID]replicaState{},
@@ -140,20 +142,21 @@ func (cc *ClusterController) GetDialer() controllerutil.DialContextFunc {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker, dialer controllerutil.DialContextFunc) error {
+func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker, dialer controllerutil.DialContextFunc, enablePDB bool) error {
 	namedLogger := log.Named("clickhouse")
 
 	clickhouseController := &ClusterController{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("clickhouse-controller"),
-		Logger:   namedLogger,
-		Webhook:  webhookv1.ClickHouseClusterWebhook{Log: namedLogger},
-		Checker:  checker,
-		Dialer:   dialer,
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorder("clickhouse-controller"),
+		Logger:    namedLogger,
+		Webhook:   webhookv1.ClickHouseClusterWebhook{Log: namedLogger},
+		Checker:   checker,
+		Dialer:    dialer,
+		EnablePDB: enablePDB,
 	}
 
-	err := ctrl.NewControllerManagedBy(mgr).
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1.ClickHouseCluster{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
 		Watches(
 			&v1.KeeperCluster{},
@@ -163,9 +166,14 @@ func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgr
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.Service{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&corev1.Pod{}).
-		Owns(&batchv1.Job{}).
+		Owns(&batchv1.Job{})
+
+	if enablePDB {
+		controllerBuilder = controllerBuilder.Owns(&policyv1.PodDisruptionBudget{})
+	}
+
+	err := controllerBuilder.
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
 		Complete(clickhouseController)
 	if err != nil {

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -79,6 +79,7 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 			Dialer: func(context.Context, string) (net.Conn, error) {
 				return nil, errors.New("disabled")
 			},
+			EnablePDB: true,
 		}
 
 		keeper := &v1.KeeperCluster{

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -92,8 +92,9 @@ type clickhouseReconciler struct {
 	statusManager
 	chctrl.ResourceManager
 
-	Dialer  ctrlutil.DialContextFunc
-	Checker *upgrade.Checker
+	Dialer    ctrlutil.DialContextFunc
+	Checker   *upgrade.Checker
+	EnablePDB bool
 
 	Cluster      *v1.ClickHouseCluster
 	ReplicaState map[v1.ClickHouseReplicaID]replicaState
@@ -133,12 +134,18 @@ func (r *clickhouseReconciler) sync(ctx context.Context, log ctrlutil.Logger) (c
 
 	steps := []chctrl.ReconcileStep{
 		{Name: "CommonResources", Fn: r.reconcileCommonResources},
-		{Name: "ClusterRevisions", Fn: r.reconcileClusterRevisions, Always: true},
-		{Name: "ActiveReplicaStatus", Fn: r.reconcileActiveReplicaStatus, Always: true},
-		{Name: "ReplicaResources", Fn: r.reconcileReplicaResources},
-		{Name: "DatabaseSync", Fn: r.reconcileDatabaseSync},
-		{Name: "CleanUp", Fn: r.reconcileCleanUp},
 	}
+	if r.EnablePDB {
+		steps = append(steps, chctrl.ReconcileStep{Name: "PodDisruptionBudget", Fn: r.reconcilePodDisruptionBudget})
+	}
+
+	steps = append(steps,
+		chctrl.ReconcileStep{Name: "ClusterRevisions", Fn: r.reconcileClusterRevisions, Always: true},
+		chctrl.ReconcileStep{Name: "ActiveReplicaStatus", Fn: r.reconcileActiveReplicaStatus, Always: true},
+		chctrl.ReconcileStep{Name: "ReplicaResources", Fn: r.reconcileReplicaResources},
+		chctrl.ReconcileStep{Name: "DatabaseSync", Fn: r.reconcileDatabaseSync},
+		chctrl.ReconcileStep{Name: "CleanUp", Fn: r.reconcileCleanUp},
+	)
 
 	result, err := chctrl.RunSteps(ctx, log, steps)
 	if err != nil {
@@ -183,12 +190,7 @@ func (r *clickhouseReconciler) sync(ctx context.Context, log ctrlutil.Logger) (c
 	return result, nil
 }
 
-func (r *clickhouseReconciler) reconcileCommonResources(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	service := templateHeadlessService(r.Cluster)
-	if _, err := r.ReconcileService(ctx, log, service, v1.EventActionReconciling); err != nil {
-		return chctrl.StepResult{}, fmt.Errorf("reconcile service resource: %w", err)
-	}
-
+func (r *clickhouseReconciler) reconcilePodDisruptionBudget(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
 	pdbIgnored := r.Cluster.Spec.PodDisruptionBudget.Ignored()
 	pdbEnabled := r.Cluster.Spec.PodDisruptionBudget.Enabled()
 
@@ -223,6 +225,15 @@ func (r *clickhouseReconciler) reconcileCommonResources(ctx context.Context, log
 				}
 			}
 		}
+	}
+
+	return chctrl.StepContinue(), nil
+}
+
+func (r *clickhouseReconciler) reconcileCommonResources(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
+	service := templateHeadlessService(r.Cluster)
+	if _, err := r.ReconcileService(ctx, log, service, v1.EventActionReconciling); err != nil {
+		return chctrl.StepResult{}, fmt.Errorf("reconcile service resource: %w", err)
 	}
 
 	getErr := r.GetClient().Get(ctx, types.NamespacedName{

--- a/internal/controller/keeper/controller.go
+++ b/internal/controller/keeper/controller.go
@@ -28,12 +28,13 @@ import (
 type ClusterController struct {
 	client.Client
 
-	Scheme   *runtime.Scheme
-	Recorder events.EventRecorder
-	Logger   controllerutil.Logger
-	Webhook  webhookv1.KeeperClusterWebhook
-	Checker  *upgrade.Checker
-	Dialer   controllerutil.DialContextFunc
+	Scheme    *runtime.Scheme
+	Recorder  events.EventRecorder
+	Logger    controllerutil.Logger
+	Webhook   webhookv1.KeeperClusterWebhook
+	Checker   *upgrade.Checker
+	Dialer    controllerutil.DialContextFunc
+	EnablePDB bool
 }
 
 // +kubebuilder:rbac:groups=clickhouse.com,resources=keeperclusters,verbs=get;list;watch;create;update;patch;delete
@@ -99,8 +100,9 @@ func (cc *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (c
 		statusManager:   chctrl.NewStatusManager(cc, cluster),
 		ResourceManager: chctrl.NewResourceManager(cc, cluster),
 
-		Dialer:  cc.Dialer,
-		Checker: cc.Checker,
+		Dialer:    cc.Dialer,
+		Checker:   cc.Checker,
+		EnablePDB: cc.EnablePDB,
 
 		Cluster:      cluster,
 		ReplicaState: map[v1.KeeperReplicaID]replicaState{},
@@ -135,27 +137,33 @@ func (cc *ClusterController) GetDialer() controllerutil.DialContextFunc {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker, dialer controllerutil.DialContextFunc) error {
+func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker, dialer controllerutil.DialContextFunc, enablePDB bool) error {
 	namedLogger := log.Named("keeper")
 
 	keeperController := &ClusterController{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorder("keeper-controller"),
-		Logger:   namedLogger,
-		Webhook:  webhookv1.KeeperClusterWebhook{Log: namedLogger},
-		Checker:  checker,
-		Dialer:   dialer,
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorder("keeper-controller"),
+		Logger:    namedLogger,
+		Webhook:   webhookv1.KeeperClusterWebhook{Log: namedLogger},
+		Checker:   checker,
+		Dialer:    dialer,
+		EnablePDB: enablePDB,
 	}
 
-	err := ctrl.NewControllerManagedBy(mgr).
+	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1.KeeperCluster{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
-		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&corev1.Pod{}).
-		Owns(&batchv1.Job{}).
+		Owns(&batchv1.Job{})
+
+	if enablePDB {
+		controllerBuilder = controllerBuilder.Owns(&policyv1.PodDisruptionBudget{})
+	}
+
+	err := controllerBuilder.
 		WithEventFilter(predicate.ResourceVersionChangedPredicate{}).
 		Complete(keeperController)
 	if err != nil {

--- a/internal/controller/keeper/controller_test.go
+++ b/internal/controller/keeper/controller_test.go
@@ -73,6 +73,7 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 			Dialer: func(context.Context, string) (net.Conn, error) {
 				return nil, errors.New("disabled")
 			},
+			EnablePDB: true,
 		}
 	})
 

--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -88,8 +88,9 @@ type keeperReconciler struct {
 	statusManager
 	chctrl.ResourceManager
 
-	Dialer  ctrlutil.DialContextFunc
-	Checker *upgrade.Checker
+	Dialer    ctrlutil.DialContextFunc
+	Checker   *upgrade.Checker
+	EnablePDB bool
 
 	Cluster      *v1.KeeperCluster
 	ReplicaState map[v1.KeeperReplicaID]replicaState
@@ -120,9 +121,15 @@ func (r *keeperReconciler) sync(ctx context.Context, log ctrlutil.Logger) (ctrl.
 		{Name: "ActiveReplicaStatus", Fn: r.reconcileActiveReplicaStatus, Always: true},
 		{Name: "QuorumMembership", Fn: r.reconcileQuorumMembership},
 		{Name: "CommonResources", Fn: r.reconcileCommonResources},
-		{Name: "ReplicaResources", Fn: r.reconcileReplicaResources},
-		{Name: "CleanUp", Fn: r.reconcileCleanUp},
 	}
+	if r.EnablePDB {
+		steps = append(steps, chctrl.ReconcileStep{Name: "PodDisruptionBudget", Fn: r.reconcilePodDisruptionBudget})
+	}
+
+	steps = append(steps,
+		chctrl.ReconcileStep{Name: "ReplicaResources", Fn: r.reconcileReplicaResources},
+		chctrl.ReconcileStep{Name: "CleanUp", Fn: r.reconcileCleanUp},
+	)
 
 	result, err := chctrl.RunSteps(ctx, log, steps)
 	if err != nil {
@@ -437,12 +444,7 @@ func (r *keeperReconciler) reconcileQuorumMembership(_ context.Context, log ctrl
 	return chctrl.StepContinue(), nil
 }
 
-func (r *keeperReconciler) reconcileCommonResources(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	service := templateHeadlessService(r.Cluster)
-	if _, err := r.ReconcileService(ctx, log, service, v1.EventActionReconciling); err != nil {
-		return chctrl.StepResult{}, fmt.Errorf("reconcile service resource: %w", err)
-	}
-
+func (r *keeperReconciler) reconcilePodDisruptionBudget(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
 	if !r.Cluster.Spec.PodDisruptionBudget.Ignored() {
 		pdb := templatePodDisruptionBudget(r.Cluster)
 		if r.Cluster.Spec.PodDisruptionBudget.Enabled() {
@@ -454,6 +456,15 @@ func (r *keeperReconciler) reconcileCommonResources(ctx context.Context, log ctr
 				return chctrl.StepResult{}, fmt.Errorf("delete disabled PodDisruptionBudget resource: %w", err)
 			}
 		}
+	}
+
+	return chctrl.StepContinue(), nil
+}
+
+func (r *keeperReconciler) reconcileCommonResources(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
+	service := templateHeadlessService(r.Cluster)
+	if _, err := r.ReconcileService(ctx, log, service, v1.EventActionReconciling); err != nil {
+		return chctrl.StepResult{}, fmt.Errorf("reconcile service resource: %w", err)
 	}
 
 	configMap, err := templateQuorumConfig(r)

--- a/internal/controller/keeper/sync_test.go
+++ b/internal/controller/keeper/sync_test.go
@@ -201,7 +201,7 @@ func setupReconciler() (util.Logger, *keeperReconciler, context.CancelFunc) {
 		},
 	}
 
-	cc := &ClusterController{Client: fakeClient, Scheme: scheme, Recorder: eventRecorder}
+	cc := &ClusterController{Client: fakeClient, Scheme: scheme, Recorder: eventRecorder, EnablePDB: true}
 
 	reconciler := &keeperReconciler{
 		Controller:      cc,

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -10,6 +10,7 @@ import (
 // Environment holds all environment variables for the application.
 type Environment struct {
 	EnableWebhooks bool     `env:"ENABLE_WEBHOOKS, default=true"`
+	EnablePDB      bool     `env:"ENABLE_PDB, default=true"`
 	WatchNamespace []string `env:"WATCH_NAMESPACE"`
 }
 

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -26,33 +26,45 @@ var _ = DescribeTable("Environment variables parsing",
 	},
 	Entry("default values", nil, Environment{
 		EnableWebhooks: true,
+		EnablePDB:      true,
 		WatchNamespace: nil,
 	}),
 	Entry("explicit enabled webhook", map[string]string{
 		"ENABLE_WEBHOOKS": "true",
 	}, Environment{
 		EnableWebhooks: true,
+		EnablePDB:      true,
 	}),
 	Entry("explicit disabled webhook", map[string]string{
 		"ENABLE_WEBHOOKS": "false",
 	}, Environment{
 		EnableWebhooks: false,
+		EnablePDB:      true,
+	}),
+	Entry("explicit disabled PDB management", map[string]string{
+		"ENABLE_PDB": "false",
+	}, Environment{
+		EnableWebhooks: true,
+		EnablePDB:      false,
 	}),
 	Entry("parse single namespace", map[string]string{
 		"WATCH_NAMESPACE": "target_namespace",
 	}, Environment{
 		EnableWebhooks: true,
+		EnablePDB:      true,
 		WatchNamespace: []string{"target_namespace"},
 	}),
 	Entry("parse multiple namespace", map[string]string{
 		"WATCH_NAMESPACE": "target,namespace",
 	}, Environment{
 		EnableWebhooks: true,
+		EnablePDB:      true,
 		WatchNamespace: []string{"target", "namespace"},
 	}),
 	Entry("empty namespace behaves as not set", map[string]string{
 		"WATCH_NAMESPACE": "",
 	}, Environment{
 		EnableWebhooks: true,
+		EnablePDB:      true,
 	}),
 )

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -124,8 +124,8 @@ var _ = BeforeSuite(func(ctx context.Context) {
 
 	upgradeChecker := upgrade.NewChecker(updater)
 	podDialer = testutil.NewPortForwardDialer(config)
-	Expect(keeper.SetupWithManager(mgr, zapLogger, upgradeChecker, podDialer)).To(Succeed())
-	Expect(clickhouse.SetupWithManager(mgr, zapLogger, upgradeChecker, podDialer)).To(Succeed())
+	Expect(keeper.SetupWithManager(mgr, zapLogger, upgradeChecker, podDialer, true)).To(Succeed())
+	Expect(clickhouse.SetupWithManager(mgr, zapLogger, upgradeChecker, podDialer, true)).To(Succeed())
 	// +kubebuilder:scaffold:builder
 
 	mgrCtx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Why

In some environments, users are restricted to creating/updating PDBs and need a way to ignore this feature.

## What

Add `ENABLE_PDB` env variable that disables PDB reconciliation and controller informers.

## Related Issues

Fixes #141
