### PR TITLE
chores: update dependencies, actions, linter config, generate helm chart with latest kubebuilder

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches: [ main ]
 env:
-  kind-version: 'v0.31.0'
+  kind-version: 'v0.32.0'
 permissions:
   contents: read
   statuses: write
@@ -19,9 +19,9 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Detect non-docs changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           predicate-quantifier: 'every'
@@ -40,7 +40,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
       VERSION: 0.0.1
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -140,7 +140,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -176,7 +176,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -195,7 +195,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -233,7 +233,7 @@ jobs:
             clickhouse_version: "26.5"
             deploy_target: test-compat-e2e
           - name: maximal-k8s-all-deploy-methods
-            k8s_image: v1.35.1
+            k8s_image: v1.36.1
             clickhouse_version: "26.5"
             deploy_target: test-compat-e2e
           - name: olm-deploy-method
@@ -250,12 +250,12 @@ jobs:
             deploy_target: test-compat-e2e-upgrade
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-tags: 'true'
 
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.0
+        uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -291,7 +291,7 @@ jobs:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse_version }}
 
       - name: Upload test report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: e2e-report-${{ matrix.name }}
@@ -309,7 +309,7 @@ jobs:
     runs-on: [self-hosted, amd-medium]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -334,7 +334,7 @@ jobs:
         run:  make test-e2e
 
       - name: Upload test report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: e2e-report-shard-${{ matrix.shard }}
@@ -348,7 +348,7 @@ jobs:
     if: ${{ !cancelled() && needs.changes.outputs.code == 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download all e2e test reports
         uses: actions/download-artifact@v8
@@ -391,7 +391,7 @@ jobs:
       OPENSHIFT_CHANNEL: stable-v0
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -16,7 +16,7 @@ jobs:
     name: vale-linter
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: errata-ai/vale-action@v2.1.1
         with:
           fail_on_error: 'true'
@@ -26,8 +26,8 @@ jobs:
     name: Doc links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -46,7 +46,7 @@ jobs:
     name: API Reference Generated
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-tags: true
           fetch-depth: '0'
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.0
+        uses: jlumbroso/free-disk-space@v1.3.1
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.0
+        uses: jlumbroso/free-disk-space@v1.3.1
       - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
@@ -39,9 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.0
+        uses: jlumbroso/free-disk-space@v1.3.1
       - name: Log in to the Container registry
         uses: docker/login-action@v4
         with:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Helm
         run: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
       - name: Verify Helm installation
@@ -89,7 +89,7 @@ jobs:
       - release-operator-helm-chart
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -127,7 +127,7 @@ jobs:
 
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v6.2
+        uses: mikepenz/release-changelog-builder-action@v6.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -152,7 +152,7 @@ jobs:
                 }]
             }
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{github.ref_name }}
@@ -201,9 +201,9 @@ jobs:
     needs: create-release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Multi-repo workflow authentication
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: generate-token
         with:
           app-id: ${{ secrets.WORKFLOW_AUTH_PUBLIC_APP_ID }}
