### PR TITLE
test: fix docs linting CI jobs

### DIFF
--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -20,15 +20,19 @@ jobs:
       - uses: errata-ai/vale-action@v2.1.1
         with:
           fail_on_error: 'true'
+          filter_mode: nofilter
 
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: tcort/github-action-markdown-link-check@v1
+      - uses: UmbrellaDocs/action-linkspector@v1
         with:
-          config-file: ci/.markdown-link-check.json
-          file-extension: '.md'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          filter_mode: nofilter
+          fail_level: any
+          config_file: .linkspector.yml
 
   api-reference-generated:
     name: API Reference Generated

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,0 +1,17 @@
+dirs:
+  - .
+useGitIgnore: true
+fileExtensions:
+  - md
+  - mdx
+excludedDirs:
+  - ./node_modules
+  - ./bin
+  - ./dist
+
+ignorePatterns:
+  # Mintlify absolute routes — resolved at deploy time by Mintlify,
+  # not present as files in this repo.
+  - pattern: '^/(products|core|cloud|operations)/'
+  # Cloudflare bot protection returns 403 to programmatic checkers.
+  - pattern: '^https://trust\.clickhouse\.com'

--- a/.vale.ini
+++ b/.vale.ini
@@ -2,11 +2,16 @@ StylesPath = docs/styles
 
 Vocab = ClickHouse
 
-# Markdown
-[*.md]
+# Treat .mdx as markdown
+[formats]
+mdx = md
+
+[*.{md,mdx}]
 BasedOnStyles = Vale
 Vale.Spelling = YES
 Vale.Terms = YES
 Vale.Repetition = YES
 Vale.Passive = YES
 Vale.Readability = YES
+# Skip MDX heading-anchor IDs ({#some-id}) — they're lowercase by convention, not subject to Terms casing rules.
+TokenIgnores = (\{#[^}]+\})

--- a/Makefile
+++ b/Makefile
@@ -611,9 +611,9 @@ docs-lint-vale: ## Run Vale linter on documentation
 	vale --config='.vale.ini' *.md docs
 
 .PHONY: docs-link-check
-docs-link-check: ## Run markdown-link-check on documentation
-	@command -v markdown-link-check >/dev/null 2>&1 || { echo "markdown-link-check is required but not installed. npm install -g markdown-link-check"; exit 1; }
-	markdown-link-check -c ci/.markdown-link-check.json *.md docs
+docs-link-check: ## Run linkspector on documentation
+	@command -v linkspector >/dev/null 2>&1 || { echo "linkspector is required but not installed. npm install -g @umbrelladocs/linkspector"; exit 1; }
+	linkspector check
 
 .PHONY: docs-lint
 docs-lint: docs-lint-vale docs-link-check ## Run all documentation linters

--- a/ci/.markdown-link-check.json
+++ b/ci/.markdown-link-check.json
@@ -1,7 +1,0 @@
-{
-  "ignorePatterns": [
-    {
-      "pattern": "^https://github.com/ClickHouse/clickhouse-operator/issues$"
-    }
-  ]
-}

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,14 +4,15 @@
 
 Choose your preferred installation method:
 
-- [Manifests Installation](./installation/kubectl.md) - Install using kubectl/kustomize
-- [Helm Installation](./installation/helm.md) - Install using Helm charts
-- [Operator Lifecycle Manager (OLM) Installation](./installation/olm.md) - Install using OLM
+- [Manifests Installation](./install/kubectl.mdx) - Install using kubectl/kustomize
+- [Helm Installation](./install/helm.mdx) - Install using Helm charts
+- [Operator Lifecycle Manager (OLM) Installation](./install/olm.mdx) - Install using OLM
 
 ## Guides
 
-- **[Introduction](./introduction.md)** - General overview of ClickHouse Operator concepts
-- **[Configuration Guide](./configuration.md)** - Configure ClickHouse and Keeper clusters
+- **[Introduction](./guides/introduction.mdx)** - General overview of ClickHouse Operator concepts
+- **[Configuration Guide](./guides/configuration.mdx)** - Configure ClickHouse and Keeper clusters
+- **[Monitoring](./guides/monitoring.mdx)** - Monitor clickhouse-operator using Prometheus metrics
 
 ## Reference
 

--- a/docs/styles/config/vocabularies/ClickHouse/accept.txt
+++ b/docs/styles/config/vocabularies/ClickHouse/accept.txt
@@ -23,3 +23,7 @@ gofmt
 Gomega
 matchers
 configs
+reachability
+interserver
+misconfiguration
+requeues


### PR DESCRIPTION
## Why

- After switching to MDX docs vale linter did not check spelling.
- Some time ago, markdown-link-check stopped working

## What

- Replace markdown-link-check with linkspector
- Configure vale to check mdx files

