### PR TITLE
feat: correctly handle ipv4-only envs

### DIFF
--- a/examples/aws_eks_gp3.yaml
+++ b/examples/aws_eks_gp3.yaml
@@ -134,8 +134,6 @@ spec:
       secret:
         key: password
         name: default-password
-    extraConfig:
-      listen_host: "0.0.0.0"
 ---
 apiVersion: v1
 kind: Service

--- a/examples/gcp_gke_ssd.yaml
+++ b/examples/gcp_gke_ssd.yaml
@@ -120,8 +120,6 @@ spec:
       secret:
         key: password
         name: default-password
-    extraConfig:
-      listen_host: "0.0.0.0"
 ---
 apiVersion: v1
 kind: Service

--- a/internal/controller/clickhouse/templates/network.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/network.yaml.tmpl
@@ -1,4 +1,7 @@
-listen_host: "::"
+listen_host:
+  - "::"
+  - "0.0.0.0"
+listen_try: 1
 {{- /* can't use composable protocol for interserver, because server disables replication,
       if interserver_http_port is not set */}}
 interserver_http_port: {{ .InterserverHTTPPort }}

--- a/internal/controller/keeper/templates.go
+++ b/internal/controller/keeper/templates.go
@@ -179,7 +179,8 @@ func generateQuorumConfig(r *keeperReconciler) quorumConfig {
 }
 
 type config struct {
-	ListenHost   string                      `yaml:"listen_host"`
+	ListenHost   []string                    `yaml:"listen_host"`
+	ListenTry    bool                        `yaml:"listen_try"`
 	Path         string                      `yaml:"path"`
 	Logger       controller.LoggerConfig     `yaml:"logger"`
 	Prometheus   controller.PrometheusConfig `yaml:"prometheus"`
@@ -326,7 +327,8 @@ func replicaLabels(cr *v1.KeeperCluster, id v1.KeeperReplicaID) map[string]strin
 
 func generateConfigForSingleReplica(cr *v1.KeeperCluster, id v1.KeeperReplicaID) (map[string]string, error) {
 	config := config{
-		ListenHost: "0.0.0.0",
+		ListenHost: []string{"::", "0.0.0.0"},
+		ListenTry:  true,
 		Path:       internal.KeeperDataPath,
 		Prometheus: controller.DefaultPrometheusConfig(PortPrometheusScrape),
 		Logger:     controller.GenerateLoggerConfig(cr.Spec.Settings.Logger, LogPath, "clickhouse-keeper"),


### PR DESCRIPTION
## Why

`listen_host: "::"` do not work in ipv4 only envs and require extra config to run.
`listen_try` is acceptable as a liveness probe that checks that the port is being listened to.

## What

Change the default listen config to work in IPv4-only environments by default

## Related Issues

Fixes #169
