### PR TITLE
test: add openshift e2e smoke test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -324,6 +324,69 @@ jobs:
           reporter: java-junit
           path: "**/*-report.xml"
 
+  openshift-compat:
+    needs: [ compat-e2e-test, e2e-test ]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, openshift, operator]
+    continue-on-error: true
+    timeout-minutes: 60
+    concurrency:
+      group: openshift-compatibility
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: write
+    env:
+      KUBECONFIG: /home/runner/okd-install/auth/kubeconfig
+      VERSION: 0.0.99-test
+      IMG: ghcr.io/clickhouse/clickhouse-operator:test
+      BUNDLE_IMG: ghcr.io/clickhouse/clickhouse-operator-bundle:test
+      CATALOG_IMG: ghcr.io/clickhouse/clickhouse-operator-catalog:test
+      SINGLE_BUNDLE_IMAGE: ghcr.io/clickhouse/clickhouse-operator-bundle:test
+      OPENSHIFT_CATALOG_IMAGE: ghcr.io/clickhouse/clickhouse-operator-catalog:test
+      OPENSHIFT_CHANNEL: stable-v0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push test operator + bundle + catalog
+        run: make docker-buildx bundle bundle-buildx catalog-buildx
+
+      - name: Clean up cluster state from previous runs
+        run: sudo /usr/local/bin/okd-cleanup.sh
+
+      - name: Install OLM tooling
+        run: make operator-sdk opm
+
+      - name: Run OLM compatibility e2e
+        run: make test-compat-e2e-olm-openshift
+
+      - name: Test Report
+        uses: dorny/test-reporter@v3
+        with:
+          name: E2E tests
+          badge-title: E2E tests
+          reporter: java-junit
+          path: "**/report/*"
+
+      - name: Wipe workspace
+        if: always()
+        run: rm -rf "$GITHUB_WORKSPACE/.git" "$GITHUB_WORKSPACE/_work" || true
+
   ci-success-check:
     name: All CI checks passed
     runs-on: ubuntu-latest

--- a/.github/workflows/openshift-runner-rebuild.yaml
+++ b/.github/workflows/openshift-runner-rebuild.yaml
@@ -1,0 +1,35 @@
+name: OpenShift runner rebuild
+
+on:
+  schedule:
+    - cron: '0 6 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openshift-compatibility
+  cancel-in-progress: false
+
+jobs:
+  rebuild:
+    runs-on: [self-hosted, openshift, operator]
+    timeout-minutes: 120
+    env:
+      KUBECONFIG: /home/runner/okd-install/auth/kubeconfig
+    steps:
+      - name: Show pre-rebuild cluster state
+        run: |
+          oc get nodes || true
+          oc get co --no-headers || true
+          sudo virsh -c qemu:///system list --all || true
+
+      - name: Rebuild OKD cluster
+        run: sudo --preserve-env=GITHUB_ACTIONS /usr/local/bin/okd-rebuild.sh
+
+      - name: Show post-rebuild cluster state
+        run: |
+          oc get nodes
+          oc get clusterversion
+          oc get co

--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,12 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e | grep -v /deploy) \
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e | grep -v /deploy | grep -v /openshift) \
 	--ginkgo.v
 
 .PHONY: test-ci
 test-ci: manifests generate fmt vet envtest ## Run tests in CI env.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e | grep -v /deploy) \
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e | grep -v /deploy | grep -v /openshift) \
 	-v -count=1 -race -coverprofile cover.out --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
 fuzz-keeper: generate # Run keeper spec fuzz tests
@@ -166,11 +166,15 @@ test-clickhouse-e2e: ## Run clickhouse e2e tests.
 
 .PHONY: test-compat-e2e  # Run compatibility smoke tests across ClickHouse versions.
 test-compat-e2e: ## Run compatibility e2e tests (requires CLICKHOUSE_VERSION env var).
-	go test ./test/deploy/ -test.timeout 30m -v --ginkgo.v --ginkgo.label-filter=!olm --ginkgo.junit-report=report/junit-report.xml
+	go test ./test/deploy/ -test.timeout 30m -v --ginkgo.v --ginkgo.label-filter='!olm' --ginkgo.junit-report=report/junit-report.xml
 
 .PHONY: test-compat-e2e-olm  # Run OLM deployment smoke test.
 test-compat-e2e-olm: ## Run OLM deployment e2e test on a dedicated cluster.
 	go test ./test/deploy/ -test.timeout 30m -v --ginkgo.v --ginkgo.label-filter=olm --ginkgo.junit-report=report/junit-report.xml
