### PR TITLE
feat: add OpenShift SecurityContextConstraints configuration

### DIFF
--- a/dist/chart/templates/scc/clickhouse-scc.yaml
+++ b/dist/chart/templates/scc/clickhouse-scc.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.openshift.scc.enabled }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: SCC denies access to all host features and
+      requires pods to be run with a UID, and SELinux context. Allows capabilities needed by ClickHouse Keeper
+  name: clickhouse-keeper-scc
+priority: null
+readOnlyRootFilesystem: false
+defaultAddCapabilities: null
+fsGroup:
+  ranges:
+    - max: 65534
+      min: 100
+  type: MustRunAs
+groups: []
+requiredDropCapabilities:
+  - ALL
+runAsUser:
+  type: MustRunAsRange
+  uidRangeMin: 100
+  uidRangeMax: 65534
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - runtime/default
+supplementalGroups:
+  ranges:
+    - max: 65534
+      min: 100
+  type: MustRunAs
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - NET_BIND_SERVICE
+  - IPC_LOCK
+  - PERFMON
+  - SYS_PTRACE
+{{- end }}

--- a/dist/chart/templates/scc/clickhouse-scc.yaml
+++ b/dist/chart/templates/scc/clickhouse-scc.yaml
@@ -4,8 +4,8 @@ kind: SecurityContextConstraints
 metadata:
   annotations:
     kubernetes.io/description: SCC denies access to all host features and
-      requires pods to be run with a UID, and SELinux context. Allows capabilities needed by ClickHouse Keeper
-  name: clickhouse-keeper-scc
+      requires pods to be run with a UID, and SELinux context. Allows capabilities needed by ClickHouse Keeper.
+  name: clickhouse-scc
 priority: null
 readOnlyRootFilesystem: false
 defaultAddCapabilities: null

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -164,6 +164,12 @@ prometheus:
     # Requires prometheus-operator to be installed in the cluster.
     service_monitor: false
 
+## OpenShift specific configurations
+##
+openshift:
+    scc:
+        # Enable creating SecurityContextConstraints for OpenShift
+        enabled: false
 
 # Extra manifests to deploy as an array
 extraManifests: []


### PR DESCRIPTION
## Why

In OpenShift "security context constraints" is used which is similar to Vanilla Kubernetes. With default OpenShift SCC restricted-v2 or restricted-v3 there is no possibility to run Keeper and Database pods. There is a need for custom SCC that allows capabilities:
  - NET_BIND_SERVICE
  - IPC_LOCK
  - PERFMON
  - SYS_PTRACE
  
  and running as user 101
https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/authentication_and_authorization/managing-pod-security-policies

Maybe it is even worth to create seperate ServiceAccount for ClickHouse and then specify in:
users:
  - system:serviceaccount:{{ .Release.Namespace }}:{{ include "clickhouse-operator.serviceAccountName" . }}
  
it is something to decide on your side.

## What

I created custom SCC and added value in helm values.yam file. I tested this setup with ClickHouse operator v.0.0.4 and OpenShift 4.20.16

## Related Issues

No related issues

