### PR TITLE
fix: paginate all tags to build olm catalog

### DIFF
--- a/ci/generate-catalog-template.sh
+++ b/ci/generate-catalog-template.sh
@@ -12,18 +12,29 @@ OUTPUT_FILE="catalog/clickhouse-operator-template.yaml"
 # Function to get all tags from ghcr.io
 get_bundle_tags() {
     local owner="clickhouse"
-    local gh_api_url="https://api.github.com/orgs/clickhouse/packages/container/clickhouse-operator-bundle/versions"
+    local gh_api_url="https://api.github.com/orgs/clickhouse/packages/container/clickhouse-operator-bundle/versions?per_page=100"
     local filter="$1"
+    local headers_file next_url
+    headers_file=$(mktemp)
+    next_url="${gh_api_url}"
 
     echo "Fetching bundle tags from ${BUNDLE_IMAGE}" >&2
     # grep guarded with `|| true` so a no-match (exit 1) does not abort the
     # surrounding `$(...)` under `set -e -o pipefail`.
-    curl -sL \
-        -H "Accept: application/vnd.github+json" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-        "${gh_api_url}" 2>/dev/null \
-        | jq -r '.[].metadata.container.tags[]' 2>/dev/null \
+    {
+        while [ -n "${next_url}" ]; do
+            curl -sL \
+                -D "${headers_file}" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                "${next_url}" 2>/dev/null \
+                | jq -r '.[].metadata.container.tags[]' 2>/dev/null
+            # Follow `Link: <url>; rel="next"` until exhausted; multi-arch+attestation rows overflow page size.
+            next_url=$(grep -i '^link:' "${headers_file}" | sed -n 's/.*<\([^>]*\)>; rel="next".*/\1/p' | tr -d '\r')
+        done
+        rm -f "${headers_file}"
+    } \
         | { grep -E "$filter" || true; } \
         | sort -V
 }


### PR DESCRIPTION
## Why

Currently, the catalog is built on the latest 30 images

## What

Use pagination to read all tags
