### PR TITLE
docs: expand default user password configuration

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -716,10 +716,13 @@ for the full list.
 
 - Use `password_sha256_hex` (or another hashed type) so the plaintext never has to
   exist in the cluster — store only the hash.
-- Use `password` only when a component needs the plaintext. Note that **only the
-  plaintext `password` type is also placed in the operator's client configuration**; with a
-  hashed type the server still authenticates the `default` user, but the operator's
-  own client connections do not carry the password.
+- Use `password` only when you need the in-pod `clickhouse-client` to authenticate
+  as `default` automatically: the operator writes the value into the client
+  configuration (`/etc/clickhouse-client/config.yaml`) **only for the plaintext
+  `password` type**. With a hashed type the server still authenticates the `default`
+  user normally, but `clickhouse-client` run inside the pod is not pre-filled with
+  the password (a hash cannot be used as a client-side password). This does not
+  affect the operator itself — it manages the cluster as a separate `operator` user.
 
 #### Full example with a Secret {#default-password-secret-example}
 

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -687,31 +687,87 @@ Set `--disable-version-update-checks=true` in air-gapped environments or when eg
 
 ### Default user password {#default-user-password}
 
-Set the default user password:
+`spec.settings.defaultUserPassword` sets the password for the built-in `default`
+user. The value is not stored inline — it is read from a key in a Secret or a
+ConfigMap that you create, and injected into the pod as an environment variable.
 
 ```yaml
 spec:
   settings:
     defaultUserPassword:
-      passwordType: <password-type> # Default: password
-      <secret|configMap>:
-        name: <resource name>
-        key: <password>
+      passwordType: password   # default; see "Password types" below
+      secret:                  # exactly one of secret OR configMap
+        name: clickhouse-password   # name of the Secret/ConfigMap
+        key: password               # the KEY inside it — not the password value
 ```
 
-<Note>
-It isn't recommended to use ConfigMap to store plain text passwords.
-</Note>
+You must specify **exactly one** of `secret` or `configMap` (setting both, or
+neither, is rejected by the validating webhook), and both `name` and `key` are
+required. `name` is the Secret/ConfigMap object, `key` is the entry within it whose
+value holds the password — the password itself is never written in the CR.
 
