### PR TITLE
feat: add prometheus port to the keeper headless service

### DIFF
--- a/internal/controller/keeper/templates.go
+++ b/internal/controller/keeper/templates.go
@@ -28,6 +28,12 @@ func templateHeadlessService(cr *v1.KeeperCluster) *corev1.Service {
 			Port:       PortInterserver,
 			TargetPort: intstr.FromInt32(PortInterserver),
 		},
+		{
+			Protocol:   corev1.ProtocolTCP,
+			Name:       "prometheus",
+			Port:       PortPrometheusScrape,
+			TargetPort: intstr.FromInt32(PortPrometheusScrape),
+		},
 	}
 
 	if !cr.Spec.Settings.TLS.Enabled || !cr.Spec.Settings.TLS.Required {


### PR DESCRIPTION
## Why

Prometheus port was missing from the Keeper Service ports list 

## What

Add missing port declaration

## Related Issues

Fixes #224
