### PR TITLE
ci: add Dependabot config for scheduled version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    # Include indirect/transitive modules, not just direct ones.
+    allow:
+      - dependency-type: "all"
+    # Group minor/patch bumps into one PR; majors stay individual.
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chores"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chores"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` enabling scheduled **version updates** for `gomod`, `github-actions`, and `docker`. Complements the security updates already enabled on the repo.

For `gomod`, Dependabot updates only **direct** deps by default — `allow: dependency-type: all` opts into **indirect/transitive** modules as well. Minor/patch bumps are grouped into one PR; majors arrive individually. Commit prefixes follow repo convention (`chores:` / `ci:`).

## Test plan

- [ ] Dependabot validates the config (Insights → Dependency graph → Dependabot)
- [ ] First scheduled run opens a grouped `gomod` version-update PR
