### PR TITLE
Docs: add Mintlify frontmatter to docs pages

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -1,3 +1,12 @@
+---
+position: 2
+slug: /clickhouse-operator/guides/configuration
+title: 'Configuration'
+keywords: ['kubernetes']
+description: 'This guide covers how to configure ClickHouse and Keeper clusters using the ClickHouse operator.'
+doc_type: 'guide'
+---
+
 # ClickHouse Operator configuration guide
 
 This guide covers how to configure ClickHouse and Keeper clusters using the operator.

--- a/docs/guides/introduction.mdx
+++ b/docs/guides/introduction.mdx
@@ -1,3 +1,12 @@
+---
+position: 1
+slug: /clickhouse-operator/guides/introduction
+title: 'Introduction'
+keywords: ['kubernetes']
+description: 'This document provides an overview of key concepts and usage patterns for the ClickHouse Operator.'
+doc_type: 'guide'
+---
+
 # Introduction to the ClickHouse Operator
 
 This document provides an overview of key concepts and usage patterns for the ClickHouse Operator.

--- a/docs/install/helm.mdx
+++ b/docs/install/helm.mdx
@@ -1,3 +1,12 @@
+---
+slug: /clickhouse-operator/install/helm
+title: 'Install the ClickHouse Operator with Helm'
+keywords: ['kubernetes']
+description: 'This guide covers installing the ClickHouse Operator using Helm charts.'
+doc_type: 'guide'
+sidebarTitle: 'Helm'
+---
+
 This guide covers installing the ClickHouse Operator using Helm charts.
 
 ## Prerequisites {#prerequisites}

--- a/docs/install/kubectl.mdx
+++ b/docs/install/kubectl.mdx
@@ -1,3 +1,12 @@
+---
+slug: /clickhouse-operator/install/kubectl
+title: 'Install the ClickHouse Operator with kubectl'
+keywords: ['kubernetes']
+description: 'This guide covers installing the ClickHouse Operator using kubectl and manifest files.'
+doc_type: 'guide'
+sidebarTitle: 'kubectl'
+---
+
 This guide covers installing the ClickHouse Operator using kubectl and manifest files.
 
 ## Prerequisites {#prerequisites}

--- a/docs/install/olm.mdx
+++ b/docs/install/olm.mdx
@@ -1,3 +1,12 @@
+---
+slug: /clickhouse-operator/install/olm
+title: 'Install the ClickHouse Operator with Operator Lifecycle Manager (OLM)'
+keywords: ['kubernetes']
+description: 'This guide covers installing the ClickHouse Operator using kubectl and manifest files.'
+doc_type: 'guide'
+sidebarTitle: 'OLM'
+---
+
 This guide covers installing the ClickHouse Operator using Operator Lifecycle Manager (OLM).
 
 ## Prerequisites {#prerequisites}

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -1,3 +1,13 @@
+---
+position: 1
+slug: /clickhouse-operator/overview
+title: 'ClickHouse Operator'
+keywords: ['kubernetes']
+description: 'Overview page for the ClickHouse Operator - a Kubernetes operator that automates the deployment, configuration, and management of ClickHouse clusters and ClickHouse Keeper clusters on Kubernetes.'
+doc_type: 'guide'
+sidebarTitle: 'Overview'
+---
+
 The ClickHouse Operator is a Kubernetes operator that automates the deployment, configuration, and management of ClickHouse clusters and ClickHouse Keeper clusters on Kubernetes.
 It provides declarative cluster management through custom resources, enabling users to easily create highly-available ClickHouse deployments.
 

--- a/docs/reference/api-reference.mdx
+++ b/docs/reference/api-reference.mdx
@@ -1,8 +1,10 @@
 ---
+position: 1
 slug: /clickhouse-operator/reference/api-reference
 title: 'ClickHouse Operator API reference'
-keywords: ['kubernetes', 'operator', 'API reference']
+keywords: ['kubernetes']
 description: 'This document provides detailed API reference for the ClickHouse Operator custom resources.'
+doc_type: 'reference'
 sidebarTitle: 'API reference'
 ---
 

--- a/docs/templates/gv_list.tpl
+++ b/docs/templates/gv_list.tpl
@@ -1,10 +1,12 @@
 {{- define "gvList" -}}
 {{- $groupVersions := . -}}
 ---
+position: 1
 slug: /clickhouse-operator/reference/api-reference
 title: 'ClickHouse Operator API reference'
-keywords: ['kubernetes', 'operator', 'API reference']
+keywords: ['kubernetes']
 description: 'This document provides detailed API reference for the ClickHouse Operator custom resources.'
+doc_type: 'reference'
 sidebarTitle: 'API reference'
 ---
 


### PR DESCRIPTION
Restores YAML frontmatter (slug, title, keywords, description, doc_type, position/sidebarTitle) on docs pages so the Mintlify sync workflow preserves it instead of repeatedly trying to remove it on each sync.

Also updates the autogen API reference template (gv_list.tpl) to emit the same frontmatter shape, so regenerated api-reference.mdx stays consistent.

## Why

<!--
Please describe why you are proposing this code change. This should include
at least a single text paragraph.
-->

The Mintlify workflows are working correctly, however I forgot to include the document frontmatter in these docs, so it is trying to remove it from the docs repo now. See: https://github.com/ClickHouse/mintlify-docs-dev/pull/32

## What

<!--
Please explain what you did. For small/trivial changes a single paragraph is
probably sufficient.
-->

Minor change: adds back front-matter to the docs.
## Related Issues

<!-- Link to related issues using #issue-number -->

Fixes #
Related to #
