### PR TITLE
feat(keeper): smart-default maxUnavailable=1 for single-replica PDB

### DIFF
--- a/internal/controller/keeper/templates.go
+++ b/internal/controller/keeper/templates.go
@@ -74,6 +74,14 @@ func templateHeadlessService(cr *v1.KeeperCluster) *corev1.Service {
 }
 
 func templatePodDisruptionBudget(cr *v1.KeeperCluster) *policyv1.PodDisruptionBudget {
+	// Smart default: single-replica clusters use maxUnavailable=1 to avoid
+	// drain deadlocks; multi-replica clusters use maxUnavailable=replicas/2
+	// to preserve Raft quorum.
+	maxUnavailable := cr.Replicas() / 2
+	if cr.Replicas() <= 1 {
+		maxUnavailable = 1
+	}
+
 	pdb := &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -93,7 +101,7 @@ func templatePodDisruptionBudget(cr *v1.KeeperCluster) *policyv1.PodDisruptionBu
 					controllerutil.LabelAppKey: cr.SpecificName(),
 				},
 			},
-			MaxUnavailable: new(intstr.FromInt32(cr.Replicas() / 2)),
+			MaxUnavailable: new(intstr.FromInt32(maxUnavailable)),
 		},
 	}
 

--- a/internal/controller/keeper/templates_test.go
+++ b/internal/controller/keeper/templates_test.go
@@ -138,6 +138,15 @@ var _ = Describe("templatePodDisruptionBudget", func() {
 		Expect(pdb.Spec.MinAvailable).To(BeNil())
 	})
 
+	It("should default to maxUnavailable=1 for single-replica cluster to avoid drain deadlocks", func() {
+		cr.Spec.Replicas = new(int32(1))
+		pdb := templatePodDisruptionBudget(cr)
+
+		Expect(pdb.Spec.MaxUnavailable).NotTo(BeNil())
+		Expect(pdb.Spec.MaxUnavailable.IntValue()).To(Equal(1)) // smart default avoids the 1/2=0 deadlock
+		Expect(pdb.Spec.MinAvailable).To(BeNil())
+	})
+
 	It("should respect custom maxUnavailable", func() {
 		cr.Spec.PodDisruptionBudget = &v1.PodDisruptionBudgetSpec{
 			MaxUnavailable: new(intstr.FromInt32(2)),


### PR DESCRIPTION
## Problem

`templatePodDisruptionBudget` in `internal/controller/keeper/templates.go` defaults to `maxUnavailable: cr.Replicas() / 2`. For a single-replica KeeperCluster, this evaluates to `1 / 2 = 0`, which produces a PDB that allows **no** voluntary disruption. The resulting PDB is unsatisfiable: any eviction attempt (e.g. a Kubernetes node drain triggered by a cluster upgrade) is blocked indefinitely.

The repro is straightforward — deploy a KeeperCluster with `spec.replicas: 1`, then attempt `kubectl drain` on its node:

```
Warning  Drain  ...  Eviction blocked by Too Many Requests (usually a pdb): keeper-keeper-0-0
```

This bites real users in production when running ClickStack at a single-Keeper sizing (development clusters, monitoring stacks, etc.) and hitting routine node maintenance.

## Fix

Apply the same smart-default pattern that `ClickHouseCluster` already uses for its single-replica case ([clickhouse/templates.go](https://github.com/ClickHouse/clickhouse-operator/blob/main/internal/controller/clickhouse/templates.go) — *"Smart default: single-replica shards use maxUnavailable=1 to avoid drain deadlocks"*):

```go
maxUnavailable := cr.Replicas() / 2
if cr.Replicas() <= 1 {
    maxUnavailable = 1
}
```

Effect by replica count:
- `replicas=1`: `0` → `1` (the fix — drains can now proceed)
- `replicas=2`: `1` → `1` (unchanged)
- `replicas=3`: `1` → `1` (unchanged)
- `replicas=5`: `2` → `2` (unchanged)

So this is a backwards-compatible default; only the broken single-replica case is affected. Multi-replica quorum behavior is preserved exactly.

User overrides via `spec.podDisruptionBudget` still apply via `ApplyOverrides()` after the default is computed — no change to that path.

## Testing

Added a unit test in `internal/controller/keeper/templates_test.go` covering the new behavior. Full `templatePodDisruptionBudget` suite passes locally:

```
$ go test ./internal/controller/keeper/ --ginkgo.focus="templatePodDisruptionBudget"
Ran 9 of 28 Specs in 0.001 seconds
SUCCESS! -- 9 Passed | 0 Failed | 0 Pending | 19 Skipped
```

Existing tests for 3-node and 5-node clusters and for user overrides are unchanged and still pass.

## Notes

- This mirrors a fix already present in the ClickHouseCluster reconciler; consistency between the two CRD controllers seemed worth aligning.
- Code follows the existing pattern in the same file; `gofmt` clean.
- No CRD/API changes, no generated-code regen needed.