### PR TITLE
Added metrics logs so the builtin dashboard display proper values. Otherwise it feels broken at cluster installation.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,6 +342,26 @@ spec:
   settings:
     extraConfig:
       background_pool_size: 20
+
+      # Required by the built-in ClickHouse dashboard. Not created by the operator by default.
+      metric_log:
+        database: system
+        table: metric_log
+        flush_interval_milliseconds: 7500
+        collect_interval_milliseconds: 1000
+        max_size_rows: 1048576
+        reserved_size_rows: 8192
+        buffer_size_rows_flush_threshold: 524288
+        flush_on_crash: false
+      asynchronous_metric_log:
+        database: system
+        table: asynchronous_metric_log
+        flush_interval_milliseconds: 7000
+        max_size_rows: 1048576
+        reserved_size_rows: 8192
+        buffer_size_rows_flush_threshold: 524288
+        flush_on_crash: false
+
 ```
 
 #### Useful links:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,26 +342,6 @@ spec:
   settings:
     extraConfig:
       background_pool_size: 20
-
-      # Required by the built-in ClickHouse dashboard. Not created by the operator by default.
-      metric_log:
-        database: system
-        table: metric_log
-        flush_interval_milliseconds: 7500
-        collect_interval_milliseconds: 1000
-        max_size_rows: 1048576
-        reserved_size_rows: 8192
-        buffer_size_rows_flush_threshold: 524288
-        flush_on_crash: false
-      asynchronous_metric_log:
-        database: system
-        table: asynchronous_metric_log
-        flush_interval_milliseconds: 7000
-        max_size_rows: 1048576
-        reserved_size_rows: 8192
-        buffer_size_rows_flush_threshold: 524288
-        flush_on_crash: false
-
 ```
 
 #### Useful links:

--- a/internal/controller/clickhouse/templates/log_tables.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/log_tables.yaml.tmpl
@@ -1,3 +1,5 @@
 query_log:
 part_log:
 text_log:
+asynchronous_metric_log:
+metric_log:


### PR DESCRIPTION
## Why

When creating a cluster using the operator, the built-in dashboard shows up with errors because the widgets query metrics that are not enabled in the default configuration proposed by the operator.
For new administrators to clickhouse like me, that leads to the feeling that something is broken, generating some confusion.

## What

Added to the custom config section in the documentation a comment and the metrics config to make dashboard run properly from the beginning.
At least, lets the user read the line "Required by the built-in dashboard" and be aware of this situation.

