### PR TITLE
fix: don't drop a non-empty Atomic default database during Replicated conversion

### DIFF
--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -514,8 +514,12 @@ func (cmd *commander) ensureReplicaDefaultDatabaseEngine(ctx context.Context, lo
 			return fmt.Errorf("check tables in  %s: %w", id, err)
 		}
 
+		// Never drop a populated `default`: converting it to Replicated would
+		// destroy existing tables. Leave it as-is so the data is preserved; the
+		// engine is only switched on an empty `default` below.
 		if count > 0 {
-			log.Warn("database `default` has tables, but its engine is not Replicated, data loss is possible")
+			log.Warn("database `default` has tables, but its engine is not Replicated; leaving it as-is to avoid data loss (skipping Replicated conversion)")
+			return nil
 		}
 
 		log.Debug("dropping default database")

--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -515,11 +515,12 @@ func (cmd *commander) ensureReplicaDefaultDatabaseEngine(ctx context.Context, lo
 		}
 
 		// Never drop a populated `default`: converting it to Replicated would
-		// destroy existing tables. Leave it as-is so the data is preserved; the
-		// engine is only switched on an empty `default` below.
+		// destroy existing tables. Leave it as-is and surface the problem as an
+		// error so the operator reports SchemaInSync=false; the engine is only
+		// switched on an empty `default` below.
 		if count > 0 {
-			log.Warn("database `default` has tables, but its engine is not Replicated; leaving it as-is to avoid data loss (skipping Replicated conversion)")
-			return nil
+			log.Warn("database `default` has tables, but its engine is not Replicated; refusing to drop it to avoid data loss")
+			return fmt.Errorf("refusing to recreate non-empty `default` database as Replicated on replica %s: it has %d table(s), dropping it would lose data", id, count)
 		}
 
 		log.Debug("dropping default database")

--- a/internal/controller/clickhouse/commands_test.go
+++ b/internal/controller/clickhouse/commands_test.go
@@ -245,6 +245,35 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 		}
 	})
 
+	It("preserves a non-empty Atomic default instead of dropping it", func(ctx context.Context) {
+		id0 := v1.ClickHouseReplicaID{ShardID: 0, Index: 0}
+
+		By("seeding a table into the Atomic default database")
+
+		conn, err := cmd.getConn(id0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conn.Exec(ctx, `CREATE TABLE default.seed (id UInt64) ENGINE=MergeTree ORDER BY id`)).To(Succeed())
+		Expect(conn.Exec(ctx, `INSERT INTO default.seed SELECT number FROM numbers(10)`)).To(Succeed())
+
+		By("running EnsureDefaultDatabaseEngine")
+
+		Expect(cmd.EnsureDefaultDatabaseEngine(ctx, cmd.log, slices.Collect(cmd.cluster.ReplicaIDs()))).To(BeTrue())
+
+		By("verifying default database is still Atomic and the seeded table survived")
+
+		var engine string
+		Expect(conn.QueryRow(ctx, `SELECT engine FROM system.databases WHERE name='default'`).Scan(&engine)).To(Succeed())
+		Expect(engine).To(Equal("Atomic"))
+
+		var count uint64
+		Expect(conn.QueryRow(ctx, `SELECT count() FROM default.seed`).Scan(&count)).To(Succeed())
+		Expect(count).To(Equal(uint64(10)))
+
+		By("dropping the seed table so the default database is empty again")
+
+		Expect(conn.Exec(ctx, `DROP TABLE default.seed SYNC`)).To(Succeed())
+	})
+
 	It("converts default database from Atomic to Replicated", func(ctx context.Context) {
 		By("running EnsureDefaultDatabaseEngine")
 

--- a/internal/controller/clickhouse/commands_test.go
+++ b/internal/controller/clickhouse/commands_test.go
@@ -257,7 +257,9 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 
 		By("running EnsureDefaultDatabaseEngine")
 
-		Expect(cmd.EnsureDefaultDatabaseEngine(ctx, cmd.log, slices.Collect(cmd.cluster.ReplicaIDs()))).To(BeTrue())
+		// A non-empty Atomic `default` must not be dropped; the operator should
+		// report failure (SchemaInSync=false) rather than destroy data.
+		Expect(cmd.EnsureDefaultDatabaseEngine(ctx, cmd.log, slices.Collect(cmd.cluster.ReplicaIDs()))).To(BeFalse())
 
 		By("verifying default database is still Atomic and the seeded table survived")
 


### PR DESCRIPTION
## Summary

`ensureReplicaDefaultDatabaseEngine` converts the `default` database from Atomic to Replicated when `enableDatabaseSync` is enabled. When `default` already existed with a non-Replicated engine **and contained tables**, the `count > 0` branch logged `"data loss is possible"` but then **fell through and ran `DROP DATABASE default SYNC` anyway**, destroying those tables before recreating `default` as Replicated.

This makes the code match its documented intent — *"It never drops tables or recreates the default database as Replicated if any tables have been created"* — by **refusing to convert** when `default` is non-empty and not Replicated, and returning an error so the operator reports the problem.

## The race this fixes

On a fresh cluster, `default` starts as **Atomic and empty**. The operator only converts it to Replicated on a reconcile pass *after* the replica is `Ready` (`reconcileDatabaseSync` operates on `readyReplicas`). Any client that connects and seeds `default` in that window — e.g. an OTel collector that auto-creates tables on first export — creates tables in the still-Atomic `default`. If that seed lands before the operator's first conversion pass, the operator finds a non-empty Atomic `default`, warns, and **drops it**. The seeded schema never comes back; downstream consumers loop on `Table default.<x> does not exist`.

This was hit in the ClickStack helm-charts on the `clickhouse-operator-helm` v0.0.6 bump (single-replica deployment): all `otel_*` tables were dropped on first boot. Ref: ClickHouse/ClickStack-helm-charts#240.

## Behavior change

| `default` state | Before | After |
|---|---|---|
| does not exist | create Replicated | create Replicated (unchanged) |
| already `Replicated` | no-op | no-op (unchanged) |
| Atomic, **empty** | drop + recreate Replicated | drop + recreate Replicated (unchanged) |
| Atomic, **non-empty** | warn, then **DROP** + recreate Replicated (**data loss**) | **leave intact, return error** (operator sets `SchemaInSync=false`) |

Fresh/empty clusters still get the Replicated engine automatically; only a populated `default` is now preserved.

## Why return an error (not skip)

When `default` is non-empty and not Replicated, the operator cannot perform the requested conversion without losing data. Returning an error propagates through `EnsureDefaultDatabaseEngine` so the operator sets `ClickHouseConditionTypeSchemaInSync = false`, surfacing the unconvertible database rather than silently leaving the cluster in a state that does not match the requested topology. The database itself is never dropped. (Per review feedback.)

## Test

Added an integration spec (`internal/controller/clickhouse/commands_test.go`): seed a table with rows into the Atomic `default`, run `EnsureDefaultDatabaseEngine`, and assert it reports failure (`false`) while the engine is still `Atomic` and the rows survived. The existing Atomic→Replicated conversion spec (empty `default`) continues to pass.

```
commander preserves a non-empty Atomic default instead of dropping it [integration]  status="passed"
commander converts default database from Atomic to Replicated [integration]          status="passed"
```

Full `commander` suite passes locally (testcontainers).

## Notes

- No CRD/API changes; `enableDatabaseSync` semantics are unchanged.
- This is a **data-loss bugfix**.