-Create the secret:
+#### Password types {#password-types}
+
+`passwordType` tells ClickHouse how to interpret the value. It defaults to
+`password` (plaintext). The common alternatives are hashed forms such as
+`password_sha256_hex` and `password_double_sha1_hex` — see the
+[ClickHouse user settings](https://clickhouse.com/docs/operations/settings/settings-users#user-namepassword)
+for the full list.
+
+- Use `password_sha256_hex` (or another hashed type) so the plaintext never has to
+  exist in the cluster — store only the hash.
+- Use `password` only when a component needs the plaintext. Note that **only the
+  plaintext `password` type is also placed in the operator's client configuration**; with a
+  hashed type the server still authenticates the `default` user, but the operator's
+  own client connections do not carry the password.
+
+#### Full example with a Secret {#default-password-secret-example}
+
+Create the Secret, then reference its key:
 
 ```bash
-kubectl create secret generic clickhouse-password --from-literal=password='your-secure-password'
+kubectl create secret generic clickhouse-password \
+  --from-literal=password='your-secure-password'
 ```
 
-#### Using ConfigMap for user passwords {#using-configmap-for-user-passwords}
+```yaml
+apiVersion: clickhouse.com/v1alpha1
+kind: ClickHouseCluster
+metadata:
+  name: my-cluster
+spec:
+  settings:
+    defaultUserPassword:
+      passwordType: password
+      secret:
+        name: clickhouse-password
+        key: password
+```
 
-You can also use ConfigMap for non-sensitive default passwords:
+For a hashed password, store the hash instead of the plaintext:
+
+```bash
+echo -n 'your-secure-password' | sha256sum   # use the hex digest as the value
+kubectl create secret generic clickhouse-password \
+  --from-literal=password='<sha256-hex-digest>'
+```
+
+```yaml
+spec:
+  settings:
+    defaultUserPassword:
+      passwordType: password_sha256_hex
+      secret:
+        name: clickhouse-password
+        key: password
+```
+
+#### Using a ConfigMap {#using-configmap-for-user-passwords}
+
+A ConfigMap works the same way but stores its value in plaintext on the API server,
+so use it **only for non-sensitive or already-hashed values** — for example a
+`password_sha256_hex` digest, which does not contain the plaintext password
+(though a weak password may still be recoverable from the hash by brute force):
 
 ```yaml
 spec:
@@ -722,6 +778,11 @@ spec:
         name: clickhouse-config
         key: default_password
 ```
+
+<Note>
+Do not put a plaintext password in a ConfigMap — ConfigMap data is not protected
+like Secret data. Use a Secret for any plaintext (`passwordType: password`) value.
+</Note>
 
 ### Custom users in configuration {#custom-users-in-configuration}
 

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -688,41 +688,30 @@ Set `--disable-version-update-checks=true` in air-gapped environments or when eg
 ### Default user password {#default-user-password}
 
 `spec.settings.defaultUserPassword` sets the password for the built-in `default`
-user. The value is not stored inline; it is read from a key in a Secret or a
-ConfigMap that you create, and injected into the pod as an environment variable.
+user. Provide the value from a key in a Secret (recommended) or a ConfigMap that
+you create, rather than inline in the CR:
 
 ```yaml
 spec:
   settings:
     defaultUserPassword:
       passwordType: password   # default; see "Password types" below
-      secret:                  # exactly one of secret OR configMap
+      secret:                  # exactly one of secret or configMap
         name: clickhouse-password   # name of the Secret/ConfigMap
-        key: password               # the KEY inside it, not the password value
+        key: password               # the key inside it, not the password value
 ```
 
-You must specify **exactly one** of `secret` or `configMap` (setting both, or
-neither, is rejected by the validating webhook), and both `name` and `key` are
-required. `name` is the Secret/ConfigMap object, `key` is the entry within it whose
-value holds the password. The password itself is never written in the CR.
+Provide exactly one of `secret` or `configMap`, each with both `name` (the object)
+and `key` (the entry that holds the password).
 
 #### Password types {#password-types}
 
 `passwordType` tells ClickHouse how to interpret the value. It defaults to
-`password` (plaintext). The common alternatives are hashed forms such as
-`password_sha256_hex` and `password_double_sha1_hex`. See the
+`password` (plaintext); the alternatives are hashed forms such as
+`password_sha256_hex` and `password_double_sha1_hex`. Prefer a hashed type so the
+plaintext is never stored. See the
 [ClickHouse user settings](https://clickhouse.com/docs/operations/settings/settings-users#user-namepassword)
 for the full list.
-
-- Use `password_sha256_hex` (or another hashed type) so the plaintext never has to
-  exist in the cluster; store only the hash.
-- Use `password` only when you need the in-pod `clickhouse-client` to authenticate
-  as `default` automatically: the operator writes the value into the client
-  configuration (`/etc/clickhouse-client/config.yaml`) **only for the plaintext
-  `password` type**. With a hashed type the server still authenticates the `default`
-  user normally, but `clickhouse-client` run inside the pod is not pre-filled with
-  the password (a hash cannot be used as a client-side password). This does not
-  affect the operator itself, which manages the cluster as a separate `operator` user.
 
 #### Full example with a Secret {#default-password-secret-example}
 
@@ -747,6 +736,11 @@ spec:
         key: password
 ```
 
+<Note>
+With `passwordType: password`, the in-pod `clickhouse-client` is configured with
+this password, which is handy for debugging.
+</Note>
+
 For a hashed password, store the hash instead of the plaintext:
 
 ```bash
@@ -767,10 +761,9 @@ spec:
 
 #### Using a ConfigMap {#using-configmap-for-user-passwords}
 
-A ConfigMap works the same way but stores its value in plaintext on the API server,
-so use it **only for non-sensitive or already-hashed values**, for example a
-`password_sha256_hex` digest, which does not contain the plaintext password
-(though a weak password may still be recoverable from the hash by brute force):
+A ConfigMap works the same way, but its contents are not protected like a Secret.
+Use it only for non-sensitive or already-hashed values, such as a
+`password_sha256_hex` digest:
 
 ```yaml
 spec:
@@ -783,8 +776,8 @@ spec:
 ```
 
 <Note>
-Do not put a plaintext password in a ConfigMap. ConfigMap data is not protected
-like Secret data. Use a Secret for any plaintext (`passwordType: password`) value.
+Do not put a plaintext password in a ConfigMap. Use a Secret for any plaintext
+(`passwordType: password`) value.
 </Note>
 
 ### Custom users in configuration {#custom-users-in-configuration}

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -688,7 +688,7 @@ Set `--disable-version-update-checks=true` in air-gapped environments or when eg
 ### Default user password {#default-user-password}
 
 `spec.settings.defaultUserPassword` sets the password for the built-in `default`
-user. The value is not stored inline — it is read from a key in a Secret or a
+user. The value is not stored inline; it is read from a key in a Secret or a
 ConfigMap that you create, and injected into the pod as an environment variable.
 
 ```yaml
@@ -698,31 +698,31 @@ spec:
       passwordType: password   # default; see "Password types" below
       secret:                  # exactly one of secret OR configMap
         name: clickhouse-password   # name of the Secret/ConfigMap
-        key: password               # the KEY inside it — not the password value
+        key: password               # the KEY inside it, not the password value
 ```
 
 You must specify **exactly one** of `secret` or `configMap` (setting both, or
 neither, is rejected by the validating webhook), and both `name` and `key` are
 required. `name` is the Secret/ConfigMap object, `key` is the entry within it whose
-value holds the password — the password itself is never written in the CR.
+value holds the password. The password itself is never written in the CR.
 
 #### Password types {#password-types}
 
 `passwordType` tells ClickHouse how to interpret the value. It defaults to
 `password` (plaintext). The common alternatives are hashed forms such as
-`password_sha256_hex` and `password_double_sha1_hex` — see the
+`password_sha256_hex` and `password_double_sha1_hex`. See the
 [ClickHouse user settings](https://clickhouse.com/docs/operations/settings/settings-users#user-namepassword)
 for the full list.
 
 - Use `password_sha256_hex` (or another hashed type) so the plaintext never has to
-  exist in the cluster — store only the hash.
+  exist in the cluster; store only the hash.
 - Use `password` only when you need the in-pod `clickhouse-client` to authenticate
   as `default` automatically: the operator writes the value into the client
   configuration (`/etc/clickhouse-client/config.yaml`) **only for the plaintext
   `password` type**. With a hashed type the server still authenticates the `default`
   user normally, but `clickhouse-client` run inside the pod is not pre-filled with
   the password (a hash cannot be used as a client-side password). This does not
-  affect the operator itself — it manages the cluster as a separate `operator` user.
+  affect the operator itself, which manages the cluster as a separate `operator` user.
 
 #### Full example with a Secret {#default-password-secret-example}
 
@@ -768,7 +768,7 @@ spec:
 #### Using a ConfigMap {#using-configmap-for-user-passwords}
 
 A ConfigMap works the same way but stores its value in plaintext on the API server,
-so use it **only for non-sensitive or already-hashed values** — for example a
+so use it **only for non-sensitive or already-hashed values**, for example a
 `password_sha256_hex` digest, which does not contain the plaintext password
 (though a weak password may still be recoverable from the hash by brute force):
 
@@ -783,7 +783,7 @@ spec:
 ```
 
 <Note>
-Do not put a plaintext password in a ConfigMap — ConfigMap data is not protected
+Do not put a plaintext password in a ConfigMap. ConfigMap data is not protected
 like Secret data. Use a Secret for any plaintext (`passwordType: password`) value.
 </Note>
 


### PR DESCRIPTION
## Why

The Default user password section in the Configuration guide showed a Secret/ConfigMap skeleton but used a misleading key: <password> placeholder, which could make readers think key is the password value rather than the key name inside the resource. It also omitted practical guidance for using spec.settings.defaultUserPassword, including the exactly-one-source rule, password type choices, and the security difference between Secret and ConfigMap.

## What

Rewrites the Default user password section to clarify that the password is read from a key in a Secret or ConfigMap and is never stored inline in the CR. The update documents that exactly one of secret or configMap is required, with both name and key; adds guidance for password versus password_sha256_hex, including the operator client configuration behavior; and adds full Secret + CR examples for plaintext and hashed passwords, plus ConfigMap guidance for non-sensitive values and a warning not to store plaintext passwords there. Verified against DefaultPasswordSelector.Validate(), templates.go, and config.go.