### PR TITLE
docs: document upgradeChannel and version probe

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -457,7 +457,7 @@ Allowed values (validated by the CRD with the pattern `^(lts|stable|\d+\.\d+)?$`
 | `lts` | Tracks the upstream `lts` channel — long-term support releases. Receives major upgrades less frequently, with longer support windows. |
 | `25.8` (or any `<major>.<minor>`) | Pins the channel to a specific major.minor line. Major upgrades beyond it are not proposed even if a newer version exists upstream. |
 
-A cluster left on the default (empty) channel is the safest choice for production: the operator will only flag patch-level updates, and never surprises you with a major version jump even if you redeploy the operator.
+For production, pinning the channel to an explicit `<major>.<minor>` (e.g. `25.8`) is generally preferred. It locks the cluster to the intended major release line and lets the operator surface a `WrongReleaseChannel` warning if any replica somehow drifts onto a different major — which matters especially when the image is referenced by a digest (`@sha256:...`) rather than by a human-readable tag. The empty default is fine for development clusters where major-version jumps are not a concern.
 
 ### Status conditions {#version-status-conditions}
 
@@ -466,14 +466,14 @@ Two conditions surface the result of the probe and the upgrade check:
 | Condition | Reason | Meaning |
 |---|---|---|
 | `VersionInSync` | `VersionMatch` | All replicas report the same version as the image |
-| `VersionInSync` | `VersionMismatch` | Replicas are running different versions (typically during a rolling upgrade) |
+| `VersionInSync` | `VersionMismatch` | Replicas are running different versions. This reason is suppressed during a planned rolling upgrade. It typically surfaces when a mutable image tag has been pinned (for example `latest` or a bare major like `26.3`) and the underlying registry has shifted between pulls, so different replicas ended up on different patches of the same tag. |
 | `VersionInSync` | `VersionPending` | Version probe Job has not finished yet |
 | `VersionInSync` | `VersionProbeFailed` | Probe Job failed; the operator cannot determine the running version |
 | `VersionUpgraded` | `UpToDate` | The cluster is on the latest version available in the selected channel |
 | `VersionUpgraded` | `MinorUpdateAvailable` | A newer patch is available in the same `major.minor` line |
 | `VersionUpgraded` | `MajorUpdateAvailable` | A newer `major.minor` is available within the chosen channel |
-| `VersionUpgraded` | `VersionOutdated` | The running version is older than every release in the selected channel |
-| `VersionUpgraded` | `WrongReleaseChannel` | The configured `upgradeChannel` does not match any upstream channel (e.g. typo) |
+| `VersionUpgraded` | `VersionOutdated` | The running version is out of date and will no longer receive fixes from the selected channel — typically because the major line has been dropped from `lts` or `stable` upstream |
+| `VersionUpgraded` | `WrongReleaseChannel` | The running image does not belong to the selected `upgradeChannel`. Example: a cluster running `26.5` with `upgradeChannel: lts`, since `26.5` is not part of the upstream `lts` line. |
 | `VersionUpgraded` | `UpgradeCheckFailed` | The operator could not reach the upstream release feed |
 
 Inspect them with:

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -453,7 +453,7 @@ Allowed values (validated by the CRD with the pattern `^(lts|stable|\d+\.\d+)?$`
 | Value | Behavior |
 |---|---|
 | _empty_ (default) | The operator proposes only **minor** updates within the currently-running major.minor line. A cluster on `25.8.3.1` will be told about `25.8.4.x` but not `25.9.x`. |
-| `stable` | Tracks the upstream `stable` channel — the latest non-LTS release that ClickHouse Inc. flags as stable. Receives major upgrades sooner. |
+| `stable` | Tracks the upstream `stable` channel — the latest release that ClickHouse Inc. flags as stable on the main release line. Receives major upgrades sooner than the `lts` channel. |
 | `lts` | Tracks the upstream `lts` channel — long-term support releases. Receives major upgrades less frequently, with longer support windows. |
 | `25.8` (or any `<major>.<minor>`) | Pins the channel to a specific major.minor line. Major upgrades beyond it are not proposed even if a newer version exists upstream. |
 
@@ -484,7 +484,7 @@ kubectl get clickhousecluster sample -o yaml | sed -n '/conditions:/,/^[^ ]/p'
 
 ### Overriding the version probe Job {#version-probe-template}
 
-The probe is implemented as a regular Kubernetes `Job`. If your cluster has admission policies that require specific tolerations, node selectors, security contexts, or you want to limit how long completed probe Jobs linger, override the template via `spec.versionProbeTemplate`:
+The probe is implemented as a regular Kubernetes `Job`. If your cluster has admission policies that require specific Tolerations, node selectors, security contexts, or you want to limit how long completed probe Jobs linger, override the template via `spec.versionProbeTemplate`:
 
 ```yaml
 spec:

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -432,6 +432,95 @@ spec.additionalPorts[0].port: 8123 is reserved for the operator-managed HTTP por
 spec.additionalPorts[0].name: "http" is reserved by the operator
 ```
 
+## Version probe and upgrade channel {#version-probe-and-upgrade-channel}
+
+The operator does two independent things with cluster versions:
+
+1. **Version probe** — a Kubernetes `Job` that runs the container image once to detect the running ClickHouse / Keeper version. The detected version is recorded in `.status.version` and used by other reconciliation steps (e.g. the `External Secret` named-collections key is only required from ClickHouse `25.12`).
+2. **Upgrade channel** — a periodic check against the public ClickHouse release feed (`https://clickhouse.com/data/version_date.tsv`). The operator reports whether a newer version is available via the `VersionUpgraded` status condition. It never upgrades the cluster on its own — the user is in control of the image tag.
+
+### Choosing a release channel {#upgrade-channel-choosing}
+
+`spec.upgradeChannel` selects which set of upstream releases the operator compares against. Same field exists on both `ClickHouseCluster` and `KeeperCluster`.
+
+```yaml
+spec:
+  upgradeChannel: lts   # or "stable", or "25.8", or omitted
+```
+
+Allowed values (validated by the CRD with the pattern `^(lts|stable|\d+\.\d+)?$`):
+
+| Value | Behavior |
+|---|---|
+| _empty_ (default) | The operator proposes only **minor** updates within the currently-running major.minor line. A cluster on `25.8.3.1` will be told about `25.8.4.x` but not `25.9.x`. |
+| `stable` | Tracks the upstream `stable` channel — the latest non-LTS release that ClickHouse Inc. flags as stable. Receives major upgrades sooner. |
+| `lts` | Tracks the upstream `lts` channel — long-term support releases. Receives major upgrades less frequently, with longer support windows. |
+| `25.8` (or any `<major>.<minor>`) | Pins the channel to a specific major.minor line. Major upgrades beyond it are not proposed even if a newer version exists upstream. |
+
+A cluster left on the default (empty) channel is the safest choice for production: the operator will only flag patch-level updates, and never surprises you with a major version jump even if you redeploy the operator.
+
+### Status conditions {#version-status-conditions}
+
+Two conditions surface the result of the probe and the upgrade check:
+
+| Condition | Reason | Meaning |
+|---|---|---|
+| `VersionInSync` | `VersionMatch` | All replicas report the same version as the image |
+| `VersionInSync` | `VersionMismatch` | Replicas are running different versions (typically during a rolling upgrade) |
+| `VersionInSync` | `VersionPending` | Version probe Job has not finished yet |
+| `VersionInSync` | `VersionProbeFailed` | Probe Job failed; the operator cannot determine the running version |
+| `VersionUpgraded` | `UpToDate` | The cluster is on the latest version available in the selected channel |
+| `VersionUpgraded` | `MinorUpdateAvailable` | A newer patch is available in the same `major.minor` line |
+| `VersionUpgraded` | `MajorUpdateAvailable` | A newer `major.minor` is available within the chosen channel |
+| `VersionUpgraded` | `VersionOutdated` | The running version is older than every release in the selected channel |
+| `VersionUpgraded` | `WrongReleaseChannel` | The configured `upgradeChannel` does not match any upstream channel (e.g. typo) |
+| `VersionUpgraded` | `UpgradeCheckFailed` | The operator could not reach the upstream release feed |
+
+Inspect them with:
+
+```bash
+kubectl get clickhousecluster sample -o yaml | sed -n '/conditions:/,/^[^ ]/p'
+```
+
+### Overriding the version probe Job {#version-probe-template}
+
+The probe is implemented as a regular Kubernetes `Job`. If your cluster has admission policies that require specific tolerations, node selectors, security contexts, or you want to limit how long completed probe Jobs linger, override the template via `spec.versionProbeTemplate`:
+
+```yaml
+spec:
+  versionProbeTemplate:
+    spec:
+      ttlSecondsAfterFinished: 600   # delete completed probe Jobs 10 minutes after completion
+      template:
+        spec:
+          nodeSelector:
+            kubernetes.io/arch: amd64
+          tolerations:
+            - key: dedicated
+              operator: Equal
+              value: clickhouse
+              effect: NoSchedule
+          containers:
+            - name: version-probe
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+```
+
+The container name `version-probe` is the operator's default — the entry under `containers:` matches it by name, so the operator deep-merges the user-provided fields on top of the defaults.
+
+### Operator-wide controls {#version-operator-flags}
+
+Two flags on the operator manager control the upgrade-check loop globally:
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--version-update-interval` | `24h` | How often the operator re-fetches the upstream version list |
+| `--disable-version-update-checks` | `false` | Disables the upgrade checker entirely. The `VersionUpgraded` condition is not set, and no outbound HTTP traffic to `clickhouse.com` is generated |
+
+Set `--disable-version-update-checks=true` in air-gapped environments or when egress to `clickhouse.com` is not allowed.
+
 ## ClickHouse settings {#clickhouse-settings}
 
 ### Default user password {#default-user-password}


### PR DESCRIPTION
Adds a "Version probe and upgrade channel" section to the configuration guide covering `spec.upgradeChannel`, `spec.versionProbeTemplate`, the `VersionInSync` / `VersionUpgraded` status conditions, and the operator-wide `--version-update-interval` / `--disable-version-update-checks` flags.

## Why

The operator does two version-related things that currently have no documentation:

* It runs a `Job` to detect the running ClickHouse / Keeper version (`spec.versionProbeTemplate`).
* It periodically polls the upstream release feed to surface upgrade availability (`spec.upgradeChannel` and the `VersionUpgraded` status condition).

A search for `upgradeChannel` or `versionProbe` under `docs/` returns no matches, meaning users currently need to read `api/v1alpha1/clickhousecluster_types.go`, `internal/upgrade/`, and `cmd/main.go` to understand these features, accepted release channel values, status condition meanings, and how to disable upgrade checks in air-gapped environments.

## What

Adds a new `## Version probe and upgrade channel` section to `docs/guides/configuration.mdx`, placed between `## Additional ports` and `## ClickHouse settings`, with four subsections:

* **Choosing a release channel**: explains the supported `upgradeChannel` values (empty, `lts`, `stable`, and `major.minor`), including the CRD validation pattern and guidance on when to use each option.
* **Status conditions**: documents all reasons for `VersionInSync` (`VersionMatch`, `VersionMismatch`, `VersionPending`, `VersionProbeFailed`) and `VersionUpgraded` (`UpToDate`, `MinorUpdateAvailable`, `MajorUpdateAvailable`, `VersionOutdated`, `WrongReleaseChannel`, `UpgradeCheckFailed`), based on `api/v1alpha1/conditions.go`.
* **Overriding the version probe Job**: provides a `spec.versionProbeTemplate` example showing tolerations, node selectors, `ttlSecondsAfterFinished`, and container resource overrides.
* **Operator-wide controls**: documents the `--version-update-interval` (default `24h`) and `--disable-version-update-checks` flags for tuning or disabling upgrade checks, including air-gapped deployments.

No code or chart changes. Documentation only.