### PR TITLE
feat: add clickhouse-cluster helm chart

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -176,13 +176,16 @@ jobs:
         run: helm version
 
       - name: Check helmchart generated
-        run: make generate-helmchart-ci && git diff --exit-code dist/chart/
+        run: make generate-helmchart-ci && git diff --exit-code dist/chart/ dist/chart-cluster/
 
       - name: Build Helm Chart Dependencies
         run: make build-helmchart-dependencies
 
       - name: Lint Helm Chart
         run: helm lint ./dist/chart
+
+      - name: Lint Cluster Helm Chart
+        run: make lint-cluster-chart
 
   compat-e2e-test:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           FULL_VER=$(make -s print-full-version)
           echo "VERSION=${FULL_VER#v}" >> "$GITHUB_ENV" # strips 'v' → 0.0.3-d33b34f
-      - name: Package and push helm chart
+      - name: Package and push helm charts
         run: |
           helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-          make push-helmchart
+          make push-helmchart push-cluster-chart

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,12 +72,14 @@ jobs:
         run: helm version
       - name: Set VERSION
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
-      - name: Package helm chart
+      - name: Log in registry
+        run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+      - name: Package operator helm chart
         run: make package-helmchart
       - name: Build and push helm OCI image
-        run: |
-          helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-          make push-helmchart
+        run: make push-helmchart
+      - name: Build and push cluster chart OCI image
+        run: make push-cluster-chart
 
   create-release:
     runs-on: ubuntu-latest
@@ -105,6 +107,8 @@ jobs:
         run: helm version
       - name: Package helm chart
         run: make package-helmchart
+      - name: Package cluster chart
+        run: make package-cluster-chart
 
       - name: Log in to the Container registry
         uses: docker/login-action@v4
@@ -168,4 +172,5 @@ jobs:
           files: |
             dist/clickhouse-operator.yaml
             clickhouse-operator-helm-${{env.VERSION}}.tgz
+            clickhouse-cluster-helm-${{env.VERSION}}.tgz
             clickhouse-operator_${{env.VERSION}}_*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ generate-helmchart: kubebuilder kustomize ## Generate helm charts
 	rm .github/workflows/test-chart.yml dist/install-helm.yaml
 
 .PHONY: generate-helmchart-ci
-generate-helmchart-ci: generate-helmchart ## Generate helm charts and reset some files that will always generate diff
+generate-helmchart-ci: generate-helmchart generate-cluster-chart ## Generate helm charts and reset some files that will always generate diff
 	git checkout dist/chart/templates/cert-manager/
 	git checkout dist/chart/templates/manager/
 
@@ -211,6 +211,35 @@ package-helmchart: build-helmchart-dependencies ## Package helm chart. It will b
 .PHONY: push-helmchart
 push-helmchart: package-helmchart ## Push helm image. It will be pushed to the ${IMAGE_REPO}/(helmchart name, same as in Chart.yaml)
 	helm push clickhouse-operator-helm-${VERSION}.tgz oci://$(IMAGE_REPO)
+
+##@ Cluster Helm Chart
+
+CLUSTER_CHART_DIR := dist/chart-cluster
+GEN_CLUSTER_CHART ?= $(LOCALBIN)/gen-cluster-chart
+
+.PHONY: gen-cluster-chart-bin
+gen-cluster-chart-bin: $(LOCALBIN) ## Build the cluster-chart generator binary.
+	go build -o $(GEN_CLUSTER_CHART) ./tools/gen-cluster-chart
+
+.PHONY: generate-cluster-chart
+generate-cluster-chart: manifests gen-cluster-chart-bin ## Generate cluster chart values.yaml from CRDs.
+	$(GEN_CLUSTER_CHART) \
+	    -clickhouse-crd config/crd/bases/clickhouse.com_clickhouseclusters.yaml \
+	    -keeper-crd config/crd/bases/clickhouse.com_keeperclusters.yaml \
+	    -out $(CLUSTER_CHART_DIR)
+
+.PHONY: package-cluster-chart
+package-cluster-chart: ## Package cluster chart. It will be saved as clickhouse-cluster-helm-$(VERSION).tgz
+	helm package --version ${VERSION} $(CLUSTER_CHART_DIR)
+
+.PHONY: push-cluster-chart
+push-cluster-chart: package-cluster-chart ## Push cluster chart. It will be pushed to ${IMAGE_REPO}/clickhouse-cluster-helm
+	helm push clickhouse-cluster-helm-${VERSION}.tgz oci://$(IMAGE_REPO)
+
+.PHONY: lint-cluster-chart
+lint-cluster-chart: ## Lint + dry-render cluster chart.
+	helm lint $(CLUSTER_CHART_DIR)
+	helm template test $(CLUSTER_CHART_DIR) > /dev/null
 
 ##@ Build
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,16 @@ For users who want to quickly try the operator:
      ```
 
 2. Deploy a sample cluster:
-   ```sh
-   kubectl apply -f https://raw.githubusercontent.com/ClickHouse/clickhouse-operator/refs/heads/main/examples/minimal.yaml
-   ```
+   - Using raw manifests:
+     ```sh
+     kubectl apply -f https://raw.githubusercontent.com/ClickHouse/clickhouse-operator/refs/heads/main/examples/minimal.yaml
+     ```
+   - Using the helm chart:
+     ```sh
+     helm install ch oci://ghcr.io/clickhouse/clickhouse-cluster-helm \
+        --create-namespace \
+        -n clickhouse
+     ```
 
 3. Verify the deployment:
    ```sh

