### PR TITLE
fix: hide secrets from preprocessed config

### DIFF
--- a/internal/controller/clickhouse/config_test.go
+++ b/internal/controller/clickhouse/config_test.go
@@ -1,6 +1,8 @@
 package clickhouse
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
@@ -54,6 +56,39 @@ var _ = Describe("ConfigGenerator", func() {
 
 			obj := map[any]any{}
 			Expect(yaml.Unmarshal([]byte(data), &obj)).To(Succeed())
+			Expect(findExposedEnvVars(obj)).To(BeEmpty(), "env vars should be hidden in preprocessed config")
 		})
 	}
 })
+
+func findExposedEnvVars(value any) []string {
+	switch value := value.(type) {
+	case map[any]any:
+		if env, ok := value["@from_env"]; ok {
+			if _, ok := value["@hide_in_preprocessed"]; !ok {
+				return []string{fmt.Sprintf("%v", env)}
+			}
+		} else {
+			var exposed []string
+			for path, child := range value {
+				for _, e := range findExposedEnvVars(child) {
+					exposed = append(exposed, fmt.Sprintf("%v.%s", path, e))
+				}
+			}
+
+			return exposed
+		}
+
+	case []any:
+		var exposed []string
+		for i, child := range value {
+			for _, e := range findExposedEnvVars(child) {
+				exposed = append(exposed, fmt.Sprintf("%d.%s", i, e))
+			}
+		}
+
+		return exposed
+	}
+
+	return nil
+}

--- a/internal/controller/clickhouse/templates/cluster.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/cluster.yaml.tmpl
@@ -15,11 +15,13 @@ zookeeper:
     {{- end }}
   identity:
     "@from_env": {{ .KeeperIdentityEnv }}
+    "@hide_in_preprocessed": true
 
 remote_servers:
   default:
     secret:
       "@from_env": {{ .ClusterSecretEnv }}
+      "@hide_in_preprocessed": true
     shard:
     {{- $ctx := .}}
     {{- range $shard, $replicas := .ClusterHosts }}

--- a/internal/controller/clickhouse/templates/named_collections.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/named_collections.yaml.tmpl
@@ -2,5 +2,6 @@ named_collections_storage:
   type: keeper_encrypted
   key_hex:
     "@from_env": {{ .NamedCollectionsKeyEnv }}
+    "@hide_in_preprocessed": true
   algorithm: aes_128_ctr
   path: {{ .NamedCollectionsPath }}

--- a/internal/controller/clickhouse/templates/network.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/network.yaml.tmpl
@@ -9,6 +9,7 @@ interserver_http_credentials:
   user: {{ .InterserverHTTPUser }}
   password:
     - "@from_env": {{ .InterserverHTTPPasswordEnvVar }}
+      "@hide_in_preprocessed": true
   allow_empty: false
 
 {{- /* use default tcp_port as management to use it in distributed queries */}}

--- a/internal/controller/clickhouse/templates/users.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/users.yaml.tmpl
@@ -5,6 +5,7 @@ users:
     {{- if .DefaultUserPasswordEnv }}
     {{ .DefaultUserType }}:
       - '@from_env': {{ .DefaultUserPasswordEnv }}
+        '@hide_in_preprocessed': true
     {{ else }}
     no_password:
     {{ end}}
@@ -13,7 +14,9 @@ users:
   {{ .OperatorUserName }}:
     profile: {{ .OperatorProfileName }}
     quota: default
-    password_sha256_hex: {{ .OperatorUserPasswordHash }}
+    password_sha256_hex:
+      '@hide_in_preprocessed': true
+      '#text': {{ .OperatorUserPasswordHash }}
     grants: {{/* TODO restrict */}}
       - query: "GRANT ALL ON *.*"
 profiles:


### PR DESCRIPTION
## Why

Plaintext secrets get exposed on the data disk

## What

Require `@hide_in_preprocessed` to be set for all config cfg fields populated from env. 
