### PR TITLE
feat: add registry option to helm charts

### DIFF
--- a/dist/chart-cluster/templates/clickhouse-cluster.yaml
+++ b/dist/chart-cluster/templates/clickhouse-cluster.yaml
@@ -17,7 +17,10 @@ metadata:
 spec:
   {{- /* Chart-provided defaults: image tag from .Values.imageTag (fallback: chart appVersion). User values override. */}}
   {{- $tag := default .Chart.AppVersion .Values.imageTag }}
-  {{- $defaults := dict "containerTemplate" (dict "image" (dict "tag" $tag)) }}
+  {{- $repository := .Values.clickhouse.image.repository }}
+  {{- $registry := default .Values.clickhouse.image.registry ((.Values.global | default dict).imageRegistry) }}
+  {{- if $registry }}{{- $repository = printf "%s/%s" (trimSuffix "/" $registry) $repository }}{{- end }}
+  {{- $defaults := dict "containerTemplate" (dict "image" (dict "tag" $tag "repository" $repository)) }}
   {{- $spec := mergeOverwrite $defaults (deepCopy (.Values.clickhouse.spec | default dict)) }}
   {{- /* Auto-wire keeperClusterRef when keeper is enabled in-chart and user did not pin one. */}}
   {{- if and .Values.keeper.enabled (not (hasKey $spec "keeperClusterRef")) }}

--- a/dist/chart-cluster/templates/keeper-cluster.yaml
+++ b/dist/chart-cluster/templates/keeper-cluster.yaml
@@ -17,7 +17,10 @@ metadata:
 spec:
   {{- /* Chart-provided defaults: image tag from .Values.imageTag (fallback: chart appVersion). User values override. */}}
   {{- $tag := default .Chart.AppVersion .Values.imageTag }}
-  {{- $defaults := dict "containerTemplate" (dict "image" (dict "tag" $tag)) }}
+  {{- $repository := .Values.keeper.image.repository }}
+  {{- $registry := default .Values.keeper.image.registry ((.Values.global | default dict).imageRegistry) }}
+  {{- if $registry }}{{- $repository = printf "%s/%s" (trimSuffix "/" $registry) $repository }}{{- end }}
+  {{- $defaults := dict "containerTemplate" (dict "image" (dict "tag" $tag "repository" $repository)) }}
   {{- $spec := mergeOverwrite $defaults (deepCopy (.Values.keeper.spec | default dict)) }}
   {{- toYaml $spec | nindent 2 }}
 {{- end }}

--- a/dist/chart-cluster/values.yaml
+++ b/dist/chart-cluster/values.yaml
@@ -20,9 +20,24 @@
 # clickhouse.spec.containerTemplate.image.tag / keeper.spec.containerTemplate.image.tag.
 imageTag: ""
 
+# Global values shared across this chart and its parent chart.
+global:
+  # Optional registry prefix prepended to every image repository rendered by
+  # this chart. Routes all pulls through a single mirror/proxy registry.
+  # Empty disables the prefix. Overrides clickhouse.image.registry / keeper.image.registry.
+  imageRegistry: ""
+
 clickhouse:
   # Whether to create the ClickHouseCluster CR.
   enabled: true
+
+  # Container image for ClickHouse server. The effective value is injected into
+  # spec.containerTemplate.image.repository (an explicit spec value still wins).
+  # registry is an optional prefix overridden by global.imageRegistry; empty
+  # uses repository as-is.
+  image:
+    registry: ""
+    repository: docker.io/clickhouse/clickhouse-server
 
   # Metadata applied to the ClickHouseCluster CR itself.
   meta:
@@ -88,6 +103,14 @@ clickhouse:
 keeper:
   # Whether to create the KeeperCluster CR.
   enabled: true