--- a/dist/chart-cluster/.helmignore
+++ b/dist/chart-cluster/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building Helm packages.
+# Operating system files
+.DS_Store
+
+# Version control directories
+.git/
+.gitignore
+.bzr/
+.hg/
+.hgignore
+.svn/
+
+# Backup and temporary files
+*.swp
+*.tmp
+*.bak
+*.orig
+*~
+
+# IDE and editor-related files
+.idea/
+.vscode/
+
+# Helm chart artifacts
+dist/chart/*.tgz

--- a/dist/chart-cluster/Chart.yaml
+++ b/dist/chart-cluster/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: clickhouse-cluster-helm
+type: application
+version: 0.0.1
+appVersion: "latest"
+kubeVersion: ">= 1.28.0-0"
+description: |
+  Chart that deploys a ClickHouse cluster and a Keeper via the ClickHouse Operator.
+  Install the operator chart first (oci://ghcr.io/clickhouse/clickhouse-operator-helm).
+  This chart only renders ClickHouseCluster + KeeperCluster CRs and relies on the operator's reconcilers
+  to do the actual provisioning.
+keywords:
+  - database
+  - clickhouse
+  - keeper
+maintainers:
+  - name: ClickHouse Team
+    email: operator@clickhouse.com
+home: https://github.com/ClickHouse/clickhouse-operator
+icon: "https://clickhouse.com/docs/img/clickhouse-operator-logo.svg"

--- a/dist/chart-cluster/templates/NOTES.txt
+++ b/dist/chart-cluster/templates/NOTES.txt
@@ -1,0 +1,25 @@
+{{- $ch := .Values.clickhouse.enabled }}
+{{- $kp := .Values.keeper.enabled }}
+ClickHouse cluster {{ .Release.Name }} installed in namespace {{ .Release.Namespace }}.
+
+{{ if $ch }}ClickHouseCluster:  {{ include "clickhouse-cluster.clickhouse.name" . }}{{ end }}
+{{ if $kp }}KeeperCluster:      {{ include "clickhouse-cluster.keeper.name" . }}{{ end }}
+
+Watch reconciliation:
+  kubectl -n {{ .Release.Namespace }} get clickhousecluster,keepercluster -w
+
+{{- if $ch }}
+ClickHouseCluster status:
+  kubectl -n {{ .Release.Namespace }} describe clickhousecluster {{ include "clickhouse-cluster.clickhouse.name" . }}
+
+{{- end }}
+{{- if $kp }}
+KeeperCluster status:
+  kubectl -n {{ .Release.Namespace }} describe keepercluster {{ include "clickhouse-cluster.keeper.name" . }}
+
+{{- end }}
+NOTE: this chart only renders CRs. The ClickHouse Operator must be installed separately.
+Match --version with this chart for guaranteed compatibility:
+
+  helm install clickhouse-operator oci://ghcr.io/clickhouse/clickhouse-operator-helm \
+    --version {{ .Chart.Version }} --create-namespace -n clickhouse-operator-system

--- a/dist/chart-cluster/templates/_helpers.tpl
+++ b/dist/chart-cluster/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "clickhouse-cluster.chart-name" -}}
+{{ trimSuffix "-helm" .Chart.Name }}
+{{- end }}
+
+{{/*
+Fully-qualified release-scoped name used as the base of all CR names.
+If the release name already contains the chart name, just use the release name.
+*/}}
+{{- define "clickhouse-cluster.fullname" -}}
+{{- $name := include "clickhouse-cluster.chart-name" . }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+ClickHouseCluster CR name. Respects clickhouse.meta.name.
+*/}}
+{{- define "clickhouse-cluster.clickhouse.name" -}}
+{{- if .Values.clickhouse.meta.name }}
+{{- .Values.clickhouse.meta.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- include "clickhouse-cluster.fullname" . | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+KeeperCluster CR name. Respects keeper.meta.name. Defaults to fullname.
+*/}}
+{{- define "clickhouse-cluster.keeper.name" -}}
+{{- if .Values.keeper.meta.name }}
+{{- .Values.keeper.meta.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- (include "clickhouse-cluster.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/dist/chart-cluster/templates/clickhouse-cluster.yaml
+++ b/dist/chart-cluster/templates/clickhouse-cluster.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.clickhouse.enabled -}}
+apiVersion: clickhouse.com/v1alpha1
+kind: ClickHouseCluster
+metadata:
+  name: {{ include "clickhouse-cluster.clickhouse.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: clickhouse
+    app.kubernetes.io/component: clickhouse-cluster
+    {{- with .Values.clickhouse.meta.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.clickhouse.meta.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- /* Chart-provided defaults: image tag from .Values.imageTag (fallback: chart appVersion). User values override. */}}
+  {{- $tag := default .Chart.AppVersion .Values.imageTag }}
+  {{- $defaults := dict "containerTemplate" (dict "image" (dict "tag" $tag)) }}
+  {{- $spec := mergeOverwrite $defaults (deepCopy (.Values.clickhouse.spec | default dict)) }}
+  {{- /* Auto-wire keeperClusterRef when keeper is enabled in-chart and user did not pin one. */}}
+  {{- if and .Values.keeper.enabled (not (hasKey $spec "keeperClusterRef")) }}
+  {{- $_ := set $spec "keeperClusterRef" (dict "name" (include "clickhouse-cluster.keeper.name" .)) }}
+  {{- end }}
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}

--- a/dist/chart-cluster/templates/keeper-cluster.yaml
+++ b/dist/chart-cluster/templates/keeper-cluster.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.keeper.enabled -}}
+apiVersion: clickhouse.com/v1alpha1
+kind: KeeperCluster
+metadata:
+  name: {{ include "clickhouse-cluster.keeper.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: keeper
+    app.kubernetes.io/component: keeper-cluster
+    {{- with .Values.keeper.meta.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.keeper.meta.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- /* Chart-provided defaults: image tag from .Values.imageTag (fallback: chart appVersion). User values override. */}}
+  {{- $tag := default .Chart.AppVersion .Values.imageTag }}
+  {{- $defaults := dict "containerTemplate" (dict "image" (dict "tag" $tag)) }}
+  {{- $spec := mergeOverwrite $defaults (deepCopy (.Values.keeper.spec | default dict)) }}
+  {{- toYaml $spec | nindent 2 }}
+{{- end }}

--- a/dist/chart-cluster/values.yaml
+++ b/dist/chart-cluster/values.yaml
@@ -1,0 +1,133 @@
+# Default values for clickhouse-cluster-helm.
+#
+# THIS FILE IS GENERATED FROM CRD SCHEMAS. DO NOT EDIT BY HAND.
+# Regenerate with: make generate-cluster-chart
+#
+# Top-level keys map to the two CRs:
+#   clickhouse.{meta,spec}:  applied to ClickHouseCluster metadata + spec
+#   keeper.{meta,spec}:      applied to KeeperCluster metadata + spec
+#
+# Sub-objects (podTemplate, dataVolumeClaimSpec, settings, ...) are free-form
+# pass-throughs validated by the operator webhook on apply.
+#
+# Match --version with the operator chart for compatibility:
+#
+#   helm install clickhouse-operator oci://ghcr.io/clickhouse/clickhouse-operator-helm --version X.Y.Z ...
+#   helm install ch                  oci://ghcr.io/clickhouse/clickhouse-cluster-helm  --version X.Y.Z ...
+
+# Default container image tag for both ClickHouseCluster and KeeperCluster.
+# Empty falls back to the chart appVersion. Per-component overrides via
+# clickhouse.spec.containerTemplate.image.tag / keeper.spec.containerTemplate.image.tag.
+imageTag: ""
+
+clickhouse:
+  # Whether to create the ClickHouseCluster CR.
+  enabled: true
+
+  # Metadata applied to the ClickHouseCluster CR itself.
+  meta:
+    # CR name. Defaults to the Helm release name when empty.
+    name: ""
+    labels: {}
+    annotations: {}
+
+  # ClickHouseCluster.spec — passed verbatim into the CR.
+  spec:
+
+    # Additional annotations that are added to resources.
+    # annotations: {}
+
+    # ClusterDomain is the Kubernetes cluster domain suffix used for DNS resolution.
+    clusterDomain: cluster.local
+
+    # Parameters passed to the ClickHouse container spec.
+    # containerTemplate: {}
+
+    # Specification of persistent storage for ClickHouse data.
+    # dataVolumeClaimSpec: {}
+
+    # ExternalSecret is an optional reference to an externally-managed Secret containing cluster secrets.
+    # The secret must reside in the same namespace as the cluster.
+    # externalSecret: {}
+
+    # Reference to the KeeperCluster that is used for ClickHouse coordination.
+    # When namespace is omitted, the ClickHouseCluster namespace is used.
+    # keeperClusterRef: {}
+
+    # Additional labels that are added to resources.
+    # labels: {}
+
+    # PodDisruptionBudget configures the PDB created for each shard.
+    # When unset, the operator defaults to maxUnavailable=1 for single-replica
+    # shards and minAvailable=1 for multi-replica shards.
+    # podDisruptionBudget: {}
+
+    # Parameters passed to the ClickHouse pod spec.
+    # podTemplate: {}
+
+    # Number of replicas in the single shard.
+    replicas: 3
+
+    # Configuration parameters for ClickHouse server.
+    # settings: {}
+
+    # Number of shards in the cluster.
+    shards: 1
+
+    # UpgradeChannel specifies the release channel for major version upgrade checks.
+    # When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8).
+    # upgradeChannel: ""
+
+    # VersionProbeTemplate overrides for the version detection Job.
+    # versionProbeTemplate: {}
+
+keeper:
+  # Whether to create the KeeperCluster CR.
+  enabled: true
+
+  # Metadata applied to the KeeperCluster CR itself.
+  meta:
+    # CR name. Defaults to the Helm release name when empty.
+    name: ""
+    labels: {}
+    annotations: {}
+
+  # KeeperCluster.spec — passed verbatim into the CR.
+  spec:
+
+    # Additional annotations that are added to resources.
+    # annotations: {}
+
+    # ClusterDomain is the Kubernetes cluster domain suffix used for DNS resolution.
+    clusterDomain: cluster.local
+
+    # Parameters passed to the Keeper container spec.
+    # containerTemplate: {}
+
+    # Specification of persistent storage for ClickHouse Keeper data.
+    # dataVolumeClaimSpec: {}
+
+    # Additional labels that are added to resources.
+    # labels: {}
+
+    # PodDisruptionBudget configures the PDB created for the Keeper cluster.
+    # When unset, the operator defaults to maxUnavailable=replicas/2
+    # (preserving quorum for a 2F+1 cluster).
+    # podDisruptionBudget: {}
+
+    # Parameters passed to the Keeper pod spec.
+    # podTemplate: {}
+
+    # Number of replicas in the cluster
+    replicas: 3
+
+    # Configuration parameters for ClickHouse Keeper server.
+    # settings: {}
+
+    # UpgradeChannel specifies the release channel for major version upgrade checks.
+    # When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8).
+    # upgradeChannel: ""
+
+    # VersionProbeTemplate overrides for the version detection Job.
+    # versionProbeTemplate: {}
+

--- a/go.mod
+++ b/go.mod
@@ -21,10 +21,12 @@ require (
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.35.4
+	k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/randfill v1.0.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -147,7 +149,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.35.4 // indirect
 	k8s.io/apiserver v0.35.4 // indirect
 	k8s.io/component-base v0.35.4 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
@@ -157,5 +158,4 @@ require (
 	sigs.k8s.io/gateway-api v1.5.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -308,7 +308,7 @@ var _ = Describe("Helm deployment", Ordered, Label("helm"), func() {
 			}, "2m", "100ms").Should(Succeed())
 		})
 
-		testDeployment(namespace)
+		testHelmCluster(namespace)
 	},
 		Entry("default values", "default", map[string]any{}),
 		Entry("disabled webhook", "webhookless", map[string]any{
@@ -343,6 +343,41 @@ spec:
 		}),
 	)
 })
