### PR TITLE
feat: add crds as a separate release artifact, build stripped crds to fit client-side apply

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,12 @@ jobs:
         run: |
           make build-installer
           mv dist/install.yaml dist/clickhouse-operator.yaml
+          make build-installer-stripped
+          mv dist/install-stripped-crds.yaml dist/clickhouse-operator-stripped-crds.yaml
+          make build-crds
+          mv dist/crds.yaml dist/clickhouse-operator-crds.yaml
+          make build-crds-stripped
+          mv dist/crds-stripped.yaml dist/clickhouse-operator-crds-stripped.yaml
       - name: Install Helm
         run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       - name: Verify Helm installation
@@ -152,10 +158,22 @@ jobs:
           name: ${{github.ref_name }}
           draft: true
           body: |
-            ## Install using the manifest
+            ## Install using the manifest (server-side apply)
             ```
-            kubectl apply -f https://github.com/ClickHouse/clickhouse-operator/releases/download/${{github.ref_name}}/clickhouse-operator.yaml
+            kubectl apply --server-side --force-conflicts -f https://github.com/ClickHouse/clickhouse-operator/releases/download/${{github.ref_name}}/clickhouse-operator.yaml
             ```
+
+            For clusters restricted to client-side apply, use the description-stripped CRDs:
+            ```
+            kubectl apply -f https://github.com/ClickHouse/clickhouse-operator/releases/download/${{github.ref_name}}/clickhouse-operator-stripped-crds.yaml
+            ```
+
+            ## CRDs only
+            ```
+            kubectl apply --server-side --force-conflicts -f https://github.com/ClickHouse/clickhouse-operator/releases/download/${{github.ref_name}}/clickhouse-operator-crds.yaml
+            ```
+
+            Client-side apply variant: `clickhouse-operator-crds-stripped.yaml`
             
             ## Install using helmchart
             ```
@@ -171,6 +189,9 @@ jobs:
           append_body: true
           files: |
             dist/clickhouse-operator.yaml
+            dist/clickhouse-operator-stripped-crds.yaml
+            dist/clickhouse-operator-crds.yaml
+            dist/clickhouse-operator-crds-stripped.yaml
             clickhouse-operator-helm-${{env.VERSION}}.tgz
             clickhouse-cluster-helm-${{env.VERSION}}.tgz
             clickhouse-operator_${{env.VERSION}}_*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -329,12 +329,12 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	$(KUSTOMIZE) build config/default > dist/install.yaml
 
 .PHONY: build-installer-stripped
-build-installer-stripped: manifests generate kustomize ## Generate a consolidated installer with description-stripped CRDs (for client-side kubectl apply).
+build-installer-stripped: controller-gen kustomize ## Generate a consolidated installer with description-stripped CRDs (for client-side kubectl apply).
 	mkdir -p dist
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd:maxDescLen=0 paths="./..." output:crd:artifacts:config=config/crd/bases
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install-stripped-crds.yaml
-	$(MAKE) manifests
+	$(CONTROLLER_GEN) crd paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: build-crds
 build-crds: manifests kustomize ## Generate standalone CRD manifests.
@@ -342,11 +342,11 @@ build-crds: manifests kustomize ## Generate standalone CRD manifests.
 	$(KUSTOMIZE) build config/crd > dist/crds.yaml
 
 .PHONY: build-crds-stripped
-build-crds-stripped: manifests kustomize ## Generate standalone CRD manifests with descriptions stripped (for client-side kubectl apply).
+build-crds-stripped: controller-gen kustomize ## Generate standalone CRD manifests with descriptions stripped (for client-side kubectl apply).
 	mkdir -p dist
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd:maxDescLen=0 paths="./..." output:crd:artifacts:config=config/crd/bases
 	$(KUSTOMIZE) build config/crd > dist/crds-stripped.yaml
-	$(MAKE) manifests
+	$(CONTROLLER_GEN) crd paths="./..." output:crd:artifacts:config=config/crd/bases
 
 ##@ Deployment
 

--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,26 @@ build-installer: manifests generate kustomize ## Generate a consolidated YAML wi
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/install.yaml
 
+.PHONY: build-installer-stripped
+build-installer-stripped: manifests generate kustomize ## Generate a consolidated installer with description-stripped CRDs (for client-side kubectl apply).
+	mkdir -p dist
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default > dist/install-stripped-crds.yaml
+	$(MAKE) manifests
+
+.PHONY: build-crds
+build-crds: manifests kustomize ## Generate standalone CRD manifests.
+	mkdir -p dist
+	$(KUSTOMIZE) build config/crd > dist/crds.yaml
+
+.PHONY: build-crds-stripped
+build-crds-stripped: manifests kustomize ## Generate standalone CRD manifests with descriptions stripped (for client-side kubectl apply).
+	mkdir -p dist
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd:maxDescLen=0 webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(KUSTOMIZE) build config/crd > dist/crds-stripped.yaml
+	$(MAKE) manifests
+
 ##@ Deployment
 
 ifndef ignore-not-found
@@ -336,7 +356,7 @@ endif
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply --server-side --force-conflicts -f -
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -345,7 +365,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/default | $(KUBECTL) apply --server-side --force-conflicts -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For users who want to quickly try the operator:
 1. Install the Custom Resource Definitions(CRD) and operator (Requires cert-manager to issue webhook certificates):
    - Using pre-built manifests:
      ```sh
