### PR TITLE
fix: wrong defaulting of setting enableDatabaseSync to false

### DIFF
--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -197,7 +197,7 @@ type ClickHouseSettings struct {
 	// Supports only Replicated and integration databases.
 	// +optional
 	// +kubebuilder:default:=true
-	EnableDatabaseSync bool `json:"enableDatabaseSync,omitempty"`
+	EnableDatabaseSync *bool `json:"enableDatabaseSync,omitempty"`
 
 	// Additional ClickHouse configuration that will be merged with the default one.
 	// +nullable

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -229,6 +229,11 @@ func (in *ClickHouseSettings) DeepCopyInto(out *ClickHouseSettings) {
 		*out = new(EncryptionSettings)
 		**out = **in
 	}
+	if in.EnableDatabaseSync != nil {
+		in, out := &in.EnableDatabaseSync, &out.EnableDatabaseSync
+		*out = new(bool)
+		**out = **in
+	}
 	in.ExtraConfig.DeepCopyInto(&out.ExtraConfig)
 	in.ExtraUsersConfig.DeepCopyInto(&out.ExtraUsersConfig)
 }

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -763,7 +763,7 @@ func (r *clickhouseReconciler) reconcileReplicaResources(ctx context.Context, lo
 }
 
 func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	if !r.Cluster.Spec.Settings.EnableDatabaseSync {
+	if enabled := r.Cluster.Spec.Settings.EnableDatabaseSync; enabled != nil && !*enabled {
 		log.Debug("database sync is disabled, skipping")
 		r.SetCondition(metav1.Condition{
 			Type:    v1.ClickHouseConditionTypeSchemaInSync,


### PR DESCRIPTION
## Why

`omitempty` wipes the `false` value from JSON, and the API server sets the value to default=`true`

## What

Make it a pointer to distinguish a false and "not specified" case.