+
+// testHelmCluster validates the Helm based deployment using the clickhouse-cluster-helm chart to deploy sample cluster.
+func testHelmCluster(namespace string) {
+	body := func(ctx context.Context, version string) {
+		releaseName := "cluster-" + version
+		chName := "ch-" + version
+		keeperName := "keeper-" + version
+
+		By("Installing clickhouse-cluster chart")
+		runCmd(ctx, "helm", "install", releaseName, "dist/chart-cluster", "-n", namespace,
+			"--set", "clickhouse.meta.name="+chName,
+			"--set", "keeper.meta.name="+keeperName,
+			"--set", "clickhouse.spec.replicas=1",
+			"--set", "keeper.spec.replicas=1",
+			"--set-string", "imageTag="+version,
+		)
+
+		DeferCleanup(func(ctx context.Context) {
+			By("Uninstalling clickhouse-cluster chart")
+			runCmd(ctx, "helm", "uninstall", releaseName, "-n", namespace)
+		})
+
+		By("Waiting for KeeperCluster to be ready")
+		runCmd(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
+			"keepercluster/"+keeperName)
+
+		By("Waiting for ClickHouse to be ready")
+		runCmd(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
+			"clickhousecluster/"+chName)
+	}
+
+	tableArgs := make([]any, 1, len(versionEntries)+1)
+	tableArgs[0] = body
+	DescribeTable("cluster chart should successfully deploy", append(tableArgs, versionEntries...)...)
+}
 
 func testDeployment(namespace string) {
 	body := func(ctx context.Context, version string) {

--- a/tools/gen-cluster-chart/main.go
+++ b/tools/gen-cluster-chart/main.go
@@ -1,0 +1,294 @@
+// Package main generates the clickhouse-cluster-helm chart's values.yaml from
+// ClickHouseCluster + KeeperCluster CRD schemas via an embedded text template.
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"flag"
+	"fmt"
+	"log"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"text/template"
+
+	"gopkg.in/yaml.v2"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	sigyaml "sigs.k8s.io/yaml"
+)
+
+const (
+	dirPerm  = 0o750
+	filePerm = 0o600
+)
+
+var (
+	//go:embed templates/values.yaml.tmpl
+	valuesTemplateStr string
+
+	valuesTemplate = template.Must(template.New("values").Funcs(template.FuncMap{
+		"yaml":    tmplYAML,
+		"indent":  tmplIndent,
+		"comment": tmplComment,
+	}).Parse(valuesTemplateStr))
+)
+
+type chartValues struct {
+	ClickHouseFields []fieldBlock
+	KeeperFields     []fieldBlock
+}
+
+type fieldBlock struct {
+	Key         string
+	Description string
+	Constraints string
+	HasValue    bool
+	Multiline   bool
+	Value       any
+	Zero        string
+}
+
+func main() {
+	clickhouseCRD := ""
+	keeperCRD := ""
+	outDir := ""
+
+	flag.StringVar(&clickhouseCRD, "clickhouse-crd", "", "Path to ClickHouseCluster CRD YAML")
+	flag.StringVar(&keeperCRD, "keeper-crd", "", "Path to KeeperCluster CRD YAML")
+	flag.StringVar(&outDir, "out", "", "Output chart directory")
+	flag.Parse()
+
+	if clickhouseCRD == "" || keeperCRD == "" || outDir == "" {
+		fmt.Fprintln(os.Stderr,
+			"usage: gen-cluster-chart -clickhouse-crd <path> -keeper-crd <path> -out <chart-dir>")
+		os.Exit(2)
+	}
+
+	if err := run(clickhouseCRD, keeperCRD, outDir); err != nil {
+		log.Fatalf("cluster chart generation failed: %v", err)
+	}
+}
+
+func run(clickhouseCRD, keeperCRD, outDir string) error {
+	chFields, err := buildFields(clickhouseCRD)
+	if err != nil {
+		return fmt.Errorf("extract clickhouse fields from CRD: %w", err)
+	}
+
+	kFields, err := buildFields(keeperCRD)
+	if err != nil {
+		return fmt.Errorf("extract keeper fields from CRD: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := valuesTemplate.Execute(&buf, chartValues{
+		ClickHouseFields: chFields,
+		KeeperFields:     kFields,
+	}); err != nil {
+		return fmt.Errorf("render values template: %w", err)
+	}
+
+	if err := os.MkdirAll(outDir, dirPerm); err != nil {
+		return fmt.Errorf("mkdir %s: %w", outDir, err)
+	}
+
+	out := filepath.Join(outDir, "values.yaml")
+
+	data := regexp.MustCompile(`\n\n\n+`).ReplaceAll(buf.Bytes(), []byte("\n\n"))
+	if err := os.WriteFile(out, data, filePerm); err != nil {
+		return fmt.Errorf("write %s: %w", out, err)
+	}
+
+	if _, err := fmt.Fprintf(os.Stdout, "wrote %s\n", out); err != nil {
+		return fmt.Errorf("stdout: %w", err)
+	}
+
+	return nil
+}
+
+func buildFields(crdPath string) ([]fieldBlock, error) {
+	b, err := os.ReadFile(filepath.Clean(crdPath))
+	if err != nil {
+		return nil, fmt.Errorf("open crd file: %w", err)
+	}
+
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err = sigyaml.Unmarshal(b, &crd); err != nil {
+		return nil, fmt.Errorf("unmarshal crd: %w", err)
+	}
+
+	spec, err := getSpecSchema(&crd)
+	if err != nil {
+		return nil, err
+	}
+
+	fields := make([]fieldBlock, 0, len(spec.Properties))
+
+	for _, name := range slices.Sorted(maps.Keys(spec.Properties)) {
+		f, err := buildField(name, spec.Properties[name])
+		if err != nil {
+			return nil, fmt.Errorf("build field %s: %w", name, err)
+		}
+
+		fields = append(fields, f)
+	}
+
+	return fields, nil
+}
+
+func getSpecSchema(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.JSONSchemaProps, error) {
+	var ver *apiextensionsv1.CustomResourceDefinitionVersion
+
+	for i := range crd.Spec.Versions {
+		if crd.Spec.Versions[i].Storage {
+			ver = &crd.Spec.Versions[i]
+			break
+		}
+	}
+
+	if ver == nil {
+		return nil, fmt.Errorf("no storage version in CRD %s", crd.Name)
+	}
+
+	if ver.Schema == nil || ver.Schema.OpenAPIV3Schema == nil {
+		return nil, fmt.Errorf("no schema in CRD %s", crd.Name)
+	}
+
+	spec, ok := ver.Schema.OpenAPIV3Schema.Properties["spec"]
+	if !ok {
+		return nil, fmt.Errorf("no spec property in CRD %s", crd.Name)
+	}
+
+	return &spec, nil
+}
+
+func buildField(name string, prop apiextensionsv1.JSONSchemaProps) (fieldBlock, error) {
+	f := fieldBlock{
+		Key:         name,
+		Description: strings.TrimSpace(prop.Description),
+	}
+
+	if prop.Default == nil {
+		f.Zero = zeroRepr(prop)
+		return f, nil
+	}
+
+	v, err := decodeDefault(prop.Default)
+	if err != nil {
+		return fieldBlock{}, err
+	}
+
+	f.HasValue = true
+	f.Value = v
+	f.Multiline = isMultiline(v)
+
+	return f, nil
+}
+
+func zeroRepr(prop apiextensionsv1.JSONSchemaProps) string {
+	switch prop.Type {
+	case "string":
+		return `""`
+	case "integer", "number":
+		return "0"
+	case "boolean":
+		return "false"
+	case "array":
+		return "[]"
+	case "object":
+		return "{}"
+	default:
+		return "null"
+	}
+}
+
+func decodeDefault(def *apiextensionsv1.JSON) (any, error) {
+	var v any
+	if err := sigyaml.Unmarshal(def.Raw, &v); err != nil {
+		return nil, fmt.Errorf("unmarshal default %q: %w", string(def.Raw), err)
+	}
+
+	return v, nil
+}
+
+func isMultiline(v any) bool {
+	switch v.(type) {
+	case nil, bool, string, int, int32, int64, float32, float64:
+		return false
+	}
+
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(strings.TrimRight(string(b), "\n"), "\n")
+}
+
+// Template helpers.
+
+func tmplYAML(v any) (string, error) {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("marshal yaml: %w", err)
+	}
+
+	return strings.TrimRight(string(b), "\n"), nil
+}
+
+func tmplIndent(countRaw, strRaw any) (string, error) {
+	count, ok := countRaw.(int)
+	if !ok {
+		return "", fmt.Errorf("indent: expected int, got %T", countRaw)
+	}
+
+	str, ok := strRaw.(string)
+	if !ok {
+		return "", fmt.Errorf("indent: expected string, got %T", strRaw)
+	}
+
+	pad := strings.Repeat(" ", count)
+
+	b := strings.Builder{}
+	for i, line := range strings.Split(str, "\n") {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+
+		if line != "" {
+			b.WriteString(pad)
+		}
+
+		b.WriteString(line)
+	}
+
+	return b.String(), nil
+}
+
+func tmplComment(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+
+	b := strings.Builder{}
+	for i, line := range strings.Split(s, "\n") {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+
+		if line == "" {
+			b.WriteByte('#')
+			continue
+		}
+
+		b.WriteString("# ")
+		b.WriteString(line)
+	}
+
+	return b.String()
+}

