### PR TITLE
build: publish per-commit bundle + catalog on 'fast' channel

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-tags: true
+          fetch-depth: '0'
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.0
       - name: Set up Go
@@ -31,6 +32,8 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v3.2.0
       - name: Build operator image
         run: make docker-buildx-latest
       - name: Install Helm
@@ -38,8 +41,16 @@ jobs:
       - name: Set VERSION
         run: |
           FULL_VER=$(make -s print-full-version)
-          echo "VERSION=${FULL_VER#v}" >> "$GITHUB_ENV" # strips 'v' → 0.0.3-d33b34f
+          echo "VERSION=${FULL_VER#v}" >> "$GITHUB_ENV"
       - name: Package and push helm charts
         run: |
           helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           make push-helmchart push-cluster-chart
+      - name: Build and push fast bundle
+        run: make bundle bundle-buildx
+      - name: Build catalog
+        run: make catalog-buildx
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Mark catalog as latest
+        run: make catalog-push-latest

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,19 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
+#
 ifeq ($(VERSION),)
-VERSION := $(shell git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n1 | cut -c 2-)
-ifeq ($(VERSION),)
-VERSION := 0.0.0
+LAST_RELEASED_VERSION := $(shell git tag --list "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | head -n1 | cut -c 2-)
+ifeq ($(LAST_RELEASED_VERSION),)
+LAST_RELEASED_VERSION := 0.0.0
 endif
-FULL_VERSION := v$(VERSION)-$(shell git rev-parse --short HEAD)
+VERSION := $(shell echo $(LAST_RELEASED_VERSION) | awk -F. -v OFS=. '{$$NF+=1; print}')
+# Commits since the last release tag. Used as the first pre-release identifier
+# so SemVer orders successive fast builds monotonically (per-spec: pure-numeric
+# identifiers are compared numerically). Falls back to total HEAD count when
+# no tags exist.
+COMMIT_COUNT := $(shell git rev-list --count v$(LAST_RELEASED_VERSION)..HEAD 2>/dev/null || git rev-list --count HEAD)
+FULL_VERSION := v$(VERSION)-$(COMMIT_COUNT).$(shell git rev-parse --short HEAD)
 else
 FULL_VERSION := v$(VERSION)
 endif
@@ -22,7 +29,7 @@ print-full-version: ## Print the computed full version
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
 # - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
 # - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-CHANNELS ?= stable
+CHANNELS ?= stable,fast
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 
 # DEFAULT_CHANNEL defines the default channel used in the bundle.

--- a/ci/generate-catalog-template.sh
+++ b/ci/generate-catalog-template.sh
@@ -13,28 +13,20 @@ OUTPUT_FILE="catalog/clickhouse-operator-template.yaml"
 get_bundle_tags() {
     local owner="clickhouse"
     local gh_api_url="https://api.github.com/orgs/clickhouse/packages/container/clickhouse-operator-bundle/versions"
+    local filter="$1"
 
     echo "Fetching bundle tags from ${BUNDLE_IMAGE}" >&2
+    # grep guarded with `|| true` so a no-match (exit 1) does not abort the
+    # surrounding `$(...)` under `set -e -o pipefail`.
     curl -sL \
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
         -H "Authorization: Bearer ${GITHUB_TOKEN}" \
         "${gh_api_url}" 2>/dev/null \
         | jq -r '.[].metadata.container.tags[]' 2>/dev/null \
-        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+        | { grep -E "$filter" || true; } \
         | sort -V
 }
-
-# Get all bundle tags
-BUNDLE_TAGS=$(get_bundle_tags)
-
-if [ -z "$BUNDLE_TAGS" ]; then
-    echo "Error: No bundle tags found in registry"
-    exit 1
-fi
-
-echo "Found bundle tags:"
-echo "$BUNDLE_TAGS"
 
 # Create catalog directory if it doesn't exist
 mkdir -p catalog
@@ -48,9 +40,40 @@ Stable:
   Bundles:
 EOF
 
+# Get release bundle tags
+BUNDLE_TAGS=$(get_bundle_tags '^v[0-9]+\.[0-9]+\.[0-9]+$')
+if [ -z "$BUNDLE_TAGS" ]; then
+    echo "Error: No bundle tags found in registry"
+    exit 1
+fi
+
+echo "Found bundle tags:"
+echo "$BUNDLE_TAGS"
 for tag in $BUNDLE_TAGS; do
     if [ -n "$tag" ]; then
-        echo "  - Image: ${BUNDLE_IMAGE}:${tag}" >> "$OUTPUT_FILE"
+        echo "    - Image: ${BUNDLE_IMAGE}:${tag}" >> "$OUTPUT_FILE"
+    fi
+done
+
+# Get fast bundle tags
+BUNDLE_TAGS=$(get_bundle_tags '^v[0-9]+\.[0-9]+\.[0-9]+-[a-z0-9.]+$')
+if [ -z "$BUNDLE_TAGS" ]; then
+    echo "Error: No fast bundle tags found in registry"
+    exit 1
+fi
+
+echo "Found fast bundle tags:"
+echo "$BUNDLE_TAGS"
+
+# Generate the template YAML
+cat >> "$OUTPUT_FILE" <<EOF
+Fast:
+  Bundles:
+EOF
+
+for tag in $BUNDLE_TAGS; do
+    if [ -n "$tag" ]; then
+        echo "    - Image: ${BUNDLE_IMAGE}:${tag}" >> "$OUTPUT_FILE"
     fi
 done
 


### PR DESCRIPTION
## Why

Needed by #202 to test OpenShift deployment with the latest commit and to allow OLM users to deploy the latest  builds

## What

- Make pre-release version match semver semantics. Add commits since the last release to the per-release close to enforce ordering
- Build per-commit OLM bundle images
- Add a "fast" channel to the OLM catalog

## Related Issues

Related to #202
