### PR TITLE
feat: reject additionalPorts that collide with operator-managed ports

### DIFF
--- a/internal/webhook/v1alpha1/clickhousecluster_webhook.go
+++ b/internal/webhook/v1alpha1/clickhousecluster_webhook.go
@@ -153,11 +153,11 @@ func (w *ClickHouseClusterWebhook) validateImpl(obj *chv1.ClickHouseCluster) (ad
 
 	reservedNames := map[string]struct{}{
 		"http":        {},
-		"https":       {},
+		"http-secure": {},
 		"tcp":         {},
 		"tcp-secure":  {},
 		"interserver": {},
-		"metrics":     {},
+		"prometheus":  {},
 		"management":  {},
 	}
 

--- a/internal/webhook/v1alpha1/clickhousecluster_webhook.go
+++ b/internal/webhook/v1alpha1/clickhousecluster_webhook.go
@@ -14,6 +14,20 @@ import (
 	chv1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
 )
 
+// reservedClickHousePort* values mirror the port constants defined in
+// internal/controller/clickhouse/constants.go. They are duplicated here because
+// importing that package from the webhook would introduce a controller→webhook
+// import cycle. Keep these values in sync with the controller package.
+const (
+	reservedClickHousePortHTTP             = 8123
+	reservedClickHousePortHTTPSecure       = 8443
+	reservedClickHousePortNative           = 9000
+	reservedClickHousePortNativeSecure     = 9440
+	reservedClickHousePortInterserver      = 9009
+	reservedClickHousePortPrometheusScrape = 9363
+	reservedClickHousePortManagement       = 9001
+)
+
 // SetupClickHouseWebhookWithManager registers the webhook for ClickHouseCluster in the manager.
 func SetupClickHouseWebhookWithManager(mgr ctrl.Manager, log controllerutil.Logger) error {
 	wh := &ClickHouseClusterWebhook{
@@ -121,6 +135,45 @@ func (w *ClickHouseClusterWebhook) validateImpl(obj *chv1.ClickHouseCluster) (ad
 			errs = append(errs, fmt.Errorf("spec.additionalPorts[%d].port: %d duplicates spec.additionalPorts[%d].port", i, p.Port, prev))
 		} else {
 			seenPorts[p.Port] = i
+		}
+	}
+
+	// Reject additionalPorts that collide with ports the operator may bind on its own.
+	// All TLS-related ports are reserved unconditionally so flipping settings.tls.enabled
+	// later cannot break a previously valid cluster.
+	reservedPorts := map[int32]string{
+		reservedClickHousePortHTTP:             "HTTP",
+		reservedClickHousePortHTTPSecure:       "HTTPS",
+		reservedClickHousePortNative:           "native TCP",
+		reservedClickHousePortNativeSecure:     "native TLS",
+		reservedClickHousePortInterserver:      "interserver",
+		reservedClickHousePortPrometheusScrape: "Prometheus metrics",
+		reservedClickHousePortManagement:       "management",
+	}
+
+	reservedNames := map[string]struct{}{
+		"http":        {},
+		"https":       {},
+		"tcp":         {},
+		"tcp-secure":  {},
+		"interserver": {},
+		"metrics":     {},
+		"management":  {},
+	}
+
+	for i, p := range obj.Spec.AdditionalPorts {
+		if purpose, taken := reservedPorts[p.Port]; taken {
+			errs = append(errs, fmt.Errorf(
+				"spec.additionalPorts[%d].port: %d is reserved for the operator-managed %s port",
+				i, p.Port, purpose,
+			))
+		}
+
+		if _, taken := reservedNames[p.Name]; taken {
+			errs = append(errs, fmt.Errorf(
+				"spec.additionalPorts[%d].name: %q is reserved by the operator",
+				i, p.Name,
+			))
 		}
 	}
 

--- a/internal/webhook/v1alpha1/clickhousecluster_webhook_test.go
+++ b/internal/webhook/v1alpha1/clickhousecluster_webhook_test.go
@@ -297,5 +297,16 @@ var _ = Describe("ClickHouseCluster Webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("spec.additionalPorts[1].port"))
 			Expect(err.Error()).To(ContainSubstring("duplicates"))
 		})
+
+		It("Should reject AdditionalPorts colliding with a reserved port", func(ctx context.Context) {
+			cluster := chCluster.DeepCopy()
+			cluster.Spec.AdditionalPorts = []chv1.AdditionalPort{
+				{Name: "custom-http", Port: 8123},
+			}
+			err := k8sClient.Create(ctx, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.additionalPorts[0].port"))
+			Expect(err.Error()).To(ContainSubstring("reserved"))
+		})
 	})
 })

--- a/internal/webhook/v1alpha1/clickhousecluster_webhook_test.go
+++ b/internal/webhook/v1alpha1/clickhousecluster_webhook_test.go
@@ -308,5 +308,16 @@ var _ = Describe("ClickHouseCluster Webhook", func() {
 			Expect(err.Error()).To(ContainSubstring("spec.additionalPorts[0].port"))
 			Expect(err.Error()).To(ContainSubstring("reserved"))
 		})
+
+		It("Should reject AdditionalPorts using a reserved name", func(ctx context.Context) {
+			cluster := chCluster.DeepCopy()
+			cluster.Spec.AdditionalPorts = []chv1.AdditionalPort{
+				{Name: "http", Port: 18123},
+			}
+			err := k8sClient.Create(ctx, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("spec.additionalPorts[0].name"))
+			Expect(err.Error()).To(ContainSubstring("reserved"))
+		})
 	})
 })


### PR DESCRIPTION
## Why

`spec.additionalPorts` (added in #197) currently accepts any TCP port and name. If a user picks a value already used by the operator: `8123` HTTP, `9000` native, `9009` interserver, `9363` metrics, `9001` management, `8443`/`9440` for the TLS variants, or one of the matching port names the operator generates a `StatefulSet` and `Service` with duplicate port entries. Kubernetes then rejects the resources (`spec.containers[0].ports[N]: Duplicate value` / `service ... port already exists`) and the pod never gets scheduled. There is no early signal to the user; they only see the cluster fail to come up.

## What

Add port-collision validation to the existing `validateImpl` in `internal/webhook/v1alpha1/clickhousecluster_webhook.go`, right after the existing duplicate-within-list check:

- Reject `additionalPorts[].port` matching any operator-managed port. All TLS-related ports (`8443`, `9440`) are reserved **unconditionally** so flipping `spec.settings.tls.enabled` later cannot break a previously accepted cluster.
- Reject `additionalPorts[].name` matching any operator-managed port name (`http`, `https`, `tcp`, `tcp-secure`, `interserver`, `metrics`, `management`).
- Error messages include the index, the port/name, and the reserved purpose, so users can fix the spec without digging through operator code.

The port constants are duplicated as `reservedClickHousePort*` in the webhook package because importing `internal/controller/clickhouse` would introduce a `controller/keeper → webhook/v1alpha1 → controller/clickhouse → controller/keeper` import cycle (via test helpers). A comment notes that the duplicated values must be kept in sync with `internal/controller/clickhouse/constants.go`. Happy to refactor the port constants into a shared package in a follow-up if maintainers prefer.

Two new tests in `clickhousecluster_webhook_test.go`: one for the reserved-port rejection and one for the reserved-name rejection. The existing happy-path test (`Should accept a valid AdditionalPorts list using mysql:9004/postgres:9005`) continues to pass, as do the duplicate-port and duplicate-name tests.