--- a/tools/gen-cluster-chart/templates/values.yaml.tmpl
+++ b/tools/gen-cluster-chart/templates/values.yaml.tmpl
@@ -1,0 +1,68 @@
+{{- /* Per-field block emitted under the `spec:` key, indented 4 spaces. */ -}}
+{{- define "field" -}}
+{{- if .Description }}
+{{ comment .Description | indent 4 -}}
+{{- end }}
+{{- if not .HasValue }}
+    # {{ .Key }}: {{ .Zero }}
+{{- else if .Multiline }}
+    {{ .Key }}:
+{{ yaml .Value | indent 6 -}}
+{{- else }}
+    {{ .Key }}: {{ yaml .Value }}
+{{- end }}
+{{ end -}}
+# Default values for clickhouse-cluster-helm.
+#
+# THIS FILE IS GENERATED FROM CRD SCHEMAS. DO NOT EDIT BY HAND.
+# Regenerate with: make generate-cluster-chart
+#
+# Top-level keys map to the two CRs:
+#   clickhouse.{meta,spec}:  applied to ClickHouseCluster metadata + spec
+#   keeper.{meta,spec}:      applied to KeeperCluster metadata + spec
+#
+# Sub-objects (podTemplate, dataVolumeClaimSpec, settings, ...) are free-form
+# pass-throughs validated by the operator webhook on apply.
+#
+# Match --version with the operator chart for compatibility:
+#
+#   helm install clickhouse-operator oci://ghcr.io/clickhouse/clickhouse-operator-helm --version X.Y.Z ...
+#   helm install ch                  oci://ghcr.io/clickhouse/clickhouse-cluster-helm  --version X.Y.Z ...
+
+# Default container image tag for both ClickHouseCluster and KeeperCluster.
+# Empty falls back to the chart appVersion. Per-component overrides via
+# clickhouse.spec.containerTemplate.image.tag / keeper.spec.containerTemplate.image.tag.
+imageTag: ""
+
+clickhouse:
+  # Whether to create the ClickHouseCluster CR.
+  enabled: true
+
+  # Metadata applied to the ClickHouseCluster CR itself.
+  meta:
+    # CR name. Defaults to the Helm release name when empty.
+    name: ""
+    labels: {}
+    annotations: {}
+
+  # ClickHouseCluster.spec — passed verbatim into the CR.
+  spec:
+{{ range .ClickHouseFields }}
+{{ template "field" . -}}
+{{ end }}
+keeper:
+  # Whether to create the KeeperCluster CR.
+  enabled: true
+
+  # Metadata applied to the KeeperCluster CR itself.
+  meta:
+    # CR name. Defaults to the Helm release name when empty.
+    name: ""
+    labels: {}
+    annotations: {}
+
+  # KeeperCluster.spec — passed verbatim into the CR.
+  spec:
+{{ range .KeeperFields }}
+{{ template "field" . -}}
+{{ end }}


### PR DESCRIPTION
## Why

For the projects with Helm-based deployment, it's convenient to use a Helm chart to deploy a CRs to create a cluster

## What

Introduced a new Helm chart for keeper+clickhouse deployment.
values.yaml are generated from the CRD to represent the chart structure