+
+.PHONY: test-compat-e2e-olm-openshift  # Run OLM deployment smoke test on OpenShift.
+test-compat-e2e-olm-openshift: ## Run OLM deployment e2e against an OpenShift cluster.
+	go test ./test/openshift/ -test.timeout 30m -v --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
 .PHONY: test-compat-e2e-manifest  # Run compatibility smoke tests (manifests deployment only).
 test-compat-e2e-manifest: ## Run compatibility e2e tests using manifests deployment only (requires CLICKHOUSE_VERSION env var).

--- a/ci/actionlint.yaml
+++ b/ci/actionlint.yaml
@@ -1,3 +1,6 @@
 self-hosted-runner:
   labels:
     - amd-medium
+    - openshift
+    - operator
+    - openshift-okd

--- a/ci/generate-catalog-template.sh
+++ b/ci/generate-catalog-template.sh
@@ -1,13 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Generate OLM catalog template with all available bundles from registry
-# Usage: ./ci/generate-catalog-template.sh [<bundle-image>]
+# Default mode: list released + fast bundle tags from ghcr, emit stable-v0
+# + fast-v0 template.
+#
+# SINGLE_BUNDLE_IMAGE=<image> mode: emit a one-bundle stable-v0 template
+# pointing at the given image. Used by the per-PR OpenShift compatibility
+# job which builds its own bundle for the PR head.
 
-# Image repository
 BUNDLE_IMAGE=${1-ghcr.io/clickhouse/clickhouse-operator-bundle}
-# Output file
 OUTPUT_FILE="catalog/clickhouse-operator-template.yaml"
+mkdir -p catalog
+
+if [ -n "${SINGLE_BUNDLE_IMAGE:-}" ]; then
+    cat > "$OUTPUT_FILE" <<EOF
+Schema: olm.semver
+GenerateMajorChannels: true
+GenerateMinorChannels: false
+Stable:
+  Bundles:
+    - Image: ${SINGLE_BUNDLE_IMAGE}
+EOF
+    echo "Single-bundle catalog: ${SINGLE_BUNDLE_IMAGE}"
+    cat "$OUTPUT_FILE"
+    exit 0
+fi
 
 # Function to get all tags from ghcr.io
 get_bundle_tags() {
@@ -39,10 +56,6 @@ get_bundle_tags() {
         | sort -V
 }
 
-# Create catalog directory if it doesn't exist
-mkdir -p catalog
-
-# Generate the template YAML
 cat > "$OUTPUT_FILE" <<EOF
 Schema: olm.semver
 GenerateMajorChannels: true

--- a/internal/controller/clickhouse/templates.go
+++ b/internal/controller/clickhouse/templates.go
@@ -703,6 +703,13 @@ func buildVolumes(r *clickhouseReconciler, id v1.ClickHouseReplicaID) []corev1.V
 		})
 	}
 
+	if r.Cluster.Spec.DataVolumeClaimSpec == nil && !controller.UserMountsAt(r.Cluster.Spec.ContainerTemplate.VolumeMounts, internal.ClickHouseDataPath) {
+		volumes = append(volumes, corev1.Volume{
+			Name:         internal.PersistentVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+	}
+
 	return volumes
 }
 
@@ -722,6 +729,11 @@ func buildMounts(r *clickhouseReconciler) []corev1.VolumeMount {
 				SubPath:   "var-log-clickhouse",
 			},
 		)
+	} else if !controller.UserMountsAt(r.Cluster.Spec.ContainerTemplate.VolumeMounts, internal.ClickHouseDataPath) {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      internal.PersistentVolumeName,
+			MountPath: internal.ClickHouseDataPath,
+		})
 	}
 
 	seenPaths := map[string]struct{}{}

--- a/internal/controller/clickhouse/templates_test.go
+++ b/internal/controller/clickhouse/templates_test.go
@@ -59,8 +59,8 @@ var _ = Describe("BuildVolumes", func() {
 		volumes := buildVolumes(&ctx, v1.ClickHouseReplicaID{})
 		mounts := buildMounts(&ctx)
 
-		Expect(volumes).To(HaveLen(4))
-		Expect(mounts).To(HaveLen(4))
+		Expect(volumes).To(HaveLen(5))
+		Expect(mounts).To(HaveLen(5))
 		checkVolumeMounts(volumes, mounts)
 	})
 
