### PR TITLE
fix: default probe ports and probe-failure rollout gating

### DIFF
--- a/internal/controller/clickhouse/constants.go
+++ b/internal/controller/clickhouse/constants.go
@@ -13,11 +13,12 @@ import (
 )
 
 const (
-	PortManagement   = 9001
-	PortNative       = 9000
-	PortNativeSecure = 9440
-	PortHTTP         = 8123
-	PortHTTPSecure   = 8443
+	PortManagement     = 9001
+	PortManagementHTTP = 9002
+	PortNative         = 9000
+	PortNativeSecure   = 9440
+	PortHTTP           = 8123
+	PortHTTPSecure     = 8443
 
 	PortPrometheusScrape = 9363
 	PortInterserver      = 9009

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -59,7 +59,7 @@ func (r replicaState) UpdateStage(rev chctrl.RevisionState) chctrl.ReplicaUpdate
 		return chctrl.StageNotExists
 	}
 
-	if r.Error || r.ReloadError != nil {
+	if r.Error {
 		return chctrl.StageError
 	}
 
@@ -71,7 +71,8 @@ func (r replicaState) UpdateStage(rev chctrl.RevisionState) chctrl.ReplicaUpdate
 		return chctrl.StageHasDiff
 	}
 
-	if !r.Ready() || !r.Reloaded(rev.ReloadConfigRevision) {
+	// ReloadError is a retryable connectivity state, not a replica error:
+	if !r.Ready() || r.ReloadError != nil || !r.Reloaded(rev.ReloadConfigRevision) {
 		return chctrl.StageNotReadyUpToDate
 	}
 
@@ -479,9 +480,7 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 			probe, err = r.commander.Probe(ctx, id)
 			if err != nil {
 				log.Debug("failed to probe replica", "replica_id", id, "error", err)
-			}
-
-			if cfg, ok := configMaps[id]; ok && !probe.Reloaded(cfg.Annotations[ctrlutil.AnnotationReloadableConfigHash]) {
+			} else if cfg, ok := configMaps[id]; ok && !probe.Reloaded(cfg.Annotations[ctrlutil.AnnotationReloadableConfigHash]) {
 				if reloadErr = r.commander.ReloadConfig(ctx, id); reloadErr != nil {
 					log.Debug("replica config reload failed", "replica_id", id, "error", reloadErr)
 				} else if probe, err = r.commander.Probe(ctx, id); err != nil {

--- a/internal/controller/clickhouse/sync_test.go
+++ b/internal/controller/clickhouse/sync_test.go
@@ -1,0 +1,85 @@
+package clickhouse
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	chctrl "github.com/ClickHouse/clickhouse-operator/internal/controller"
+	ctrlutil "github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+var _ = Describe("UpdateStage", func() {
+	rev := chctrl.RevisionState{
+		StatefulSetRevision:   "sts-rev",
+		ConfigurationRevision: "cfg-rev",
+		RestartConfigRevision: "restart-rev",
+		ReloadConfigRevision:  "reload-rev",
+	}
+
+	settledReplica := func() replicaState {
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-0-0",
+				Generation: 1,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{ctrlutil.AnnotationConfigHash: rev.RestartConfigRevision},
+					},
+				},
+			},
+			Status: appsv1.StatefulSetStatus{
+				ObservedGeneration: 1,
+				ReadyReplicas:      1,
+				CurrentRevision:    "rev-1",
+				UpdateRevision:     "rev-1",
+			},
+		}
+		ctrlutil.AddSpecHashToObject(sts, rev.StatefulSetRevision)
+
+		cfg := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-0-0-configmap"}}
+		ctrlutil.AddObjectConfigHash(cfg, rev.ConfigurationRevision)
+
+		return replicaState{
+			replicaProbe: replicaProbe{
+				Version:                   "26.5.1.1",
+				ReloadConfigRevision:      rev.ReloadConfigRevision,
+				UsersReloadConfigRevision: rev.ReloadConfigRevision,
+			},
+			ReplicaState: chctrl.ReplicaState{STS: sts, CFG: cfg},
+		}
+	}
+
+	It("should report UpToDate for a settled healthy replica", func() {
+		Expect(settledReplica().UpdateStage(rev)).To(Equal(chctrl.StageUpToDate))
+	})
+
+	It("should treat a reload failure as NotReadyUpToDate, not Error", func() {
+		replica := settledReplica()
+		replica.ReloadError = errors.New("dial tcp: connect: connection refused")
+
+		Expect(replica.UpdateStage(rev)).To(Equal(chctrl.StageNotReadyUpToDate))
+	})
+
+	It("should keep a pending template change at HasDiff when the probe fails", func() {
+		replica := settledReplica()
+		replica.replicaProbe = replicaProbe{}
+		replica.ReloadError = errors.New("dial tcp: i/o timeout")
+		ctrlutil.AddSpecHashToObject(replica.STS, "next-sts-rev")
+
+		Expect(replica.UpdateStage(rev)).To(Equal(chctrl.StageHasDiff))
+	})
+
+	It("should report NotReadyUpToDate when the probe returned nothing", func() {
+		replica := settledReplica()
+		replica.replicaProbe = replicaProbe{}
+
+		Expect(replica.UpdateStage(rev)).To(Equal(chctrl.StageNotReadyUpToDate))
+	})
+})