+
+  # Container image for ClickHouse Keeper. The effective value is injected into
+  # spec.containerTemplate.image.repository (an explicit spec value still wins).
+  # registry is an optional prefix overridden by global.imageRegistry; empty
+  # uses repository as-is.
+  image:
+    registry: ""
+    repository: docker.io/clickhouse/clickhouse-keeper
 
   # Metadata applied to the KeeperCluster CR itself.
   meta:

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -114,7 +114,10 @@ spec:
         - name: {{ $k }}
           value: {{ $v | quote }}
         {{- end }}
-        image: "{{ .Values.manager.image.repository }}{{- if .Values.manager.image.digest }}@{{ .Values.manager.image.digest }}{{- else if not (contains "@" .Values.manager.image.repository) }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}{{- end }}"
+        {{- $repository := .Values.manager.image.repository }}
+        {{- $registry := default .Values.manager.image.registry (.Values.global | default dict).imageRegistry }}
+        {{- if $registry }}{{- $repository = printf "%s/%s" (trimSuffix "/" $registry) $repository }}{{- end }}
+        image: "{{ $repository }}{{- if .Values.manager.image.digest }}@{{ .Values.manager.image.digest }}{{- else if not (contains "@" $repository) }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}{{- end }}"
         {{- with .Values.manager.image.pullPolicy }}
         imagePullPolicy: {{ . }}
         {{- end }}

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -6,6 +6,17 @@
 ##
 # fullnameOverride: ""
 
+## Global values shared across this chart and its subcharts.
+##
+global:
+  ## Optional registry prefix prepended to every image repository rendered by
+  ## this chart. Routes all pulls through a single mirror/proxy registry.
+  ## Empty disables the prefix. Overrides per-image registry settings.
+  ## Example: "my-proxy.example.com" renders
+  ##          my-proxy.example.com/ghcr.io/clickhouse/clickhouse-operator
+  ##
+  imageRegistry: ""
+
 ## Configure the controller manager settings
 ##
 controller:
@@ -30,6 +41,10 @@ manager:
   replicas: 1
 
   image:
+    ## Optional registry prefix for this image. Overridden by global.imageRegistry
+    ## when set. Empty uses repository as-is.
+    ##
+    registry: ""
     repository: ghcr.io/clickhouse/clickhouse-operator
     ## Digest of the image to use. Tag is used if unset.
     ##

--- a/tools/gen-cluster-chart/templates/values.yaml.tmpl
+++ b/tools/gen-cluster-chart/templates/values.yaml.tmpl
@@ -34,9 +34,24 @@
 # clickhouse.spec.containerTemplate.image.tag / keeper.spec.containerTemplate.image.tag.
 imageTag: ""
 
+# Global values shared across this chart and its parent chart.
+global:
+  # Optional registry prefix prepended to every image repository rendered by
+  # this chart. Routes all pulls through a single mirror/proxy registry.
+  # Empty disables the prefix. Overrides clickhouse.image.registry / keeper.image.registry.
+  imageRegistry: ""
+
 clickhouse:
   # Whether to create the ClickHouseCluster CR.
   enabled: true
+
+  # Container image for ClickHouse server. The effective value is injected into
+  # spec.containerTemplate.image.repository (an explicit spec value still wins).
+  # registry is an optional prefix overridden by global.imageRegistry; empty
+  # uses repository as-is.
+  image:
+    registry: ""
+    repository: docker.io/clickhouse/clickhouse-server
 
   # Metadata applied to the ClickHouseCluster CR itself.
   meta:
@@ -53,6 +68,14 @@ clickhouse:
 keeper:
   # Whether to create the KeeperCluster CR.
   enabled: true
+
+  # Container image for ClickHouse Keeper. The effective value is injected into
+  # spec.containerTemplate.image.repository (an explicit spec value still wins).
+  # registry is an optional prefix overridden by global.imageRegistry; empty
+  # uses repository as-is.
+  image:
+    registry: ""
+    repository: docker.io/clickhouse/clickhouse-keeper
 
   # Metadata applied to the KeeperCluster CR itself.
   meta:


### PR DESCRIPTION
## Why

An easier way to specify the image registry mirror

## What

Support global/local registry option in both operator/cluster charts

## Related Issues

Fixes #219