### PR TITLE
test: fix flaky operator-upgrade keeper writes

### DIFF
--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -425,13 +425,16 @@ var _ = Describe("Operator upgrade", Ordered, Label("upgrade"), func() {
 			"--for=condition=Ready", "clickhousecluster/"+chName)).To(Succeed())
 
 		By("writing test data", func() {
-			keeperClient, err := testutil.NewKeeperClient(ctx, dialer, &keeperCR)
-			Expect(err).NotTo(HaveOccurred())
+			// A freshly formed keeper ensemble re-elects for a while, so retry through transient leader loss.
+			Eventually(func(g Gomega) {
+				keeperClient, err := testutil.NewKeeperClient(ctx, dialer, &keeperCR)
+				g.Expect(err).NotTo(HaveOccurred())
 
-			defer keeperClient.Close()
+				defer keeperClient.Close()
 
-			Expect(keeperClient.CheckWrite(0)).To(Succeed())
-			Expect(keeperClient.CheckRead(0)).To(Succeed())
+				g.Expect(keeperClient.CheckWrite(0)).To(Succeed())
+				g.Expect(keeperClient.CheckRead(0)).To(Succeed())
+			}, "2m", "5s").Should(Succeed())
 
 			chClient, err := testutil.NewClickHouseClient(ctx, dialer, &chCR)
 			Expect(err).NotTo(HaveOccurred())
@@ -466,14 +469,17 @@ var _ = Describe("Operator upgrade", Ordered, Label("upgrade"), func() {
 				g.Expect(meta.IsStatusConditionTrue(cluster.Status.Conditions, v1.ConditionTypeReady)).To(BeTrue())
 			}, "10m", "5s").Should(Succeed())
 
-			keeperClient, err := testutil.NewKeeperClient(ctx, dialer, &keeperCR)
-			Expect(err).NotTo(HaveOccurred())
+			// Keeper re-elects after the rolling restart, so retry through transient leader loss.
+			Eventually(func(g Gomega) {
+				keeperClient, err := testutil.NewKeeperClient(ctx, dialer, &keeperCR)
+				g.Expect(err).NotTo(HaveOccurred())
 
-			defer keeperClient.Close()
+				defer keeperClient.Close()
 
-			Expect(keeperClient.CheckRead(0)).To(Succeed())
-			Expect(keeperClient.CheckWrite(1)).To(Succeed())
-			Expect(keeperClient.CheckRead(1)).To(Succeed())
+				g.Expect(keeperClient.CheckRead(0)).To(Succeed())
+				g.Expect(keeperClient.CheckWrite(1)).To(Succeed())
+				g.Expect(keeperClient.CheckRead(1)).To(Succeed())
+			}, "2m", "5s").Should(Succeed())
 		})
 
 		By("updating clickhouse and verifying its health", func() {

--- a/test/testutil/keeper_client.go
+++ b/test/testutil/keeper_client.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -134,7 +135,9 @@ func (c *KeeperClient) Close() {
 func (c *KeeperClient) CheckWrite(order int) error {
 	for i := range 10 {
 		path := fmt.Sprintf(keeperTestDataKey, order, i)
-		if _, err := c.client.Create(path, []byte(fmt.Sprintf(keeperTestDataVal, i)), 0, nil); err != nil {
+
+		_, err := c.client.Create(path, []byte(fmt.Sprintf(keeperTestDataVal, i)), 0, nil)
+		if err != nil && !errors.Is(err, zk.ErrNodeExists) {
 			return fmt.Errorf("creating test data failed: %w", err)
 		}
 


### PR DESCRIPTION
## Why

The `operator-upgrade` e2e test (added in #229) is flaky. Example failure: https://github.com/ClickHouse/clickhouse-operator/actions/runs/27624811978/job/81683404561

A freshly formed (and post-upgrade rolled) keeper ensemble keeps re-electing its RAFT leader for ~20-30s after it first reports `ClusterReady` — the condition flaps `Ready`↔`No leader` every 1-2s under CI load. The test connected and wrote keeper data right after the `kubectl wait --for=condition=Ready` returned, so `KeeperClient.CheckWrite` (a bare `Create` with no retry) intermittently failed with `zk: connection closed` during a transient no-leader window.

## What

- Wrap the pre-upgrade keeper write and the post-upgrade keeper writability check in `Eventually` with a fresh client per attempt, so they retry through the transient leader loss.
- Make `KeeperClient.CheckWrite` tolerate `zk.ErrNodeExists` so the retry is idempotent (the helper is only used by this test).

## Test plan

- [ ] `compat-e2e-test (operator-upgrade)` passes