### PR TITLE
fix: use resourceName helper for webhook-server-cert secret name

### DIFF
--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: clickhouse-operator-helm
 type: application
-version: 0.1.0
+version: 0.0.1
 appVersion: "latest"
 kubeVersion: ">= 1.28.0-0"
 description: |

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: clickhouse-operator-helm
 type: application
-version: 0.0.1
+version: 0.1.0
 appVersion: "latest"
 kubeVersion: ">= 1.28.0-0"
 description: |

--- a/dist/chart/templates/cert-manager/serving-cert.yaml
+++ b/dist/chart/templates/cert-manager/serving-cert.yaml
@@ -20,5 +20,5 @@ spec:
     kind: Issuer
     name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "selfsigned-issuer" "context" $) }}
   {{- end }}
-  secretName: webhook-server-cert
+  secretName: {{ include "clickhouse-operator.resourceName" (dict "suffix" "webhook-server-cert" "context" $) }}
 {{- end }}

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -190,7 +190,7 @@ spec:
       {{- if and .Values.certManager.enabled .Values.webhook.enabled }}
       - name: webhook-certs
         secret:
-          secretName: webhook-server-cert
+          secretName: {{ include "clickhouse-operator.resourceName" (dict "suffix" "webhook-server-cert" "context" $) }}
       {{- if and .Values.metrics.enabled .Values.metrics.secure }}
       - name: metrics-certs
         secret:


### PR DESCRIPTION
## Summary

The `webhook-server-cert` secret name was hardcoded in the Helm chart, preventing multiple releases (or other operators with the same cert secret name which are also unconfigurable) in the same namespace from working correctly (name collision).

This change uses the existing `resourceName` helper (with suffix `webhook-server-cert`) so the secret name is scoped to the release, defaulting to `$RELEASE_NAME-webhook-server-cert`.

## Changes

- `dist/chart/templates/cert-manager/serving-cert.yaml`: Use `resourceName` helper for `secretName`
- `dist/chart/templates/manager/manager.yaml`: Use `resourceName` helper for the webhook-certs volume's `secretName`

## Verification

- `helm lint` passes
- `helm template` renders the secret name with release-name prefix correctly