### PR TITLE
fix: compare Keeper replica versions numerically, not lexicographically

### DIFF
--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -670,7 +670,7 @@ func (r *keeperReconciler) evaluateVersionConditions(isUpdating bool) {
 		if s.Status.Version != "" {
 			versionByReplica[strconv.FormatInt(int64(id), 10)] = s.Status.Version
 
-			if observedVersion < s.Status.Version {
+			if observedVersion == "" || newerVersion(s.Status.Version, observedVersion) {
 				observedVersion = s.Status.Version
 			}
 		}
@@ -699,6 +699,17 @@ func (r *keeperReconciler) evaluateVersionConditions(isUpdating bool) {
 	} else {
 		meta.RemoveStatusCondition(r.Cluster.GetStatus().GetConditions(), v1.ConditionTypeVersionUpgraded)
 	}
+}
+
+func newerVersion(a, b string) bool {
+	parsedA, errA := upgrade.ParseBareVersion(a)
+	parsedB, errB := upgrade.ParseBareVersion(b)
+
+	if errA != nil || errB != nil {
+		return b < a
+	}
+
+	return upgrade.CompareVersions(parsedA, parsedB) > 0
 }
 
 func (r *keeperReconciler) updateReplica(ctx context.Context, log ctrlutil.Logger, replicaID v1.KeeperReplicaID) (*ctrl.Result, error) {

--- a/internal/controller/keeper/sync_test.go
+++ b/internal/controller/keeper/sync_test.go
@@ -198,6 +198,20 @@ var _ = Describe("Keeper version status", func() {
 		Expect(meta.FindStatusCondition(rec.Cluster.Status.Conditions, v1.ConditionTypeVersionUpgraded)).To(BeNil())
 	})
 
+	It("should report the numerically newest replica version across a .9 to .10 boundary", func() {
+		_, rec, cancelEvents := setupReconciler()
+		defer cancelEvents()
+
+		rec.ReplicaState = map[v1.KeeperReplicaID]replicaState{
+			0: {Status: serverStatus{Version: "25.9.1.100"}},
+			1: {Status: serverStatus{Version: "25.10.2.5"}},
+		}
+
+		rec.evaluateReplicaConditions()
+
+		Expect(rec.Cluster.Status.Version).To(Equal("25.10.2.5"))
+	})
+
 	It("should keep last known version when no live replica version is observed", func() {
 		_, rec, cancelEvents := setupReconciler()
 		defer cancelEvents()


### PR DESCRIPTION
## Why

`keeperReconciler.evaluateVersionConditions` picks the cluster's observed version by comparing the replicas' reported version strings with Go's `<` operator, which is lexicographic. Whenever a component crosses a digit-count boundary (e.g. `25.9` → `25.10`), the older version compares as "greater": `"25.9.1.100" > "25.10.2.5"`.

During a rolling upgrade across such a boundary this means:

- `KeeperCluster.Status.Version` keeps reporting the old version even after replicas have upgraded, and
- `GetVersionSyncCondition` uses the old version as the reference, so the `VersionInSync` condition flags the already-upgraded replicas as mismatched instead of the pending ones.

The impact is limited to status/condition reporting, but ClickHouse crosses a `.9 → .10` minor boundary every year, so any Keeper upgrade over that boundary hits it.

## What

Replaced the string comparison with a small `newerVersion` helper that reuses the existing `upgrade.ParseBareVersion`/`upgrade.CompareVersions` (already used for the same purpose elsewhere, e.g. in the upgrade checker and fetcher), falling back to the previous lexicographic behavior if a version doesn't parse.

Added a unit test in the existing `Keeper version status` spec that reproduces the bug with two replicas on `25.9.1.100` and `25.10.2.5`: before the fix `Status.Version` reports `25.9.1.100`, after the fix it correctly reports `25.10.2.5`.

The ClickHouse controller is not affected — it takes `Status.Version` from the version probe result directly rather than from a max over replica versions.

## Related Issues

None — found while reading the reconciler code.
