### PR TITLE
ci: bypass v1 registries.conf in opm catalog render

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -598,7 +598,7 @@ catalog-template: # Generate catalog template with all bundles from registry
 
 .PHONY: catalog-render
 catalog-render: opm catalog-template ## Generate FBC catalog from template
-	$(OPM) alpha render-template catalog/clickhouse-operator-template.yaml > catalog/catalog.yaml
+	CONTAINERS_REGISTRIES_CONF=/dev/null $(OPM) alpha render-template catalog/clickhouse-operator-template.yaml > catalog/catalog.yaml
 	$(OPM) validate catalog
 
 .PHONY: catalog-build


### PR DESCRIPTION
## Summary
- `release-main` catalog build broke on the latest push to main ([run 27828751663](https://github.com/ClickHouse/clickhouse-operator/actions/runs/27828751663/job/82359818542)).
- #240 bumped `OPERATOR_MANAGER_VERSION` v1.68.0 → v1.72.0. opm v1.72.0 ships a newer `containers/image` that **dropped v1→v2 auto-conversion** of `registries.conf` and hard-errors on the `ubuntu-latest` runner's v1-format `/etc/containers/registries.conf`:
  ```
  Error: rendering template: ... loading registries configuration "/etc/containers/registries.conf": registries.conf must be in v2 format but is in v1
  ```
- Only `opm alpha render-template` is affected (the sole step pulling bundle images); `opm validate` operates on the local FBC dir.
- Fix in `catalog-render` so it also covers `release.yaml` stable releases and local runs: point `CONTAINERS_REGISTRIES_CONF` at `/dev/null` so the lib uses built-in defaults. Fully-qualified `ghcr.io/...` pulls need no registries config.

## Test plan
- [ ] `release-main` catalog build is green after merge to main.