### PR TITLE
feat: drop all capabilities by default, remove restricted security settings in OpenShift installations

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -183,6 +183,12 @@ func run() error {
 		return fmt.Errorf("unable to start manager: %w", err)
 	}
 
+	if err = controllerutil.DetectOpenShift(config); err != nil {
+		setupLog.Error(err, "OpenShift detection failed; falling back to vanilla defaults")
+	}
+
+	setupLog.Info("platform detected", "openshift", controllerutil.IsOpenShift())
+
 	zapLogger := controllerutil.NewLogger(logger)
 
 	var upgradeChecker *upgrade.Checker

--- a/config/manifests/bases/clickhouse-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/clickhouse-operator.clusterserviceversion.yaml
@@ -45,7 +45,9 @@ spec:
       - description: Specification of persistent storage for ClickHouse data.
         displayName: Data Volume Claim Spec
         path: dataVolumeClaimSpec
-      - description: Reference to the KeeperCluster that is used for ClickHouse coordination.
+      - description: |-
+          Reference to the KeeperCluster that is used for ClickHouse coordination.
+          When namespace is omitted, the ClickHouseCluster namespace is used.
         displayName: Keeper Cluster Reference
         path: keeperClusterRef
       - description: Number of replicas in the single shard.
@@ -79,6 +81,11 @@ spec:
       - description: Version indicates the version reported by the container image.
         displayName: Version
         path: version
+      - description: |-
+          VersionProbeRevision is the image hash of the last successful version probe.
+          When this matches the current image hash, the cached Version is used directly.
+        displayName: Version Probe Revision
+        path: versionProbeRevision
       version: v1alpha1
     - description: KeeperCluster is the Schema for the `keeperclusters` API.
       displayName: Keeper Cluster
@@ -137,6 +144,11 @@ spec:
       - description: Version indicates the version reported by the container image.
         displayName: Version
         path: version
+      - description: |-
+          VersionProbeRevision is the image hash of the last successful version probe.
+          When this matches the current image hash, the cached Version is used directly.
+        displayName: Version Probe Revision
+        path: versionProbeRevision
       version: v1alpha1
   description: |
     The ClickHouse Operator is a Kubernetes operator that automates the deployment, configuration, and management of ClickHouse clusters and ClickHouse Keeper clusters on Kubernetes.

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -441,7 +441,7 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 			RunAsUser: new(int64(7)),
 		}
 		updatedCR.Spec.ContainerTemplate.SecurityContext = &corev1.SecurityContext{
-			Privileged: new(true),
+			AllowPrivilegeEscalation: new(true),
 		}
 		testutil.ReconcileStatefulSets(ctx, updatedCR, suite)
 		Expect(suite.Client.Update(ctx, updatedCR)).To(Succeed())
@@ -459,7 +459,7 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 		}, &sts)).To(Succeed())
 
 		Expect(*sts.Spec.Template.Spec.SecurityContext.RunAsUser).To(BeEquivalentTo(7))
