### PR TITLE
test: pre pull clickhouse images in e2e test, test campatible versions only with manifests installation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,15 +177,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Minimal supported kubernetes with LTS ClickHouse release"
+          - name: minimal-k8s-all-deploy-methods
             k8s_image: v1.28.15
             clickhouse_version: "26.3"
-          - name: "Latest kubernetes version with LTS ClickHouse release"
+            deploy_target: test-compat-e2e
+          - name: maximal-k8s-all-deploy-methods
             k8s_image: v1.35.1
             clickhouse_version: "26.3"
-          - name: "Supported ClickHouse versions"
+            deploy_target: test-compat-e2e
+          - name: supported-clickhouse-compatibility
             k8s_image: v1.30.13
             clickhouse_version: "26.3,26.2,26.1,25.8"
+            deploy_target: test-compat-e2e-manifest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -222,7 +225,7 @@ jobs:
           done
 
       - name: Run compatibility e2e tests
-        run: make test-compat-e2e
+        run: make ${{ matrix.deploy_target }}
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse_version }}
 
@@ -230,7 +233,7 @@ jobs:
         uses: actions/upload-artifact@v6
         if: ${{ !cancelled() }}
         with:
-          name: compat-e2e-report-${{ strategy.job-index }}
+          name: e2e-report-${{ matrix.name }}
           path: "**/report/*"
           if-no-files-found: error
           overwrite: true
@@ -241,7 +244,7 @@ jobs:
       fail-fast: false
       matrix:
         scope: [ test-keeper-e2e, test-clickhouse-e2e ]
-    runs-on: [self-hosted, func-tester]
+    runs-on: [self-hosted, amd-medium]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -279,12 +282,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
-      - name: Download all compat test reports
-        uses: actions/download-artifact@v8
-        with:
-          pattern: compat-e2e-report-*
-
-
       - name: Download all e2e test reports
         uses: actions/download-artifact@v8
         with:

--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,10 @@ test-clickhouse-e2e: ## Run clickhouse e2e tests.
 test-compat-e2e: ## Run compatibility e2e tests (requires CLICKHOUSE_VERSION env var).
 	go test ./test/deploy/ -test.timeout 30m -v --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
+.PHONY: test-compat-e2e-manifest  # Run compatibility smoke tests (manifests deployment only).
+test-compat-e2e-manifest: ## Run compatibility e2e tests using manifests deployment only (requires CLICKHOUSE_VERSION env var).
+	go test ./test/deploy/ -test.timeout 30m -v --ginkgo.v --ginkgo.label-filter=manifest --ginkgo.junit-report=report/junit-report.xml
+
 .PHONY: lint
 lint: golangci-lint codespell actionlint ## Run golangci-lint linter, codespell, and actionlint
 	$(GOLANGCI_LINT) run

--- a/ci/actionlint.yaml
+++ b/ci/actionlint.yaml
@@ -1,3 +1,3 @@
 self-hosted-runner:
   labels:
-    - func-tester
+    - amd-medium

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/sethvargo/go-envconfig v1.3.0
 	github.com/testcontainers/testcontainers-go v0.41.0
 	go.uber.org/zap v1.27.1
+	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
@@ -134,7 +135,6 @@ require (
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -130,7 +130,7 @@ var _ = JustAfterEach(func(ctx context.Context) {
 	testutil.DumpNamespaceDiagnostics(ctx, config, k8sClient, ns, reportDir)
 })
 
-var _ = Describe("Manifests deployment", Ordered, func() {
+var _ = Describe("Manifests deployment", Ordered, Label("manifest"), func() {
 	namespace := "clickhouse-operator-system"
 
 	BeforeAll(func(ctx context.Context) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -97,6 +97,15 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	By("pre-loading clickhouse images into kind")
+
+	imagePuller := testutil.PreloadImages(ctx, []string{
+		"docker.io/clickhouse/clickhouse-server:" + BaseVersion,
+		"docker.io/clickhouse/clickhouse-server:" + UpdateVersion,
+		"docker.io/clickhouse/clickhouse-keeper:" + BaseVersion,
+		"docker.io/clickhouse/clickhouse-keeper:" + UpdateVersion,
+	})
+
 	By("installing CRDs")
 	Expect(testutil.InstallCRDs(ctx)).To(Succeed())
 	DeferCleanup(func(ctx context.Context) {
@@ -139,6 +148,10 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	DeferCleanup(func() {
 		cancel()
 	})
+
+	if err = imagePuller.Wait(); err != nil {
+		GinkgoWriter.Printf("failed to pre pull images: %s", err)
+	}
 })
 
 var _ = JustAfterEach(func(ctx context.Context) {

--- a/test/testutil/utils.go
+++ b/test/testutil/utils.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"time"
@@ -22,6 +23,7 @@ import (
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/sync/errgroup"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -464,6 +466,37 @@ func SetupCA(ctx context.Context, k8sClient client.Client, namespace string, suf
 			_, _ = fmt.Fprintf(GinkgoWriter, "failed to delete CA issuer: %v\n", err)
 		}
 	})
+}
+
+// PreloadImages pulls each image from the registry and loads it into the kind cluster.
+// All images are processed in parallel.
+func PreloadImages(ctx context.Context, images []string) *errgroup.Group {
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, image := range images {
+		g.Go(func() error {
+			// Remove any cached manifest-index
+			_ = exec.CommandContext(ctx, "docker", "image", "rm", image).Run()
+
+			By("pulling image:" + image)
+
+			pull := exec.CommandContext(ctx, "docker", "pull", "--platform", "linux/"+runtime.GOARCH, image)
+			if out, err := pull.CombinedOutput(); err != nil {
+				return fmt.Errorf("docker pull %s: %w\n%s", image, err, out)
+			}
+
+			By("loading image into kind: " + image)
+
+			load := exec.CommandContext(ctx, "kind", "load", "docker-image", image)
+			if out, err := load.CombinedOutput(); err != nil {
+				return fmt.Errorf("kind load %s: %w\n%s", image, err, out)
+			}
+
+			return nil
+		})
+	}
+
+	return g
 }
 
 // EnsureNamespace ensures the test namespace is created and active.


### PR DESCRIPTION
## Why

- After #111, the operator will wait for the version probe job before resource creation. Pre-pulling the image should speed up e2e tests in this case.
- Supported ch versions suite takes too long and became pretty flaky, and it doesn't make sense to test it for each install method

## What

- Add ClickHouse image pre-pulling to the e2e test suite.
- For the ClickHouse version compatibility test, run only the manifests install suite