@@ -221,7 +221,7 @@ jobs:
       - name: Generate operator bundle
         run: make bundle
       - name: Checkout community-operators fork
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.repository_owner }}/community-operators
           token: ${{ steps.generate-token.outputs.token }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,10 @@ linters:
     - errname
     - errorlint
     - nilerr
+    - nilnesserr
+    - asasalint
+    - canonicalheader
+    - goprintffuncname
     - gocritic
     - bodyclose
     - clickhouselint
@@ -67,20 +71,16 @@ linters:
     - mirror
     - mnd
     - musttag
-    - nakedret
     - noctx
     - nosprintfhostport
     - perfsprint
-    - predeclared
     - promlinter
-    - reassign
     - recvcheck
     - rowserrcheck
     - sloglint
     - sqlclosecheck
     - tagalign
     - unqueryvet
-    - unused
     - usetesting
     - whitespace
     - wrapcheck

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,11 @@ endif
 # Set the Operator SDK version to use. By default, what is installed on the system is used.
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.42.2
-OPERATOR_MANAGER_VERSION ?= v1.68.0
+OPERATOR_MANAGER_VERSION ?= v1.72.0
 # Image URL to use all building/pushing image targets
 IMG ?= ${IMAGE_TAG_BASE}:${FULL_VERSION}
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION ?= 1.35.0
+ENVTEST_K8S_VERSION ?= 1.36.0
 
 # HELM_IMG defines the image used for the helm chart oci-based repo.
 HELM_IMG ?= $(IMAGE_REPO)/clickhouse-operator-helm
@@ -396,8 +396,8 @@ KUSTOMIZE_VERSION ?= v5.8.1
 CONTROLLER_TOOLS_VERSION ?= v0.21.0
 ENVTEST_VERSION ?= release-0.24
 GOLANGCI_LINT_VERSION ?= v2.12.2
-GINKGO_VERSION ?= v2.29.0
-KUBEBUILDER_VERSION ?= v4.14.0
+GINKGO_VERSION ?= v2.31.0
+KUBEBUILDER_VERSION ?= v4.15.0
 CODESPELL_VERSION ?= 2.4.2
 CRD_SCHEMA_CHECKER_VERSION ?= latest
 CRD_REF_DOCS_VERSION ?= v0.3.0

--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -63,12 +63,12 @@ Cribbed from the cert-manager organization.
 
 {{/*
 ServiceAccount name to use.
-If serviceAccount.enable is explicitly false and serviceAccount.name is set,
+If serviceAccount.enabled is explicitly false and serviceAccount.name is set,
 use that name. Otherwise, use the standard resourceName helper with
 "controller-manager" suffix.
 */}}
 {{- define "clickhouse-operator.serviceAccountName" -}}
-{{- if and (hasKey .Values.serviceAccount "enable") (not .Values.serviceAccount.enable) .Values.serviceAccount.name }}
+{{- if and (hasKey .Values.serviceAccount "enabled") (not .Values.serviceAccount.enabled) .Values.serviceAccount.name }}
 {{- .Values.serviceAccount.name }}
 {{- else }}
 {{- include "clickhouse-operator.resourceName" (dict "suffix" "controller-manager" "context" .) }}

--- a/dist/chart/templates/cert-manager/metrics-certs.yaml
+++ b/dist/chart/templates/cert-manager/metrics-certs.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.enable .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.certManager.enabled .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
+++ b/dist/chart/templates/cert-manager/selfsigned-issuer.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.enable (not .Values.certManager.issuerRef) }}
+{{- if and .Values.certManager.enabled (not .Values.certManager.issuerRef) }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.certManager.enable .Values.webhook.enable }}
+{{- if and .Values.certManager.enabled .Values.webhook.enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.enable }}
+{{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/dist/chart/templates/crd/keeperclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/keeperclusters.clickhouse.com.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.crd.enable }}
+{{- if .Values.crd.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -82,7 +82,7 @@ spec:
         command:
         - /manager
         args:
-        {{- if .Values.metrics.enable }}
+        {{- if .Values.metrics.enabled }}
         - --metrics-bind-address=:{{ .Values.metrics.port }}
         {{- if not .Values.metrics.secure }}
         - --metrics-secure=false
@@ -95,17 +95,17 @@ spec:
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
-        {{- if and .Values.certManager.enable .Values.webhook.enable }}
+        {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
-        {{- if and .Values.metrics.enable .Values.metrics.secure }}
+        {{- if and .Values.metrics.enabled .Values.metrics.secure }}
         - --metrics-cert-path=/tmp/k8s-metrics-server/metrics-certs
         {{- end }}
         {{- end }}
         env:
         - name: ENABLE_WEBHOOKS
-          value: {{ .Values.webhook.enable | quote }}
+          value: {{ .Values.webhook.enabled | quote }}
         - name: ENABLE_PDB
-          value: {{ .Values.controller.pdbManagement.enable | quote }}
+          value: {{ .Values.controller.pdbManagement.enabled | quote }}
         {{- if not (empty .Values.controller.watchNamespaces) }}
         - name: WATCH_NAMESPACE
           value: {{ join "," .Values.controller.watchNamespaces | quote }}
@@ -134,12 +134,12 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         ports:
-        {{- if .Values.webhook.enable }}
+        {{- if .Values.webhook.enabled }}
         - containerPort: {{ .Values.webhook.port }}
           name: webhook-server
           protocol: TCP
         {{- end }}
-        {{- if .Values.metrics.enable }}
+        {{- if .Values.metrics.enabled }}
         - containerPort: {{ .Values.metrics.port }}
           name: metrics-server
           protocol: TCP
@@ -156,16 +156,16 @@ spec:
           {{- else }}
           {}
           {{- end }}
-        {{- if or .Values.manager.extraVolumeMounts .Values.certManager.enable }}
+        {{- if or .Values.manager.extraVolumeMounts .Values.certManager.enabled }}
         volumeMounts:
         {{- with .Values.manager.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if and .Values.certManager.enable .Values.webhook.enable }}
+        {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: webhook-certs
           readOnly: true
-        {{- if and .Values.metrics.enable .Values.metrics.secure }}
+        {{- if and .Values.metrics.enabled .Values.metrics.secure }}
         - mountPath: /tmp/k8s-metrics-server/metrics-certs
           name: metrics-certs
           readOnly: true
@@ -182,16 +182,16 @@ spec:
       {{- if and (hasKey .Values.manager "terminationGracePeriodSeconds") (ne .Values.manager.terminationGracePeriodSeconds nil) }}
       terminationGracePeriodSeconds: {{ .Values.manager.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if or .Values.manager.extraVolumes .Values.certManager.enable }}
+      {{- if or .Values.manager.extraVolumes .Values.certManager.enabled }}
       volumes:
       {{- with .Values.manager.extraVolumes }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- if and .Values.certManager.enable .Values.webhook.enable }}
+      {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
       - name: webhook-certs
         secret:
           secretName: webhook-server-cert
-      {{- if and .Values.metrics.enable .Values.metrics.secure }}
+      {{- if and .Values.metrics.enabled .Values.metrics.secure }}
       - name: metrics-certs
         secret:
           secretName: metrics-server-cert

--- a/dist/chart/templates/metrics/metrics-service.yaml
+++ b/dist/chart/templates/metrics/metrics-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.enable }}
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
+++ b/dist/chart/templates/network-policy/allow-metrics-traffic.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
+  name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "allow-metrics-traffic" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            metrics: enabled
+      ports:
+        - port: {{ .Values.metrics.port }}
+          protocol: TCP
+{{- end }}

--- a/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
+++ b/dist/chart/templates/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.networkPolicy.enabled .Values.webhook.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
+  name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "allow-webhook-traffic" "context" $) }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled
+      ports:
+        - port: {{ .Values.webhook.port }}
+          protocol: TCP
+{{- end }}