-		Expect(*sts.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeEquivalentTo(true))
+		Expect(*sts.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeEquivalentTo(true))
 	})
 
 	It("should ignore PDBs if Ignored", func(ctx context.Context) {

--- a/internal/controller/clickhouse/templates.go
+++ b/internal/controller/clickhouse/templates.go
@@ -295,15 +295,11 @@ func templatePodSpec(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (corev1
 	controllerutil.SortKey(volumes, func(v corev1.Volume) string { return v.Name })
 
 	podSpec := corev1.PodSpec{
-		RestartPolicy: corev1.RestartPolicyAlways,
-		DNSPolicy:     corev1.DNSClusterFirst,
-		Volumes:       volumes,
-		Containers:    []corev1.Container{container},
-		SecurityContext: &corev1.PodSecurityContext{
-			FSGroup:    new(controller.DefaultUser),
-			RunAsUser:  new(controller.DefaultUser),
-			RunAsGroup: new(controller.DefaultUser),
-		},
+		RestartPolicy:   corev1.RestartPolicyAlways,
+		DNSPolicy:       corev1.DNSClusterFirst,
+		Volumes:         volumes,
+		Containers:      []corev1.Container{container},
+		SecurityContext: controller.DefaultPodSecurityContext(),
 	}
 
 	if cr.Spec.PodTemplate.TopologyZoneKey != nil && *cr.Spec.PodTemplate.TopologyZoneKey != "" {
@@ -433,11 +429,7 @@ func templateContainer(r *clickhouseReconciler) (corev1.Container, error) {
 		ReadinessProbe:           &readinessProbe,
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		SecurityContext: &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"IPC_LOCK", "PERFMON", "SYS_PTRACE"},
-			},
-		},
+		SecurityContext:          controller.DefaultContainerSecurityContext(),
 	}
 
 	for i := range clusterSecrets {

--- a/internal/controller/clickhouse/templates_test.go
+++ b/internal/controller/clickhouse/templates_test.go
@@ -229,6 +229,48 @@ var _ = Describe("BuildVolumes", func() {
 	})
 })
 
+var _ = Describe("SecurityContext defaults", func() {
+	newCtx := func() clickhouseReconciler {
+		return clickhouseReconciler{
+			Cluster: &v1.ClickHouseCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: v1.ClickHouseClusterSpec{
+					DataVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{},
+				},
+			},
+		}
+	}
+
+	Context("on vanilla Kubernetes", func() {
+		BeforeEach(func() { controllerutil.SetOpenShiftForTest(false) })
+		AfterEach(func() { controllerutil.SetOpenShiftForTest(false) })
+
+		It("should pin pod FSGroup to the ClickHouse user", func() {
+			ctx := newCtx()
+			podSpec, err := templatePodSpec(&ctx, v1.ClickHouseReplicaID{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podSpec.SecurityContext).NotTo(BeNil())
+			Expect(podSpec.SecurityContext.FSGroup).NotTo(BeNil())
+			Expect(*podSpec.SecurityContext.FSGroup).To(BeEquivalentTo(101))
+		})
+	})
+
+	Context("on OpenShift", func() {
+		BeforeEach(func() { controllerutil.SetOpenShiftForTest(true) })
+		AfterEach(func() { controllerutil.SetOpenShiftForTest(false) })
+
+		It("should leave pod UID/GID/FSGroup unset so SCC can inject them", func() {
+			ctx := newCtx()
+			podSpec, err := templatePodSpec(&ctx, v1.ClickHouseReplicaID{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podSpec.SecurityContext).NotTo(BeNil())
+			Expect(podSpec.SecurityContext.FSGroup).To(BeNil())
+			Expect(podSpec.SecurityContext.RunAsUser).To(BeNil())
+			Expect(podSpec.SecurityContext.RunAsGroup).To(BeNil())
+		})
+	})
+})
+
 var _ = Describe("PDB", func() {
 	var cr *v1.ClickHouseCluster
 

--- a/internal/controller/keeper/controller_test.go
+++ b/internal/controller/keeper/controller_test.go
@@ -302,7 +302,7 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 			RunAsUser: new(int64(7)),
 		}
 		updatedCR.Spec.ContainerTemplate.SecurityContext = &corev1.SecurityContext{
-			Privileged: new(true),
+			AllowPrivilegeEscalation: new(true),
 		}
 		testutil.ReconcileStatefulSets(ctx, updatedCR, suite)
 		Expect(suite.Client.Update(ctx, updatedCR)).To(Succeed())
@@ -317,7 +317,7 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 		}, &sts)).To(Succeed())
 
 		Expect(*sts.Spec.Template.Spec.SecurityContext.RunAsUser).To(BeEquivalentTo(7))
