### PR TITLE
feat: add ExternalSecret print column to ClickHouseCluster

### DIFF
--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -268,6 +268,7 @@ func (r *KeeperClusterReference) NamespacedName(defaultNamespace string) types.N
 // +kubebuilder:printcolumn:name="ReadyReplicas",type="number",JSONPath=".status.readyReplicas"
 // +kubebuilder:printcolumn:name="Replicas",type="number",JSONPath=".spec.replicas"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version"
+// +kubebuilder:printcolumn:name="ExternalSecret",type="string",priority=1,JSONPath=".status.conditions[?(@.type==\"ExternalSecretValid\")].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +operator-sdk:csv:customresourcedefinitions:displayName="ClickHouse Cluster"
 // +operator-sdk:csv:customresourcedefinitions:resources={{Pod,v1}}

--- a/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
+++ b/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
@@ -33,6 +33,10 @@ spec:
     - jsonPath: .status.version
       name: Version
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ExternalSecretValid")].status
+      name: ExternalSecret
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
@@ -36,6 +36,10 @@ spec:
     - jsonPath: .status.version
       name: Version
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ExternalSecretValid")].status
+      name: ExternalSecret
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date


### PR DESCRIPTION
## Why

 #203 added documentation for the `spec.externalSecret` feature and the `ExternalSecretValid` status condition. Today, to see whether a cluster's external secret is valid, users have to run `kubectl describe` or read `.status.conditions` with JSONPath. This PR surfaces that condition directly in `kubectl get`.

## What

Add a `+kubebuilder:printcolumn` marker to `ClickHouseCluster` exposing the `ExternalSecretValid` status condition. The column has `priority=1` so it does **not** appear in the default `kubectl get clickhousecluster` output, only with `-o wide`. This keeps the default view unchanged for users who don't use external secrets.

For clusters without `spec.externalSecret`, the condition is absent and the column renders as empty. For clusters with it:
```
$ kubectl get clickhousecluster -o wide
  NAME     READY   STATUS                     READYREPLICAS  REPLICAS  VERSION        EXTERNALSECRET  AGE
  sample   True       All shards are ready   2             2      26.5.1.882.        True        1h
```
Verified end-to-end on a kind cluster with the operator deployed from this branch.