### PR TITLE
docs: document spec.additionalPorts and reserved-port validation

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -331,6 +331,107 @@ The operator requeues reconciliation while the Secret is invalid, so once you ad
 The set of required keys depends on the running ClickHouse version. `named-collections-key` is only validated once the operator's version probe has detected ClickHouse `25.12` or newer. On older versions the key may be absent from the Secret.
 </Note>
 
+## Additional ports {#additional-ports}
+
+The operator exposes a fixed set of ports on every ClickHouse Pod and its headless Service: `8123` HTTP, `9000` native, `9009` interserver, `9001` management, `9363` Prometheus metrics, and the TLS variants `8443`/`9440` when TLS is enabled. To make ClickHouse listen on additional protocols — MySQL, PostgreSQL, gRPC, or any custom port — declare them in `spec.additionalPorts`:
+
+```yaml
+spec:
+  additionalPorts:
+    - name: mysql
+      port: 9004
+    - name: postgres
+      port: 9005
+    - name: grpc
+      port: 9100
+```
+
+The operator adds those ports to the Pod's `containerPorts` and to the headless Service. The complete example lives at [`examples/custom_protocols.yaml`](https://github.com/ClickHouse/clickhouse-operator/blob/main/examples/custom_protocols.yaml).
+
+<Warning>
+`additionalPorts` only opens the ports on the Kubernetes side. It does **not** configure the ClickHouse server to listen on them. You also have to enable the matching protocol in `spec.settings.extraConfig.protocols`. Without that, the port is open on the Service but nothing inside the pod is answering.
+</Warning>
+
+### End-to-end example: MySQL wire protocol {#additional-ports-mysql-example}
+
+To expose ClickHouse over the MySQL wire protocol on port `9004`:
+
+```yaml
+apiVersion: clickhouse.com/v1alpha1
+kind: ClickHouseCluster
+metadata:
+  name: sample
+spec:
+  replicas: 1
+  keeperClusterRef:
+    name: sample
+  dataVolumeClaimSpec:
+    resources:
+      requests:
+        storage: 2Gi
+
+  # 1) Open the port on the Pod and the headless Service.
+  additionalPorts:
+    - name: mysql
+      port: 9004
+
+  # 2) Tell ClickHouse server to actually listen on it.
+  settings:
+    extraConfig:
+      protocols:
+        mysql:
+          type: mysql
+          port: 9004
+          description: "MySQL wire protocol"
+```
+
+After applying, verify from inside the cluster:
+
+```bash
+kubectl exec sample-clickhouse-0-0-0 -- \
+  clickhouse-client --port 9004 --query "SELECT 1"
+```
+
+### Field constraints {#additional-ports-constraints}
+
+| Field | Rule |
+|---|---|
+| `name` | Must match the DNS_LABEL pattern `^[a-z]([-a-z0-9]*[a-z0-9])?$`, max 63 characters. Uniqueness is enforced by the CRD as a list-map key. |
+| `port` | Integer in `[1, 65535]`. The webhook rejects duplicate port numbers within the list. |
+
+### Reserved ports and names {#additional-ports-reserved}
+
+The validating webhook rejects `additionalPorts` entries that would collide with ports the operator binds itself. All TLS-related ports are reserved **unconditionally** so that flipping `spec.settings.tls.enabled` later cannot break a previously valid cluster.
+
+| Port | Reserved for |
+|---|---|
+| `8123` | HTTP |
+| `8443` | HTTPS |
+| `9000` | native TCP |
+| `9440` | native TLS |
+| `9009` | interserver |
+| `9001` | management |
+| `9363` | Prometheus metrics |
+
+The following names are also rejected — they are the operator's internal protocol-type identifiers (not the human-readable aliases):
+
+| Name |
+|---|
+| `http` |
+| `http-secure` |
+| `tcp` |
+| `tcp-secure` |
+| `interserver` |
+| `management` |
+| `prometheus` |
+
+A rejected request produces an error such as:
+
+```
+spec.additionalPorts[0].port: 8123 is reserved for the operator-managed HTTP port
+spec.additionalPorts[0].name: "http" is reserved by the operator
+```
+
 ## ClickHouse settings {#clickhouse-settings}
 
 ### Default user password {#default-user-password}


### PR DESCRIPTION
Adds a new top-level section in configuration.mdx covering spec.additionalPorts (introduced in #197), placed between External Secret and ClickHouse settings. The section explains:

- Which ports the operator already binds and why additionalPorts exists
- The gotcha that additionalPorts only opens the port on the Kubernetes side; spec.settings.extraConfig.protocols still has to be configured for ClickHouse server to actually listen
- An end-to-end example for the MySQL wire protocol with verification via kubectl exec
- Field constraints (DNS_LABEL pattern, port range) sourced from the kubebuilder markers on AdditionalPort
- The complete list of reserved ports and reserved names enforced by the validating webhook (#205), with sample error messages so users can recognise a rejected request

No code or chart changes. Documentation only

## Why

`spec.additionalPorts` has been available since #197 but is not mentioned in the docs site. The important fact about the feature, that it only opens the port on the Pod and Service, not on the ClickHouse server, is only discoverable from the GoDoc or by reading examples/custom_protocols.yaml. The reserved-port validation from #205 is also undocumented.

## What

Adds `## Additional ports` to `docs/guides/configuration.mdx` with four subsections: introduction with the operator-managed port list and a `<Warning>` about `spec.settings.extraConfig.protocols`, an end-to-end MySQL wire-protocol example with verification, field constraints from the kubebuilder markers, and the reserved ports/names tables with sample webhook errors.