-     kubectl apply -f https://github.com/ClickHouse/clickhouse-operator/releases/latest/download/clickhouse-operator.yaml
+     kubectl apply --server-side --force-conflicts -f https://github.com/ClickHouse/clickhouse-operator/releases/latest/download/clickhouse-operator.yaml
      ```
    - Using helm chart
      ```sh

--- a/docs/install/kubectl.mdx
+++ b/docs/install/kubectl.mdx
@@ -24,7 +24,13 @@ Requires cert-manager to issue webhook certificates.
 Install the operator and CRDs from the latest release:
 
 ```bash
-kubectl apply -f https://github.com/ClickHouse/clickhouse-operator/releases/latest/download/clickhouse-operator.yaml
+kubectl apply --server-side --force-conflicts -f https://github.com/ClickHouse/clickhouse-operator/releases/latest/download/clickhouse-operator.yaml
+```
+
+Server-side apply is required because the combined CRDs exceed the client-side apply size limit. For environments that only support client-side apply, use the description-stripped CRD variant:
+
+```bash
+kubectl apply -f https://github.com/ClickHouse/clickhouse-operator/releases/latest/download/clickhouse-operator-stripped-crds.yaml
 ```
 
 This will:
@@ -94,7 +100,7 @@ Build the operator manifests and apply them:
 
 ```bash
 make build-installer VERSION=<required operator version> [IMG=<custom registry path>]
-kubectl apply -f dist/install.yaml
+kubectl apply --server-side --force-conflicts -f dist/install.yaml
 ```
 
 </Step>

--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -142,7 +142,8 @@ var _ = Describe("Manifests deployment", Ordered, Label("manifest"), func() {
 		Expect(testutil.MustRun(ctx, "make", "build-installer", "IMG="+testImage)).To(Succeed())
 
 		By("applying installer manifest")
-		Expect(testutil.MustRun(ctx, "kubectl", "apply", "-f", "dist/install.yaml")).To(Succeed())
+		Expect(testutil.MustRun(ctx, "kubectl", "apply", "--server-side", "--force-conflicts",
+			"-f", "dist/install.yaml")).To(Succeed())
 
 		DeferCleanup(func(ctx context.Context) {
 			By("removing installer manifest resources")


### PR DESCRIPTION
## Why

Changes like #136 make CRD too large for client-side apply. Need to provide different options for the operator deployment after it is merged.

## What

Add a CRDs as a separate release artifact and stripped versions that should fit client-side apply

