### PR TITLE
Docs/external secret config

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -296,6 +296,10 @@ stringData:
 | `Observe` (default) | Reconciliation is **blocked** until every required key is present. The operator reports each missing key — and the format hint for it — via the `ExternalSecretValid` status condition and a `Warning` event. |
 | `Manage` | The operator **generates** any missing required keys and writes them back to the same Secret. Useful for bootstrapping: create an empty Secret, let the operator fill it, then optionally tighten access. The operator still never deletes the Secret. |
 
+<Note>
+Even with `policy: Manage` the Secret must already exist in the namespace — the operator never creates the Secret itself, it only writes generated keys into an existing one. If the referenced Secret is missing, reconciliation is blocked with the `ExternalSecretNotFound` reason regardless of policy.
+</Note>
+
 Pick `Observe` when an external system (Vault, ESO, sealed-secrets, GitOps) is the source of truth and you want the operator to fail loudly on misconfiguration. Pick `Manage` when you want self-sufficient bootstrapping but still want to retain ownership of the Secret object itself (for example, to back it up).
 
 ### Status condition and troubleshooting {#external-secret-status}
@@ -303,6 +307,13 @@ Pick `Observe` when an external system (Vault, ESO, sealed-secrets, GitOps) is t
 The operator exposes a `ExternalSecretValid` condition on `ClickHouseCluster.status.conditions`. Inspect it when reconciliation looks stuck:
 
 ```bash
+# Plain kubectl — works out of the box
+kubectl describe clickhousecluster sample | sed -n '/Conditions:/,$p'
+
+# Same data as YAML
+kubectl get clickhousecluster sample -o yaml | sed -n '/conditions:/,/^[^ ]/p'
+
+# Pretty-printed JSON (requires jq)
 kubectl get clickhousecluster sample -o jsonpath='{.status.conditions}' | jq
 ```
 

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -230,6 +230,96 @@ spec:
             key: <ca-certificate-key>
 ```
 
+## External Secret {#external-secret}
+
+By default the operator creates and owns a Secret containing the cluster's internal credentials (interserver password, management password, keeper identity, cluster secret, named-collections key). The Secret is named after the cluster and lives in the cluster's namespace.
+
+If you want to manage these credentials yourself — for example, sourcing them from HashiCorp Vault, AWS Secrets Manager, or [External Secrets Operator](https://external-secrets.io/) — point the operator at a pre-existing Secret using `spec.externalSecret`:
+
+```yaml
+apiVersion: clickhouse.com/v1alpha1
+kind: ClickHouseCluster
+metadata:
+  name: sample
+spec:
+  replicas: 2
+  keeperClusterRef:
+    name: sample
+  dataVolumeClaimSpec:
+    resources:
+      requests:
+        storage: 10Gi
+  externalSecret:
+    name: my-clickhouse-credentials
+    policy: Observe
+```
+
+<Note>
+The referenced Secret must reside in the **same namespace** as the ClickHouseCluster. The operator never deletes a Secret it did not create.
+</Note>
+
+### Required keys {#external-secret-required-keys}
+
+The Secret must contain the following keys:
+
+| Key | Format | When required |
+|---|---|---|
+| `interserver-password` | plaintext password | Always |
+| `management-password` | plaintext password | Always |
+| `keeper-identity` | `clickhouse:<password>` | Always |
+| `cluster-secret` | plaintext password | Always |
+| `named-collections-key` | hex-encoded 16-byte AES key (32 hex chars) | ClickHouse `>= 25.12` only |
+
+A complete Secret looks like this:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-clickhouse-credentials
+  namespace: sample
+type: Opaque
+stringData:
+  interserver-password: "a-strong-random-password"
+  management-password: "another-strong-password"
+  keeper-identity: "clickhouse:keeper-auth-password"
+  cluster-secret: "cluster-internal-secret"
+  named-collections-key: "0123456789abcdef0123456789abcdef"   # 32 hex chars = 16 bytes
+```
+
+### Policy: Observe vs Manage {#external-secret-policy}
+
+`spec.externalSecret.policy` controls how the operator handles missing required keys:
+
+| Policy | Behavior on missing keys |
+|---|---|
+| `Observe` (default) | Reconciliation is **blocked** until every required key is present. The operator reports each missing key — and the format hint for it — via the `ExternalSecretValid` status condition and a `Warning` event. |
+| `Manage` | The operator **generates** any missing required keys and writes them back to the same Secret. Useful for bootstrapping: create an empty Secret, let the operator fill it, then optionally tighten access. The operator still never deletes the Secret. |
+
+Pick `Observe` when an external system (Vault, ESO, sealed-secrets, GitOps) is the source of truth and you want the operator to fail loudly on misconfiguration. Pick `Manage` when you want self-sufficient bootstrapping but still want to retain ownership of the Secret object itself (for example, to back it up).
+
+### Status condition and troubleshooting {#external-secret-status}
+
+The operator exposes a `ExternalSecretValid` condition on `ClickHouseCluster.status.conditions`. Inspect it when reconciliation looks stuck:
+
+```bash
+kubectl get clickhousecluster sample -o jsonpath='{.status.conditions}' | jq
+```
+
+Possible reasons:
+
+| `reason` | Meaning | Fix |
+|---|---|---|
+| `ExternalSecretNotFound` | The referenced Secret does not exist in the namespace. | Create the Secret, or fix `spec.externalSecret.name`. |
+| `ExternalSecretInvalid` | The Secret exists but lacks required keys (only with `Observe`). The message lists each missing key together with its expected format. | Add the missing keys, or switch to `policy: Manage`. |
+| `ExternalSecretValid` | All required keys are present and the operator is using the Secret. | — |
+
+The operator requeues reconciliation while the Secret is invalid, so once you add the missing keys the next reconcile picks them up automatically — no need to bounce pods.
+
+<Note>
+The set of required keys depends on the running ClickHouse version. `named-collections-key` is only validated once the operator's version probe has detected ClickHouse `25.12` or newer. On older versions the key may be absent from the Secret.
+</Note>
+
 ## ClickHouse settings {#clickhouse-settings}
 
 ### Default user password {#default-user-password}


### PR DESCRIPTION
Adds a top-level "External Secret" section to the configuration guide covering:

  - The `spec.externalSecret` field and namespace constraint
  - Complete list of required Secret keys with format hints
  - `Observe` vs `Manage` policy semantics and when to pick each
  - The `ExternalSecretValid` status condition and how to debug `ExternalSecretNotFound` / `ExternalSecretInvalid` reasons

  ## Why

  The External Secret feature has been available since #168 but the documentation site had zero mention of it (`grep -c externalSecret docs/` returned 0). Users have to read `api/v1alpha1/common.go` and the
  reconciler in `internal/controller/clickhouse/sync.go` to understand the `Observe` vs `Manage` policy distinction, the required Secret keys (including the conditional `named-collections-key` for ClickHouse `>=
  25.12`), and how to interpret the `ExternalSecretValid` status condition.
  
  ## What

  Adds a new top-level `## External Secret` section in `docs/guides/configuration.mdx`, placed between TLS configuration and ClickHouse settings. Four subsections:

  - Introduction with a complete `ClickHouseCluster` example using `externalSecret`
  - Required keys table with format hints sourced from `internal/controller/clickhouse/constants.go`
  - `Observe` vs `Manage` policy comparison with guidance on when to pick each
  - Troubleshooting of the `ExternalSecretValid` status condition with `ExternalSecretNotFound` / `ExternalSecretInvalid` reasons

  No code or chart changes. documentation only