### PR TITLE
docs: document spec.settings.logger server logging configuration

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -717,6 +717,47 @@ spec:
 
 When enabled, the operator synchronizes Replicated and integration tables to new replicas.
 
+### Server logging {#server-logging}
+
+Configure the ClickHouse server log through `spec.settings.logger`. Every field is optional with a safe default, so a cluster you never touch already logs at `trace` to both the container console and a rotated file on disk.
+
+```yaml
+spec:
+  settings:
+    logger:
+      logToFile: true   # Default: true. Set false to log only to the console
+      jsonLogs: false   # Default: false. Set true for structured JSON log lines
+      level: trace      # Default: trace
+      size: 1000M       # Default: 1000M. Rotate a log file once it reaches this size
+      count: 50         # Default: 50. Number of rotated files to keep
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `logToFile` | `true` | When `false`, the operator drops the file targets and the server logs only to the container console. |
+| `jsonLogs` | `false` | When `true`, the operator adds `formatting.type: json` so each line is a JSON object. |
+| `level` | `trace` | Log verbosity. One of `test`, `trace`, `debug`, `information`, `notice`, `warning`, `error`, `critical`, `fatal`. |
+| `size` | `1000M` | Maximum size of a single log file before rotation. |
+| `count` | `50` | Number of rotated log files the server retains. |
+
+The operator always keeps console logging on so that `kubectl logs` works, and layers file logging on top when `logToFile` is `true`. A cluster with the defaults renders this `logger` block:
+
+```yaml
+logger:
+  console: true
+  level: trace
+  log: /var/log/clickhouse-server/clickhouse-server.log
+  errorlog: /var/log/clickhouse-server/clickhouse-server.err.log
+  size: 1000M
+  count: 50
+```
+
+The same `spec.settings.logger` block applies to a `KeeperCluster`; the operator writes its files under `/var/log/clickhouse-keeper/` instead.
+
+<Note>
+Console logging stays on regardless of `logToFile`, so `kubectl logs` keeps working even when you disable file logging. Set `jsonLogs: true` when you ship logs to a structured log store that parses JSON.
+</Note>
+
 ## Custom configuration {#custom-configuration}
 
 ### Embedded extra configuration {#embedded-extra-configuration}


### PR DESCRIPTION
## Why

The `spec.settings.logger` block is fully implemented on both `ClickHouseCluster` and `KeeperCluster` (with kubebuilder defaults and an enum-validated `level`), but it was not documented anywhere in the configuration guide. Users had no reference for how to change the log level, disable file logging, switch to JSON output, ortune log rotation, and no indication that console logging always stays on so `kubectl logs` keeps working.

## What

 Adds a **Server logging** subsection under *ClickHouse settings* in `docs/guides/configuration.mdx`:
  - Documents all five fields with their defaults: `logToFile` (true), `jsonLogs` (false), `level` (trace; full enum listed), `size` (1000M), `count` (50).
  - Shows the rendered `logger:` block so users can see that console logging is always on and file targets (`log` / `errorlog`) are only added when logToFile: true`.
  - Notes that the same `spec.settings.logger` block applies to `KeeperCluster` (files under `/var/log/clickhouse-keeper/`)