--- a/internal/controller/clickhouse/templates.go
+++ b/internal/controller/clickhouse/templates.go
@@ -443,22 +443,22 @@ func templateContainer(r *clickhouseReconciler) (corev1.Container, error) {
 	cr := r.Cluster
 	protocols := buildProtocols(cr)
 
+	// Interserver listener opens before table loading, client listeners after:
+	// liveness survives slow synchronous loads, readiness implies serving queries.
 	livenessProbe := controller.DefaultLivenessProbeSettings
 	livenessProbe.ProbeHandler = corev1.ProbeHandler{
-		TCPSocket: &corev1.TCPSocketAction{
-			Port: intstr.FromInt32(PortNative),
+		HTTPGet: &corev1.HTTPGetAction{
+			Path:   "/ping",
+			Port:   intstr.FromInt32(PortInterserver),
+			Scheme: corev1.URISchemeHTTP,
 		},
-	}
-
-	if cr.Spec.Settings.TLS.Enabled && cr.Spec.Settings.TLS.Required {
-		livenessProbe.TCPSocket.Port.IntVal = PortNativeSecure
 	}
 
 	readinessProbe := controller.DefaultReadinessProbeSettings
 	readinessProbe.ProbeHandler = corev1.ProbeHandler{
 		HTTPGet: &corev1.HTTPGetAction{
 			Path:   "/ping",
-			Port:   intstr.FromInt32(PortInterserver),
+			Port:   intstr.FromInt32(PortManagementHTTP),
 			Scheme: corev1.URISchemeHTTP,
 		},
 	}
@@ -571,13 +571,14 @@ func templateContainer(r *clickhouseReconciler) (corev1.Container, error) {
 type protocolType = string
 
 const (
-	protocolTypeInterserver protocolType = "interserver"
-	protocolTypePrometheus  protocolType = "prometheus"
-	protocolTypeManagement  protocolType = "management"
-	protocolTypeTCP         protocolType = "tcp"
-	protocolTypeTCPSecure   protocolType = "tcp-secure"
-	protocolTypeHTTP        protocolType = "http"
-	protocolTypeHTTPSecure  protocolType = "http-secure"
+	protocolTypeInterserver    protocolType = "interserver"
+	protocolTypePrometheus     protocolType = "prometheus"
+	protocolTypeManagement     protocolType = "management"
+	protocolTypeManagementHTTP protocolType = "management-http"
+	protocolTypeTCP            protocolType = "tcp"
+	protocolTypeTCPSecure      protocolType = "tcp-secure"
+	protocolTypeHTTP           protocolType = "http"
+	protocolTypeHTTPSecure     protocolType = "http-secure"
 )
 
 type protocol struct {
@@ -603,6 +604,11 @@ func buildProtocols(cr *v1.ClickHouseCluster) map[protocolType]protocol {
 			Type:        protocolTypeTCP,
 			Port:        PortManagement,
 			Description: "tcp-management",
+		},
+		protocolTypeManagementHTTP: {
+			Type:        protocolTypeHTTP,
+			Port:        PortManagementHTTP,
+			Description: "http-management",
 		},
 		protocolTypeTCP: {
 			Type: protocolTypeTCP,


### PR DESCRIPTION
## Why

A probe or reload failure against a reachable replica no longer
escalates to StageError: the error branch updates replicas without
rollout serialization, so a transient dial failure against the healthy
peer mid-rollout could take down the last serving replica. Reload is
attempted only after a successful probe, and ReloadError now maps to
StageNotReadyUpToDate.

## What

Liveness now probes /ping on the interserver port, which opens before
table loading: a slow synchronous load (async_load_databases=false,
large table count) no longer gets the container killed after ~110s.

Readiness moves to /ping on a new always-on management-http composable
protocol (9002), which opens together with client listeners after table
loading: Ready now implies the server accepts queries, keeping Service
endpoints and the rolling-update gate truthful during slow startups.

## Related Issues

Related to #261