--- a/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
+++ b/dist/chart/templates/prometheus/controller-manager-metrics-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.prometheus.enable }}
+{{- if .Values.prometheus.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -21,7 +21,7 @@ spec:
     {{- if .Values.metrics.secure }}
     tlsConfig:
       serverName: {{ include "clickhouse-operator.resourceName" (dict "suffix" "metrics-service" "context" $) }}.{{ .Release.Namespace }}.svc
-      {{- if .Values.certManager.enable }}
+      {{- if .Values.certManager.enabled }}
       ca:
         secret:
           key: ca.crt

--- a/dist/chart/templates/rbac/clickhousecluster-admin-role.yaml
+++ b/dist/chart/templates/rbac/clickhousecluster-admin-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/dist/chart/templates/rbac/clickhousecluster-editor-role.yaml
+++ b/dist/chart/templates/rbac/clickhousecluster-editor-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/dist/chart/templates/rbac/clickhousecluster-viewer-role.yaml
+++ b/dist/chart/templates/rbac/clickhousecluster-viewer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/dist/chart/templates/rbac/controller-manager.yaml
+++ b/dist/chart/templates/rbac/controller-manager.yaml
@@ -1,4 +1,4 @@
-{{- if ne .Values.serviceAccount.enable false }}
+{{- if ne .Values.serviceAccount.enabled false }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/dist/chart/templates/rbac/keepercluster-admin-role.yaml
+++ b/dist/chart/templates/rbac/keepercluster-admin-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/dist/chart/templates/rbac/keepercluster-editor-role.yaml
+++ b/dist/chart/templates/rbac/keepercluster-editor-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/dist/chart/templates/rbac/keepercluster-viewer-role.yaml
+++ b/dist/chart/templates/rbac/keepercluster-viewer-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.helpers.enable }}
+{{- if .Values.rbac.helpers.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- if .Values.rbac.namespaced }}
 kind: Role

--- a/dist/chart/templates/rbac/metrics-auth-role.yaml
+++ b/dist/chart/templates/rbac/metrics-auth-role.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
+++ b/dist/chart/templates/rbac/metrics-auth-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/dist/chart/templates/rbac/metrics-reader.yaml
+++ b/dist/chart/templates/rbac/metrics-reader.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enable .Values.metrics.secure }}
+{{- if and .Values.metrics.enabled .Values.metrics.secure }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
+++ b/dist/chart/templates/webhook/mutating-webhook-configuration.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    {{- if .Values.certManager.enable }}
+    {{- if .Values.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "clickhouse-operator.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}
   name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "mutating-webhook-configuration" "context" $) }}

