### PR TITLE
docs: prefix internal ClickHouse doc links with /core

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -350,8 +350,8 @@ spec:
 ```
 
 #### Useful links:
-* [YAML configuration examples](/concepts/features/configuration/server-config/configuration-files#example-1)
-* [All server settings](/reference/settings/server-settings/settings)
+* [YAML configuration examples](/core/concepts/features/configuration/server-config/configuration-files#example-1)
+* [All server settings](/core/reference/settings/server-settings/settings)
 
 ### Embedded extra users configuration {#embedded-extra-users-configuration}
 
@@ -383,7 +383,7 @@ spec:
 The `extraUsersConfig` is stored in k8s ConfigMap object. Avoid plain text secrets there.
 </Note>
 
-#### See [documentation](/concepts/features/configuration/settings/settings-users) for all supported ClickHouse users configuration options.
+#### See [documentation](/core/concepts/features/configuration/settings/settings-users) for all supported ClickHouse users configuration options.
 
 ### Configuration example {#configuration-example}
 

--- a/docs/guides/introduction.mdx
+++ b/docs/guides/introduction.mdx
@@ -101,7 +101,7 @@ The ClickHouse Operator automatically replicates database definitions across all
 ### What Gets Replicated {#what-gets-replicated}
 
 The operator synchronizes:
-- [Replicated](/reference/engines/database-engines/replicated) database definitions
+- [Replicated](/core/reference/engines/database-engines/replicated) database definitions
 - Integration database engines (PostgreSQL, MySQL, etc.)
 
 The operator does **not** synchronize:
@@ -114,7 +114,7 @@ The operator does **not** synchronize:
 <Tip>
 **Best practice**
 
-Always use the [Replicated](/reference/engines/database-engines/replicated) database engine for production deployments.
+Always use the [Replicated](/core/reference/engines/database-engines/replicated) database engine for production deployments.
 </Tip>
 
 Benefits:


### PR DESCRIPTION
I moved some directories around in the Mintlify site, so there are a few links in this repo that need updating.
Will have a check in place that disallows making updates to these files in the docs repo in future so that syncing only takes place in one direction.

Updates the five affected references in guides/configuration.mdx and guides/introduction.mdx so the next sync ships them correctly.

## Why

<!--
Please describe why you are proposing this code change. This should include
at least a single text paragraph.
-->

## What

<!--
Please explain what you did. For small/trivial changes a single paragraph is
probably sufficient.
-->

## Related Issues

<!-- Link to related issues using #issue-number -->

Fixes #
Related to #