-		Expect(*sts.Spec.Template.Spec.Containers[0].SecurityContext.Privileged).To(BeEquivalentTo(true))
+		Expect(*sts.Spec.Template.Spec.Containers[0].SecurityContext.AllowPrivilegeEscalation).To(BeEquivalentTo(true))
 	})
 
 	It("should ignore PDBs if Ignored", func(ctx context.Context) {

--- a/internal/controller/keeper/templates.go
+++ b/internal/controller/keeper/templates.go
@@ -393,15 +393,11 @@ func templatePodSpec(cr *v1.KeeperCluster, id v1.KeeperReplicaID) (corev1.PodSpe
 	controllerutil.SortKey(volumes, func(v corev1.Volume) string { return v.Name })
 
 	podSpec := corev1.PodSpec{
-		RestartPolicy: corev1.RestartPolicyAlways,
-		DNSPolicy:     corev1.DNSClusterFirst,
-		Volumes:       volumes,
-		Containers:    []corev1.Container{container},
-		SecurityContext: &corev1.PodSecurityContext{
-			FSGroup:    new(controller.DefaultUser),
-			RunAsUser:  new(controller.DefaultUser),
-			RunAsGroup: new(controller.DefaultUser),
-		},
+		RestartPolicy:   corev1.RestartPolicyAlways,
+		DNSPolicy:       corev1.DNSClusterFirst,
+		Volumes:         volumes,
+		Containers:      []corev1.Container{container},
+		SecurityContext: controller.DefaultPodSecurityContext(),
 	}
 
 	podTemplate := cr.Spec.PodTemplate
@@ -532,30 +528,7 @@ func templateContainer(cr *v1.KeeperCluster) (corev1.Container, error) {
 		ReadinessProbe:           &readinessProbe,
 		TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 		TerminationMessagePolicy: corev1.TerminationMessageReadFile,
-		// Default capabilities given to ClickHouse keeper.
-		// For more information, see https://unofficial-kubernetes.readthedocs.io/en/latest/concepts/policy/container-capabilities/
-		// IPC_LOCK
-		// •  Lock memory (mlock(2), mlockall(2), mmap(2), shmctl(2));
-		// •  Allocate memory using huge pages (memfd_create(2), mmap(2), shmctl(2)).
-		// ^^ Needed for better performance.
-		//
-		// SYS_PTRACE
-		// •  Trace arbitrary processes using ptrace(2);
-		// •  apply get_robust_list(2) to arbitrary processes;
-		// •  transfer data to or from the memory of arbitrary processes using process_vm_readv(2) and process_vm_writev(2);
-		// •  inspect processes using kcmp(2).
-		// ^^ Needed to get Kernel's performance counters from inside the container (to use perf)
-		//
-		// PERFMON
-		// 	 Employ various performance-monitoring mechanisms, including:
-		// •  call perf_event_open(2);
-		// •  employ various BPF operations that have performance implications.
-		// ^^ Needed to get Kernel's performance counters from inside the container (to use perf)
-		SecurityContext: &corev1.SecurityContext{
-			Capabilities: &corev1.Capabilities{
-				Add: []corev1.Capability{"IPC_LOCK", "PERFMON", "SYS_PTRACE"},
-			},
-		},
+		SecurityContext:          controller.DefaultContainerSecurityContext(),
 	}
 
 	if !cr.Spec.Settings.TLS.Enabled || !cr.Spec.Settings.TLS.Required {

--- a/internal/controller/securitycontext.go
+++ b/internal/controller/securitycontext.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+// DefaultPodSecurityContext returns the operator's default PodSecurityContext.
+// It generates different defaults for OpenShift installations, so default settings conform restricted-v2.
+func DefaultPodSecurityContext() *corev1.PodSecurityContext {
+	psc := &corev1.PodSecurityContext{
+		RunAsNonRoot:   new(true),
+		SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
+
+	if !controllerutil.IsOpenShift() {
+		psc.FSGroup = new(DefaultUser)
+		psc.RunAsUser = new(DefaultUser)
+		psc.RunAsGroup = new(DefaultUser)
+	}
+
+	return psc
+}
+
+// DefaultContainerSecurityContext returns the operator's default container-level SecurityContext.
+func DefaultContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		RunAsNonRoot:             new(true),
+		AllowPrivilegeEscalation: new(false),
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	}
+}

--- a/internal/controller/securitycontext_test.go
+++ b/internal/controller/securitycontext_test.go
@@ -1,0 +1,85 @@
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+var _ = Describe("DefaultContainerSecurityContext", func() {
+	It("should drop all capabilities", func() {
+		sc := DefaultContainerSecurityContext()
+		Expect(sc.Capabilities).NotTo(BeNil())
+		Expect(sc.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
+		Expect(sc.Capabilities.Add).To(BeEmpty())
+	})
+
+	It("should disable privilege escalation", func() {
+		sc := DefaultContainerSecurityContext()
+		Expect(sc.AllowPrivilegeEscalation).NotTo(BeNil())
+		Expect(*sc.AllowPrivilegeEscalation).To(BeFalse())
+	})
+
+	It("should require non-root execution", func() {
+		sc := DefaultContainerSecurityContext()
+		Expect(sc.RunAsNonRoot).NotTo(BeNil())
+		Expect(*sc.RunAsNonRoot).To(BeTrue())
+	})
+
+	It("should set runtime-default seccomp profile", func() {
+		sc := DefaultContainerSecurityContext()
+		Expect(sc.SeccompProfile).NotTo(BeNil())
+		Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+	})
+})
+
+var _ = Describe("DefaultPodSecurityContext", func() {
+	Context("on vanilla Kubernetes", func() {
+		BeforeEach(func() { controllerutil.SetOpenShiftForTest(false) })
+		AfterEach(func() { controllerutil.SetOpenShiftForTest(false) })
+
+		It("should set FSGroup, RunAsUser and RunAsGroup to the ClickHouse user (101)", func() {
+			sc := DefaultPodSecurityContext()
+			Expect(sc.FSGroup).NotTo(BeNil())
+			Expect(*sc.FSGroup).To(Equal(DefaultUser))
+			Expect(sc.RunAsUser).NotTo(BeNil())
+			Expect(*sc.RunAsUser).To(Equal(DefaultUser))
+			Expect(sc.RunAsGroup).NotTo(BeNil())
+			Expect(*sc.RunAsGroup).To(Equal(DefaultUser))
+		})
+
+		It("should require non-root execution", func() {
+			sc := DefaultPodSecurityContext()
+			Expect(sc.RunAsNonRoot).NotTo(BeNil())
+			Expect(*sc.RunAsNonRoot).To(BeTrue())
+		})
+
+		It("should set runtime-default seccomp profile", func() {
+			sc := DefaultPodSecurityContext()
+			Expect(sc.SeccompProfile).NotTo(BeNil())
+			Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+		})
+	})
+
+	Context("on OpenShift", func() {
+		BeforeEach(func() { controllerutil.SetOpenShiftForTest(true) })
+		AfterEach(func() { controllerutil.SetOpenShiftForTest(false) })
+
+		It("should omit FSGroup, RunAsUser and RunAsGroup so restricted-v2 SCC can inject them", func() {
+			sc := DefaultPodSecurityContext()
+			Expect(sc.FSGroup).To(BeNil())
+			Expect(sc.RunAsUser).To(BeNil())
+			Expect(sc.RunAsGroup).To(BeNil())
+		})
+
+		It("should still require non-root and runtime-default seccomp", func() {
+			sc := DefaultPodSecurityContext()
+			Expect(sc.RunAsNonRoot).NotTo(BeNil())
+			Expect(*sc.RunAsNonRoot).To(BeTrue())
+			Expect(sc.SeccompProfile).NotTo(BeNil())
+			Expect(sc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+		})
+	})
+})

--- a/internal/controller/versionprobe.go
+++ b/internal/controller/versionprobe.go
@@ -267,7 +267,7 @@ func (rm *ResourceManager) buildVersionProbeJob(cfg VersionProbeConfig, revision
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ImagePullSecrets:   cfg.PodTemplate.ImagePullSecrets,
-					SecurityContext:    cfg.PodTemplate.SecurityContext,
+					SecurityContext:    DefaultPodSecurityContext(),
 					NodeSelector:       cfg.PodTemplate.NodeSelector,
 					Tolerations:        cfg.PodTemplate.Tolerations,
 					ServiceAccountName: cfg.PodTemplate.ServiceAccountName,
@@ -277,7 +277,7 @@ func (rm *ResourceManager) buildVersionProbeJob(cfg VersionProbeConfig, revision
 							Name:                     v1.VersionProbeContainerName,
 							Image:                    cfg.ContainerTemplate.Image.String(),
 							ImagePullPolicy:          cfg.ContainerTemplate.ImagePullPolicy,
-							SecurityContext:          cfg.ContainerTemplate.SecurityContext,
+							SecurityContext:          DefaultContainerSecurityContext(),
 							TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 							Command:                  []string{"sh", "-c", fmt.Sprintf("%s --version > %s 2>&1", cfg.Binary, corev1.TerminationMessagePathDefault)},

--- a/internal/controllerutil/openshift.go
+++ b/internal/controllerutil/openshift.go
@@ -1,0 +1,48 @@
+package controllerutil
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+const openShiftGroupVersion = "security.openshift.io/v1"
+
+var isOpenShift atomic.Bool
+
+// DetectOpenShift probes the API server for the security.openshift.io API
+// group, which is registered on OpenShift but not on vanilla Kubernetes.
+// A missing group (vanilla k8s) is the expected non-OpenShift case and is not
+// returned as an error — only genuine discovery/transport failures are.
+func DetectOpenShift(cfg *rest.Config) error {
+	disc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("build discovery client: %w", err)
+	}
+
+	_, err = disc.ServerResourcesForGroupVersion(openShiftGroupVersion)
+	switch {
+	case err == nil:
+		isOpenShift.Store(true)
+		return nil
+	case apierrors.IsNotFound(err), discovery.IsGroupDiscoveryFailedError(err):
+		// Group not served — vanilla Kubernetes. Expected, not an error.
+		return nil
+	default:
+		return fmt.Errorf("OpenShift probe %s: %w", openShiftGroupVersion, err)
+	}
+}
+
+// IsOpenShift returns the result of OpenShift probe.
+func IsOpenShift() bool {
+	return isOpenShift.Load()
+}
+
+// SetOpenShiftForTest sets the OpenShift detection result.
+// For testing usage only.
+func SetOpenShiftForTest(state bool) {
+	isOpenShift.Store(state)
+}

--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -164,23 +164,12 @@ var _ = Describe("OLM deployment", Ordered, Label("olm"), func() {
 		currentTestNamespace = namespace
 
 		By("installing operator-sdk")
-		runCmd(ctx, "make", "operator-sdk")
 
-		out, err := testutil.Run(exec.CommandContext(ctx, "make", "operator-sdk-path"))
+		out, err := testutil.Run(exec.CommandContext(ctx, "make", "-s", "operator-sdk-path"))
 		Expect(err).ToNot(HaveOccurred(), string(out))
+		Expect(out).ToNot(BeEmpty(), "operator-sdk path not found in output: %s", string(out))
 
-		// Extract the path from make output, skipping make[N] directory messages.
-		var operatorSDK string
-		for line := range strings.SplitSeq(string(out), "\n") {
-			line = strings.TrimSpace(line)
-			if line != "" && strings.HasPrefix(line, "/") && strings.HasSuffix(line, "operator-sdk") {
-				operatorSDK = line
-
-				break
-			}
-		}
-
-		Expect(operatorSDK).ToNot(BeEmpty(), "operator-sdk path not found in output: %s", string(out))
+		operatorSDK := strings.TrimSpace(string(out))
 
 		By("installing OLM")
 
@@ -197,6 +186,12 @@ var _ = Describe("OLM deployment", Ordered, Label("olm"), func() {
 
 		By("creating test namespace")
 		testutil.EnsureNamespace(ctx, k8sClient, namespace)
+
+		// Enforce upstream Pod Security Admission at "restricted" level on the OLM test namespace.
+		By("labeling test namespace with PSA enforce=restricted")
+		runCmd(ctx, "kubectl", "label", "ns", namespace, "--overwrite",
+			"pod-security.kubernetes.io/enforce=restricted",
+			"pod-security.kubernetes.io/enforce-version=latest")
 
 		By("building OLM bundle")
 		runCmd(ctx, "make", "bundle", "IMG="+testImage)

--- a/test/deploy/olm_manifests.yaml.tmpl
+++ b/test/deploy/olm_manifests.yaml.tmpl
@@ -17,10 +17,25 @@ metadata:
   labels:
     app: test-catalog-server
 spec:
+  # Restricted Pod Security Standard compliance — the OLM test namespace is
+  # labeled pod-security.kubernetes.io/enforce=restricted, so the catalog
+  # server pod must drop ALL caps, run non-root, disable privilege escalation,
+  # and set the runtime-default seccomp profile.
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: opm
     image: quay.io/operator-framework/opm:v1.62.0
     command: ["opm", "serve", "/configs"]
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+      seccompProfile:
+        type: RuntimeDefault
     ports:
     - containerPort: 50051
     volumeMounts:


### PR DESCRIPTION
## Why

Defaulted capabilities are not needed in most cases and won't fit the hardened environments.
OpenShift has stricter security requirements, while some settings have injected defaults that behave as ClickHouse requires

## What

- Replace the default capabilities with drop: ["ALL"]
- Unset UID/GUID/FSUID in OpenShift environments
- Add e2e test against MicroShift

## Related Issues

Related to #180 