--- a/dist/chart/templates/webhook/validating-webhook-configuration.yaml
+++ b/dist/chart/templates/webhook/validating-webhook-configuration.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    {{- if .Values.certManager.enable }}
+    {{- if .Values.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "clickhouse-operator.resourceName" (dict "suffix" "serving-cert" "context" $) }}
     {{- end }}
   name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "validating-webhook-configuration" "context" $) }}

--- a/dist/chart/templates/webhook/webhook-service.yaml
+++ b/dist/chart/templates/webhook/webhook-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enable }}
+{{- if .Values.webhook.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -28,7 +28,7 @@ controller:
   ## Disable means operator will not call any PDB related API.
   ##
   pdbManagement:
-    enable: true
+    enabled: true
 
 
 ## Configure the controller manager deployment
@@ -176,16 +176,16 @@ rbac:
   helpers:
     ## Install convenience admin/editor/viewer roles for CRDs
     ##
-    enable: false
+    enabled: false
 
 ## ServiceAccount configuration
 ##
 serviceAccount:
   # Install default ServiceAccount provided
-  enable: true
+  enabled: true
 
-  ## Existing ServiceAccount name (only when enable=false)
-  ## Note: When enable=true, respects nameOverride/fullnameOverride
+  ## Existing ServiceAccount name (only when enabled=false)
+  ## Note: When enabled=true, respects nameOverride/fullnameOverride
   ##
   # name: ""
 
@@ -201,7 +201,7 @@ serviceAccount:
 ##
 crd:
   # Install CRDs with the chart
-  enable: true
+  enabled: true
   # Keep CRDs when uninstalling
   keep: true
 
@@ -209,7 +209,7 @@ crd:
 ## Enable to expose /metrics endpoint
 ##
 metrics:
-  enable: true
+  enabled: true
   # Metrics server port
   port: 8080
   # Enable secure metrics: HTTPS with certs/auth (true) or HTTP (false).
@@ -220,7 +220,7 @@ metrics:
 ## Required for webhook certificates and metrics endpoint certificates.
 ##
 certManager:
-    enable: true
+    enabled: true
     ## Custom issuer configuration for cert-manager issued certificates.
     ##
     # issuerRef:
@@ -230,7 +230,7 @@ certManager:
 ## Webhook server configuration
 ##
 webhook:
-  enable: true
+  enabled: true
   # Webhook server port
   port: 9443
 
@@ -242,8 +242,13 @@ prometheus:
   scraping_annotations: false
   # Enable Prometheus ServiceMonitor for metrics scraping.
   # Requires prometheus-operator to be installed in the cluster.
-  enable: false
+  enabled: false
 
+
+## Kubernetes NetworkPolicies restricting ingress to the metrics and webhook ports.
+##
+networkPolicy:
+  enabled: false
 
 # Extra manifests to deploy as an array
 extraManifests: []

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ClickHouse/clickhouse-operator
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.46.0
@@ -14,8 +14,8 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/moby/moby/api v1.54.2
-	github.com/onsi/ginkgo/v2 v2.29.0
-	github.com/onsi/gomega v1.41.0
+	github.com/onsi/ginkgo/v2 v2.31.0
+	github.com/onsi/gomega v1.42.0
 	github.com/sethvargo/go-envconfig v1.3.0
 	github.com/testcontainers/testcontainers-go v0.42.0
 	go.uber.org/zap v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -200,10 +200,10 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.29.0 h1:rfh+ZFjgJhYWRoIqVf3Uwx/W20yLrcrE2h2GmYVRaag=
-github.com/onsi/ginkgo/v2 v2.29.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
-github.com/onsi/gomega v1.41.0 h1:OwKp4pXNgVxf6sCplzYo794OFNuoL2q2SBMU5NSWOjA=
-github.com/onsi/gomega v1.41.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/onsi/ginkgo/v2 v2.31.0 h1:GtuJos5DFUV9EerYJo8RhYxosYNGvOdDE5haKq6Grfs=
+github.com/onsi/ginkgo/v2 v2.31.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
+github.com/onsi/gomega v1.42.0 h1:CJby8u36xb7v34W78F8WKvqTQP7PCMIPB78IVDB73l4=
+github.com/onsi/gomega v1.42.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=


### PR DESCRIPTION
## Why

Regular dependency/tools upgrade.

## What

- Update go deps
- Update actions
- Update kubebuilder and generate a Helm chart with a newer version.
- New helm plugin uses a consistent naming `enable` -> `enabled`
- New helm plugin generates metrics/webhook network policies