@@ -487,13 +487,13 @@ var _ = Describe("getConfigurationRevisions", func() {
 })
 
 func checkVolumeMounts(volumes []corev1.Volume, mounts []corev1.VolumeMount) {
-	volumeMap := map[string]struct{}{
-		internal.PersistentVolumeName: {},
-	}
+	volumeMap := map[string]struct{}{}
 	for _, volume := range volumes {
 		ExpectWithOffset(1, volumeMap).NotTo(HaveKey(volume.Name))
 		volumeMap[volume.Name] = struct{}{}
 	}
+
+	volumeMap[internal.PersistentVolumeName] = struct{}{}
 
 	mountPaths := map[string]struct{}{}
 	for _, mount := range mounts {

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -82,6 +82,17 @@ type OpenSSLConfig struct {
 	Client OpenSSLParams `yaml:"client,omitempty"`
 }
 
+// UserMountsAt reports whether any of the given mounts targets path.
+func UserMountsAt(mounts []corev1.VolumeMount, path string) bool {
+	for _, m := range mounts {
+		if m.MountPath == path {
+			return true
+		}
+	}
+
+	return false
+}
+
 // ProjectVolumes replaces volumes with the same mount path with a single projected volume.
 func ProjectVolumes(volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) ([]corev1.Volume, []corev1.VolumeMount, error) {
 	mountPaths := map[string][]corev1.VolumeMount{}

--- a/internal/controller/keeper/templates.go
+++ b/internal/controller/keeper/templates.go
@@ -617,6 +617,13 @@ func buildVolumes(cr *v1.KeeperCluster, id v1.KeeperReplicaID) []corev1.Volume {
 		})
 	}
 
+	if cr.Spec.DataVolumeClaimSpec == nil && !controller.UserMountsAt(cr.Spec.ContainerTemplate.VolumeMounts, internal.KeeperDataPath) {
+		volumes = append(volumes, corev1.Volume{
+			Name:         internal.PersistentVolumeName,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+	}
+
 	return volumes
 }
 
@@ -649,6 +656,11 @@ func buildMounts(cr *v1.KeeperCluster) []corev1.VolumeMount {
 				MountPath: "/var/log/clickhouse-keeper",
 				SubPath:   "var-log-clickhouse",
 			})
+	} else if !controller.UserMountsAt(cr.Spec.ContainerTemplate.VolumeMounts, internal.KeeperDataPath) {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      internal.PersistentVolumeName,
+			MountPath: internal.KeeperDataPath,
+		})
 	}
 
 	if cr.Spec.Settings.TLS.Enabled {

--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -69,18 +69,18 @@ func TestDeploy(t *testing.T) {
 
 var _ = BeforeSuite(func(ctx context.Context) {
 	By("building manager binary")
-	runCmd(ctx, "make", "build-linux-manager")
+	Expect(testutil.MustRun(ctx, "make", "build-linux-manager")).To(Succeed())
 
 	By("building operator image")
-	runCmd(ctx, "docker", "build", "-f", "dev.Dockerfile", "-t", testImage, ".")
+	Expect(testutil.MustRun(ctx, "docker", "build", "-f", "dev.Dockerfile", "-t", testImage, ".")).To(Succeed())
 
 	By("loading operator image to kind")
-	runCmd(ctx, "kind", "load", "docker-image", testImage)
+	Expect(testutil.MustRun(ctx, "kind", "load", "docker-image", testImage)).To(Succeed())
 
 	By("installing the cert-manager")
 	Expect(testutil.InstallCertManager(ctx)).To(Succeed())
 
-	runCmd(ctx, "helm",
+	Expect(testutil.MustRun(ctx, "helm",
 		"upgrade", "--install", "prometheus", "-n", "prometheus", "--create-namespace",
 		"oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack",
 		"--set", "alertmanager.enabled=false",
@@ -89,7 +89,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 		"--set", "grafana.enabled=false",
 		"--set", "kube-state-metrics.enabled=false",
 		"--set", "server.enabled=false",
-	)
+	)).To(Succeed())
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
@@ -136,14 +136,14 @@ var _ = Describe("Manifests deployment", Ordered, Label("manifest"), func() {
 		currentTestNamespace = namespace
 
 		By("building installer manifest")
-		runCmd(ctx, "make", "build-installer", "IMG="+testImage)
+		Expect(testutil.MustRun(ctx, "make", "build-installer", "IMG="+testImage)).To(Succeed())
 
 		By("applying installer manifest")
-		runCmd(ctx, "kubectl", "apply", "-f", "dist/install.yaml")
+		Expect(testutil.MustRun(ctx, "kubectl", "apply", "-f", "dist/install.yaml")).To(Succeed())
 
 		DeferCleanup(func(ctx context.Context) {
 			By("removing installer manifest resources")
-			runCmd(ctx, "kubectl", "delete", "--ignore-not-found", "-f", "dist/install.yaml")
+			Expect(testutil.MustRun(ctx, "kubectl", "delete", "--ignore-not-found", "-f", "dist/install.yaml")).To(Succeed())
 		})
 
 		By("Waiting controller to be ready")
@@ -176,12 +176,12 @@ var _ = Describe("OLM deployment", Ordered, Label("olm"), func() {
 		if _, err := testutil.Run(exec.CommandContext(ctx, operatorSDK, "olm", "status")); err != nil {
 			// Clean up any leftover OLM resources from a previous run
 			_, _ = testutil.Run(exec.CommandContext(ctx, operatorSDK, "olm", "uninstall", "--timeout", "1m"))
-			runCmd(ctx, operatorSDK, "olm", "install", "--timeout", "5m")
+			Expect(testutil.MustRun(ctx, operatorSDK, "olm", "install", "--timeout", "5m")).To(Succeed())
 		}
 
 		DeferCleanup(func(ctx context.Context) {
 			By("uninstalling OLM")
-			runCmd(ctx, operatorSDK, "olm", "uninstall", "--timeout", "5m")
+			Expect(testutil.MustRun(ctx, operatorSDK, "olm", "uninstall", "--timeout", "5m")).To(Succeed())
 		})
 
 		By("creating test namespace")
@@ -189,12 +189,12 @@ var _ = Describe("OLM deployment", Ordered, Label("olm"), func() {
 
 		// Enforce upstream Pod Security Admission at "restricted" level on the OLM test namespace.
 		By("labeling test namespace with PSA enforce=restricted")
-		runCmd(ctx, "kubectl", "label", "ns", namespace, "--overwrite",
+		Expect(testutil.MustRun(ctx, "kubectl", "label", "ns", namespace, "--overwrite",
 			"pod-security.kubernetes.io/enforce=restricted",
-			"pod-security.kubernetes.io/enforce-version=latest")
+			"pod-security.kubernetes.io/enforce-version=latest")).To(Succeed())
 
 		By("building OLM bundle")
-		runCmd(ctx, "make", "bundle", "IMG="+testImage)
+		Expect(testutil.MustRun(ctx, "make", "bundle", "IMG="+testImage)).To(Succeed())
 
 		By("creating catalog and subscription")
 
@@ -232,8 +232,8 @@ var _ = Describe("OLM deployment", Ordered, Label("olm"), func() {
 		})
 
 		By("waiting for catalog server to be ready")
-		runCmd(ctx, "kubectl", "wait", "-n", namespace, "--timeout=120s",
-			"--for=condition=Ready", "pod/test-catalog-server")
+		Expect(testutil.MustRun(ctx, "kubectl", "wait", "-n", namespace, "--timeout=120s",
+			"--for=condition=Ready", "pod/test-catalog-server")).To(Succeed())
 
 		By("waiting for ClusterServiceVersion to succeed")
 		Eventually(func(g Gomega) {
@@ -284,15 +284,15 @@ var _ = Describe("Helm deployment", Ordered, Label("helm"), func() {
 			Expect(valuesFile.Close()).To(Succeed())
 
 			By("Installing clickhouse-operator with helm")
-			runCmd(ctx, "helm", "install", namespace, "dist/chart", "-n", namespace,
-				"--create-namespace", "--values", valuesFile.Name())
+			Expect(testutil.MustRun(ctx, "helm", "install", namespace, "dist/chart", "-n", namespace,
+				"--create-namespace", "--values", valuesFile.Name())).To(Succeed())
 
 			DeferCleanup(func(ctx context.Context) {
 				By("Uninstalling clickhouse-operator with helm")
-				runCmd(ctx, "helm", "uninstall", namespace, "-n", namespace)
+				Expect(testutil.MustRun(ctx, "helm", "uninstall", namespace, "-n", namespace)).To(Succeed())
 
 				By("Deleting test namespace")
-				runCmd(ctx, "kubectl", "delete", "ns", namespace)
+				Expect(testutil.MustRun(ctx, "kubectl", "delete", "ns", namespace)).To(Succeed())
 			})
 
 			By("Waiting controller to be ready")
@@ -347,26 +347,26 @@ func testHelmCluster(namespace string) {
 		keeperName := "keeper-" + version
 
 		By("Installing clickhouse-cluster chart")
-		runCmd(ctx, "helm", "install", releaseName, "dist/chart-cluster", "-n", namespace,
+		Expect(testutil.MustRun(ctx, "helm", "install", releaseName, "dist/chart-cluster", "-n", namespace,
 			"--set", "clickhouse.meta.name="+chName,
 			"--set", "keeper.meta.name="+keeperName,
 			"--set", "clickhouse.spec.replicas=1",
 			"--set", "keeper.spec.replicas=1",
 			"--set-string", "imageTag="+version,
-		)
+		)).To(Succeed())
 
 		DeferCleanup(func(ctx context.Context) {
 			By("Uninstalling clickhouse-cluster chart")
-			runCmd(ctx, "helm", "uninstall", releaseName, "-n", namespace)
+			Expect(testutil.MustRun(ctx, "helm", "uninstall", releaseName, "-n", namespace)).To(Succeed())
 		})
 
 		By("Waiting for KeeperCluster to be ready")
-		runCmd(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
-			"keepercluster/"+keeperName)
+		Expect(testutil.MustRun(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
+			"keepercluster/"+keeperName)).To(Succeed())
 
 		By("Waiting for ClickHouse to be ready")
-		runCmd(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
-			"clickhousecluster/"+chName)
+		Expect(testutil.MustRun(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
+			"clickhousecluster/"+chName)).To(Succeed())
 	}
 
 	tableArgs := make([]any, 1, len(versionEntries)+1)
@@ -396,8 +396,8 @@ func testDeployment(namespace string) {
 		})
 
 		By("Waiting for KeeperCluster to be ready")
-		runCmd(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
-			"keepercluster/"+keeper.Name)
+		Expect(testutil.MustRun(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
+			"keepercluster/"+keeper.Name)).To(Succeed())
 
 		ch := v1.ClickHouseCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -422,8 +422,8 @@ func testDeployment(namespace string) {
 		})
 
 		By("Waiting for ClickHouse to be ready")
-		runCmd(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
-			"clickhousecluster/"+ch.Name)
+		Expect(testutil.MustRun(ctx, "kubectl", "-n", namespace, "wait", "--timeout=5m", "--for=condition=Ready",
+			"clickhousecluster/"+ch.Name)).To(Succeed())
 	}
 
 	tableArgs := make([]any, 1, len(versionEntries)+1)
@@ -431,17 +431,12 @@ func testDeployment(namespace string) {
 	DescribeTable("should successfully work with", append(tableArgs, versionEntries...)...)
 }
 
-func runCmd(ctx context.Context, name string, args ...string) {
-	out, err := testutil.Run(exec.CommandContext(ctx, name, args...))
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), string(out))
-}
-
 func templateTestResources(ctx context.Context, namespace string) string {
 	projectDir, err := testutil.GetProjectDir()
 	Expect(err).NotTo(HaveOccurred())
 
 	By("installing opm")
-	runCmd(ctx, "make", "opm")
+	Expect(testutil.MustRun(ctx, "make", "opm")).To(Succeed())
 
 	opm := filepath.Join(projectDir, "bin", "opm")
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -39,8 +39,8 @@ import (
 const (
 	pollingInterval = time.Millisecond * 100
 
-	BaseVersion   = "26.2"
-	UpdateVersion = "26.3"
+	BaseVersion   = testutil.BaseVersion
+	UpdateVersion = testutil.UpdateVersion
 )
 
 var releases = map[string][]upgrade.ClickHouseVersion{

--- a/test/openshift/openshift_test.go
+++ b/test/openshift/openshift_test.go
@@ -1,0 +1,229 @@
+package openshift
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+	"github.com/ClickHouse/clickhouse-operator/test/testutil"
+)
+
+const (
+	catalogManifests = `apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: clickhouse-operator-catalog
+  namespace: %[1]s
+spec:
+  sourceType: grpc
+  image: %[2]s
+  displayName: ClickHouse Operator Catalog
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: clickhouse-operator
+  namespace: %[1]s
+spec:
+  targetNamespaces:
+    - %[1]s
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: clickhouse-operator
+  namespace: %[1]s
+spec:
+  channel: %[3]s
+  name: clickhouse-operator
+  source: clickhouse-operator-catalog
+  sourceNamespace: %[1]s
+  installPlanApproval: Automatic
+`
+)
+
+var (
+	k8sClient      client.Client
+	config         *rest.Config
+	namespace      = "e2e-" + testutil.CurrentSpecHash()
+	versionEntries []any
+)
+
+func TestOpenShift(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	versions := []string{"latest"}
+	if v := os.Getenv("CLICKHOUSE_VERSION"); v != "" {
+		versions = strings.Split(v, ",")
+	}
+
+	for _, v := range versions {
+		versionEntries = append(versionEntries, Entry("version: "+v, v))
+	}
+
+	RunSpecs(t, "openshift suite")
+}
+
+var _ = BeforeSuite(func(ctx context.Context) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		kubeconfig = filepath.Join(homedir.HomeDir(), ".kube", "config")
+	}
+
+	var err error
+
+	config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(v1.AddToScheme(scheme.Scheme)).To(Succeed())
+	k8sClient, err = client.New(config, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating project")
+	Eventually(func(g Gomega) {
+		if _, err := testutil.Run(exec.CommandContext(ctx, "oc", "get", "project", namespace)); err == nil {
+			return
+		}
+
+		out, err := testutil.Run(exec.CommandContext(ctx, "oc", "adm", "new-project", namespace))
+		g.Expect(err).NotTo(HaveOccurred(), string(out))
+	}, "2m", "5s").Should(Succeed())
+
+	DeferCleanup(func(ctx context.Context) {
+		_, _ = testutil.Run(exec.CommandContext(ctx, "oc", "delete", "project", namespace,
+			"--ignore-not-found", "--wait=false"))
+	})
+
+	By("waiting for SCC uid-range annotation")
+	Eventually(func(g Gomega) {
+		var ns corev1.Namespace
+		g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, &ns)).To(Succeed())
+		_, ok := ns.Annotations["openshift.io/sa.scc.uid-range"]
+		g.Expect(ok).To(BeTrue(), "waiting for SCC uid-range annotation")
+	}, "2m", "5s").Should(Succeed())
+
+	manifests := fmt.Sprintf(catalogManifests,
+		namespace,
+		envOrDefault("OPENSHIFT_CATALOG_IMAGE", "ghcr.io/clickhouse/clickhouse-operator-catalog:latest"),
+		envOrDefault("OPENSHIFT_CHANNEL", "fast-v0"),
+	)
+
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifests)
+	out, err := testutil.Run(cmd)
+	Expect(err).ToNot(HaveOccurred(), string(out))
+
+	DeferCleanup(func(ctx context.Context) {
+		cmd := exec.CommandContext(ctx, "kubectl", "delete", "-f", "-")
+		cmd.Stdin = strings.NewReader(manifests)
+		out, err := testutil.Run(cmd)
+		Expect(err).ToNot(HaveOccurred(), string(out))
+	})
+	DeferCleanup(func(ctx context.Context) {
+		_ = testutil.UninstallCRDs(ctx)
+	})
+
+	By("waiting for CatalogSource to be READY")
+	Eventually(func(g Gomega) {
+		out, err := testutil.Run(exec.CommandContext(ctx, "kubectl", "get", "catalogsource",
+			"clickhouse-operator-catalog", "-n", namespace,
+			"-o", "jsonpath={.status.connectionState.lastObservedState}"))
+		g.Expect(err).ToNot(HaveOccurred(), string(out))
+		g.Expect(strings.TrimSpace(string(out))).To(Equal("READY"))
+	}, "3m", "5s").Should(Succeed())
+
+	By("waiting for ClusterServiceVersion to succeed")
+	Eventually(func(g Gomega) {
+		out, err := testutil.Run(exec.CommandContext(ctx, "kubectl", "get", "csv",
+			"-n", namespace, "--no-headers", "-o", "custom-columns=PHASE:.status.phase"))
+		g.Expect(err).ToNot(HaveOccurred(), string(out))
+		g.Expect(strings.TrimSpace(string(out))).To(Equal("Succeeded"))
+	}, "5m", "5s").Should(Succeed())
+
+	By("waiting controller to be ready")
+	Expect(testutil.MustRun(ctx, "kubectl", "wait", "-n", namespace, "--timeout=2m",
+		"--for=condition=Available", "deployment/clickhouse-operator-controller-manager")).To(Succeed())
+})
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+var _ = JustAfterEach(func(ctx context.Context) {
+	if !CurrentSpecReport().Failed() {
+		return
+	}
+
+	for _, resource := range []string{"catalogsources", "subscriptions", "installplans", "clusterserviceversions"} {
+		out, _ := testutil.Run(exec.CommandContext(ctx, "kubectl", "get", resource,
+			"-n", namespace, "-o", "yaml"))
+		AddReportEntry("=== "+resource, string(out))
+	}
+
+	catalogLog, _ := testutil.Run(exec.CommandContext(ctx, "kubectl", "logs",
+		"-n", "openshift-operator-lifecycle-manager", "-l", "app=catalog-operator", "--tail=100"))
+	AddReportEntry("=== catalog-operator log", string(catalogLog))
+
+	testutil.DumpNamespaceDiagnostics(ctx, config, k8sClient, namespace, "report")
+})
+
+var _ = Describe("OLM deployment on OpenShift", func() {
+	It("should deploy cluster with default settings", func(ctx context.Context) {
+		keeper := v1.KeeperCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "keeper",
+			},
+			Spec: v1.KeeperClusterSpec{
+				Replicas: new(int32(1)),
+				ContainerTemplate: v1.ContainerTemplateSpec{
+					Image: v1.ContainerImage{Tag: testutil.BaseVersion},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, &keeper)).To(Succeed())
+		DeferCleanup(func(ctx context.Context) { _ = k8sClient.Delete(ctx, &keeper) })
+
+		By("Waiting for KeeperCluster to be ready")
+		Expect(testutil.MustRun(ctx, "kubectl", "-n", namespace, "wait", "--timeout=15m", "--for=condition=Ready",
+			"keepercluster/"+keeper.Name)).To(Succeed())
+
+		ch := v1.ClickHouseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      "ch",
+			},
+			Spec: v1.ClickHouseClusterSpec{
+				Replicas:         new(int32(1)),
+				KeeperClusterRef: v1.KeeperClusterReference{Name: keeper.Name},
+				ContainerTemplate: v1.ContainerTemplateSpec{
+					Image: v1.ContainerImage{Tag: testutil.BaseVersion},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, &ch)).To(Succeed())
+		DeferCleanup(func(ctx context.Context) { _ = k8sClient.Delete(ctx, &ch) })
+
+		By("Waiting for ClickHouse to be ready")
+		Expect(testutil.MustRun(ctx, "kubectl", "-n", namespace, "wait", "--timeout=15m", "--for=condition=Ready",
+			"clickhousecluster/"+ch.Name)).To(Succeed())
+	})
+})

--- a/test/testutil/utils.go
+++ b/test/testutil/utils.go
@@ -40,7 +40,9 @@ const (
 	certmanagerVersion = "v1.19.2"
 	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 
-	logTailLines = 10
+	logTailLines  = 10
+	BaseVersion   = "26.2"
+	UpdateVersion = "26.3"
 )
 
 var (
@@ -103,6 +105,18 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 	}
 
 	return output, nil
+}
+
+// MustRun executes the provided command and fails the test if it returns an error.
+func MustRun(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+
+	ret, err := Run(cmd)
+	if err != nil {
+		return fmt.Errorf("cmd %q failed with error: (%w)\n%s", cmd.String(), err, ret)
+	}
+
+	return nil
 }
 
 // InstallCRDs installs the CRDs into the cluster using make install.


### PR DESCRIPTION
## Why

Need to verify OpenShift compatibility

## What

Add a special OpenShift e2e test against the pre-provided OKD cluster.
ClickHouse images have data dirs created with user 101, but OpenShift randomizes UID of the service, so now the operator mounts an emptyDir to match the data dir owner
