### PR TITLE
fix: probe job oom kill with transparent_hugepage=true

### DIFF
--- a/internal/controller/versionprobe.go
+++ b/internal/controller/versionprobe.go
@@ -271,7 +271,7 @@ func (rm *ResourceManager) buildVersionProbeJob(cfg VersionProbeConfig, revision
 							TerminationMessagePath:   corev1.TerminationMessagePathDefault,
 							Command:                  []string{versionProbeBinary},
 							Args:                     []string{"local", "--query", versionProbeQuery},
-							Env:                      []corev1.EnvVar{{Name: "MALLOC_CONF", Value: "narenas:2,dirty_decay_ms:0,muzzy_decay_ms:0"}},
+							Env:                      []corev1.EnvVar{{Name: "MALLOC_CONF", Value: "narenas:2,dirty_decay_ms:0,muzzy_decay_ms:0,thp:never"}},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse(DefaultProbeCPURequest),


### PR DESCRIPTION
## Why

transparent_hugepage=true leads to version probe job oom

## What

Set `thp:never` to reduce memory usage
