### PR TITLE
test: use latest supported ClickHouse versions in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -226,23 +226,23 @@ jobs:
         include:
           - name: minimal-k8s-all-deploy-methods
             k8s_image: v1.28.15
-            clickhouse_version: "26.3"
+            clickhouse_version: "26.5"
             deploy_target: test-compat-e2e
           - name: maximal-k8s-all-deploy-methods
             k8s_image: v1.35.1
-            clickhouse_version: "26.3"
+            clickhouse_version: "26.5"
             deploy_target: test-compat-e2e
           - name: olm-deploy-method
             k8s_image: v1.28.15
-            clickhouse_version: "26.3"
+            clickhouse_version: "26.5"
             deploy_target: test-compat-e2e-olm
           - name: supported-clickhouse-compatibility
             k8s_image: v1.30.13
-            clickhouse_version: "26.3,26.2,26.1,25.8"
+            clickhouse_version: "26.5,26.4,26.3,25.8"
             deploy_target: test-compat-e2e-manifest
           - name: operator-upgrade
             k8s_image: v1.30.13
-            clickhouse_version: "26.3"
+            clickhouse_version: "26.5"
             deploy_target: test-compat-e2e-upgrade
     steps:
       - name: Checkout code

--- a/internal/controller/clickhouse/commands_test.go
+++ b/internal/controller/clickhouse/commands_test.go
@@ -33,8 +33,8 @@ const (
 	clickhouseHostnameFormat       = "test-clickhouse-0-%d-0"
 	testPassword                   = "test-password"
 	testUsername                   = "operator"
-	keeperImage                    = "clickhouse/clickhouse-keeper:26.2"
-	clickhouseImage                = "clickhouse/clickhouse-server:26.2"
+	keeperImage                    = "clickhouse/clickhouse-keeper:26.5"
+	clickhouseImage                = "clickhouse/clickhouse-server:26.5"
 	testConfigRevision             = "test-revision-v1"
 )
 

--- a/test/testutil/utils.go
+++ b/test/testutil/utils.go
@@ -41,8 +41,8 @@ const (
 	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 
 	logTailLines  = 10
-	BaseVersion   = "26.2"
-	UpdateVersion = "26.3"
+	BaseVersion   = "26.3"
+	UpdateVersion = "26.5"
 )
 
 var (


### PR DESCRIPTION
## Why

Regular version bump to the supported ones

## What

Bump ClickHouse versions in the compatibility, e2e, and ch controller integration tests

