### PR TITLE
ci: fix paths-filter so docs-only changes actually skip CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,11 +24,15 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'
               - '!**/*.md'
               - '!**/*.mdx'
+              - '!docs/**'
+              - '!examples/**'
+              - '!LICENSE'
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The `changes` path-filter never skipped anything. It used `dorny/paths-filter`'s **default** `predicate-quantifier` ("at least one pattern matches"), so every changed file matched `**` and `code` was always `true` — the `!**/*.md` / `!**/*.mdx` negations were dead.
- Add `predicate-quantifier: 'every'` so a file counts as `code` only when it matches **all** patterns (any-file AND not-`.md` AND not-`.mdx` …).
- Extend the ignore list to the whole `docs/**` tree, `examples/**`, and `LICENSE`.

## Why
PR #238 changed only `docs/guides/configuration.mdx` yet ran the full build / unit / fuzz / helm / compat-e2e / e2e suite. The `changes` job log shows:

```
[modified] docs/guides/configuration.mdx
Filter code = true
Matching files: docs/guides/configuration.mdx
```

Docs are fully validated by `docs-lint.yaml` (Vale, linkspector, **API Reference Generated**); `ci.yaml` validates none of `docs/**`, so excluding it is safe. `examples/**` is not referenced by any Go test or Makefile target.

## Test plan
- [ ] This PR touches `.github/workflows/ci.yaml` → `code=true`, full suite runs (validates code path still works).
- [ ] After merge, a docs-only PR (e.g. re-run #238) → `code=false`, gated jobs skip, `All CI checks passed` still reports green.