### PR TITLE
feat: add internal Services for interserver and operator traffic

### DIFF
--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -98,7 +98,7 @@ type ClickHouseClusterSpec struct {
 	// +optional
 	ExternalSecret *ExternalSecret `json:"externalSecret,omitempty"`
 
-	// AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the operator-managed headless Service.
+	// AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the public headless Service.
 	// The operator only adds the ports to the Kubernetes resources, it does not configure the ClickHouse server to listen on them.
 	// +listType=map
 	// +listMapKey=name
@@ -106,7 +106,7 @@ type ClickHouseClusterSpec struct {
 	AdditionalPorts []AdditionalPort `json:"additionalPorts,omitempty"`
 }
 
-// AdditionalPort declares one extra TCP port to expose on the ClickHouse Pod and the operator-managed headless Service.
+// AdditionalPort declares one extra TCP port to expose on the ClickHouse Pod and the public headless Service.
 type AdditionalPort struct {
 	// Name uniquely identifies the port within the list. Used as both the container port name and the Service port name.
 	// This must be a DNS_LABEL.
@@ -447,6 +447,11 @@ func (v *ClickHouseCluster) HeadlessServiceName() string {
 	return v.SpecificResourceName("headless")
 }
 
+// InternalServiceNameByReplicaID returns name of the internal headless Service for a replica.
+func (v *ClickHouseCluster) InternalServiceNameByReplicaID(id ClickHouseReplicaID) string {
+	return v.SpecificResourceName(fmt.Sprintf("internal-%d-%d", id.ShardID, id.Index))
+}
+
 // PodDisruptionBudgetNameByShard returns name of the PodDisruptionBudget for the specific shard.
 func (v *ClickHouseCluster) PodDisruptionBudgetNameByShard(shard int32) string {
 	return v.SpecificResourceName(strconv.FormatInt(int64(shard), 10))
@@ -480,6 +485,11 @@ func (v *ClickHouseCluster) KeeperClusterNamespacedName() types.NamespacedName {
 // HostnameByID returns domain name for the specific replica to access within Kubernetes cluster.
 func (v *ClickHouseCluster) HostnameByID(id ClickHouseReplicaID) string {
 	return formatPodHostname(v.StatefulSetNameByReplicaID(id), v.HeadlessServiceName(), v.Namespace, v.Spec.ClusterDomain)
+}
+
+// InternalHostnameByID returns the internal domain name for the specific replica.
+func (v *ClickHouseCluster) InternalHostnameByID(id ClickHouseReplicaID) string {
+	return formatServiceHostname(v.InternalServiceNameByReplicaID(id), v.Namespace, v.Spec.ClusterDomain)
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -494,6 +494,14 @@ func formatPodHostname(stsName, serviceName, namespace, domain string) string {
 	return fmt.Sprintf("%s-0.%s.%s.svc.%s", stsName, serviceName, namespace, domain)
 }
 
+func formatServiceHostname(serviceName, namespace, domain string) string {
+	if domain == "" {
+		domain = DefaultClusterDomain
+	}
+
+	return fmt.Sprintf("%s.%s.svc.%s", serviceName, namespace, domain)
+}
+
 // TemplateMeta defines supported metadata settings for template objects.
 type TemplateMeta struct {
 	// Labels are labels applied to the template objects.

--- a/api/v1alpha1/types_test.go
+++ b/api/v1alpha1/types_test.go
@@ -137,6 +137,33 @@ var _ = Describe("ClickHouseCluster", func() {
 		})
 	})
 
+	Describe("InternalHostnameByID", func() {
+		var cluster *ClickHouseCluster
+
+		BeforeEach(func() {
+			cluster = &ClickHouseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test-ns",
+				},
+				Spec: ClickHouseClusterSpec{},
+			}
+		})
+
+		It("should use the internal service with the default cluster domain", func() {
+			id := ClickHouseReplicaID{ShardID: 0, Index: 1}
+			hostname := cluster.InternalHostnameByID(id)
+			Expect(cluster.InternalServiceNameByReplicaID(id)).To(Equal("test-clickhouse-internal-0-1"))
+			Expect(hostname).To(Equal("test-clickhouse-internal-0-1.test-ns.svc." + testDefaultClusterDomain))
+		})
+
+		It("should use a custom cluster domain", func() {
+			cluster.Spec.ClusterDomain = "k8s.example.com"
+			hostname := cluster.InternalHostnameByID(ClickHouseReplicaID{ShardID: 1, Index: 2})
+			Expect(hostname).To(Equal("test-clickhouse-internal-1-2.test-ns.svc.k8s.example.com"))
+		})
+	})
+
 	Describe("SpecificResourceName", func() {
 		It("should add suffix", func() {
 			cluster := ClickHouseCluster{ObjectMeta: metav1.ObjectMeta{Name: "test"}}

--- a/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
+++ b/config/crd/bases/clickhouse.com_clickhouseclusters.yaml
@@ -68,11 +68,11 @@ spec:
             properties:
               additionalPorts:
                 description: |-
-                  AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the operator-managed headless Service.
+                  AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the public headless Service.
                   The operator only adds the ports to the Kubernetes resources, it does not configure the ClickHouse server to listen on them.
                 items:
                   description: AdditionalPort declares one extra TCP port to expose
-                    on the ClickHouse Pod and the operator-managed headless Service.
+                    on the ClickHouse Pod and the public headless Service.
                   properties:
                     name:
                       description: |-

--- a/dist/chart-cluster/values.yaml
+++ b/dist/chart-cluster/values.yaml
@@ -49,7 +49,7 @@ clickhouse:
   # ClickHouseCluster.spec — passed verbatim into the CR.
   spec:
 
-    # AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the operator-managed headless Service.
+    # AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the public headless Service.
     # The operator only adds the ports to the Kubernetes resources, it does not configure the ClickHouse server to listen on them.
     # additionalPorts: []
 

--- a/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
+++ b/dist/chart/templates/crd/clickhouseclusters.clickhouse.com.yaml
@@ -71,11 +71,11 @@ spec:
             properties:
               additionalPorts:
                 description: |-
-                  AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the operator-managed headless Service.
+                  AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the public headless Service.
                   The operator only adds the ports to the Kubernetes resources, it does not configure the ClickHouse server to listen on them.
                 items:
                   description: AdditionalPort declares one extra TCP port to expose
-                    on the ClickHouse Pod and the operator-managed headless Service.
+                    on the ClickHouse Pod and the public headless Service.
                   properties:
                     name:
                       description: |-

--- a/docs/reference/api-reference.mdx
+++ b/docs/reference/api-reference.mdx
@@ -12,7 +12,7 @@ This document provides detailed API reference for the ClickHouse Operator custom
 
 ## AdditionalPort {#additionalport}
 
-AdditionalPort declares one extra TCP port to expose on the ClickHouse Pod and the operator-managed headless Service.
+AdditionalPort declares one extra TCP port to expose on the ClickHouse Pod and the public headless Service.
 
 | Field | Type | Description | Required | Default |
 |-------|------|-------------|----------|---------|
@@ -89,7 +89,7 @@ ClickHouseClusterSpec defines the desired state of ClickHouseCluster.
 | `upgradeChannel` | string | UpgradeChannel specifies the release channel for major version upgrade checks.<br />When empty, only minor updates will be proposed. Allowed values are: stable, lts or specific major.minor version (e.g. 25.8). | false |  |
 | `versionProbeTemplate` | [VersionProbeTemplate](#versionprobetemplate) | VersionProbeTemplate overrides for the version detection Job. | false |  |
 | `externalSecret` | [ExternalSecret](#externalsecret) | ExternalSecret is an optional reference to an externally-managed Secret containing cluster secrets.<br />The secret must reside in the same namespace as the cluster. | false |  |
-| `additionalPorts` | [AdditionalPort](#additionalport) array | AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the operator-managed headless Service.<br />The operator only adds the ports to the Kubernetes resources, it does not configure the ClickHouse server to listen on them. | false |  |
+| `additionalPorts` | [AdditionalPort](#additionalport) array | AdditionalPorts declares extra TCP ports to expose on the ClickHouse Pod and the public headless Service.<br />The operator only adds the ports to the Kubernetes resources, it does not configure the ClickHouse server to listen on them. | false |  |
 
 Appears in:
 - [ClickHouseCluster](#clickhousecluster)

--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -466,7 +466,7 @@ func (cmd *commander) getConn(id v1.ClickHouseReplicaID) (clickhouse.Conn, error
 		cmd.log.Debug("creating new ClickHouse connection", "replica_id", id)
 
 		conn, err := clickhouse.Open(&clickhouse.Options{
-			Addr:        []string{net.JoinHostPort(cmd.cluster.HostnameByID(id), strconv.FormatInt(int64(PortManagement), 10))},
+			Addr:        []string{net.JoinHostPort(cmd.cluster.InternalHostnameByID(id), strconv.FormatInt(int64(PortManagement), 10))},
 			Auth:        cmd.auth,
 			DialContext: cmd.dialer,
 			Debugf: func(format string, args ...any) {

--- a/internal/controller/clickhouse/commands_test.go
+++ b/internal/controller/clickhouse/commands_test.go
@@ -203,7 +203,7 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 			port, err := ctr.MappedPort(ctx, chPort)
 			Expect(err).NotTo(HaveOccurred())
 
-			hostTargets[cluster.HostnameByID(v1.ClickHouseReplicaID{Index: i})] = net.JoinHostPort(host, port.Port())
+			hostTargets[cluster.InternalHostnameByID(v1.ClickHouseReplicaID{Index: i})] = net.JoinHostPort(host, port.Port())
 		}
 
 		zapLogger := zap.NewRaw(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true))

--- a/internal/controller/clickhouse/config.go
+++ b/internal/controller/clickhouse/config.go
@@ -316,7 +316,7 @@ func clusterConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, id
 	for shard := range r.Cluster.Shards() {
 		hosts := make([]string, r.Cluster.Replicas())
 		for replica := range r.Cluster.Replicas() {
-			hosts[replica] = r.Cluster.HostnameByID(v1.ClickHouseReplicaID{ShardID: shard, Index: replica})
+			hosts[replica] = r.Cluster.InternalHostnameByID(v1.ClickHouseReplicaID{ShardID: shard, Index: replica})
 		}
 
 		clusterHosts[shard] = hosts
@@ -354,6 +354,7 @@ func clusterConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, id
 }
 
 type networkConfigParams struct {
+	InterserverHTTPHost           string
 	InterserverHTTPPort           uint16
 	InterserverHTTPUser           string
 	InterserverHTTPPasswordEnvVar string
@@ -366,7 +367,7 @@ type namedProtocol struct {
 	Protocol protocol
 }
 
-func networkConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, _ v1.ClickHouseReplicaID) (string, error) {
+func networkConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, id v1.ClickHouseReplicaID) (string, error) {
 	var protocols []namedProtocol
 	for name, proto := range buildProtocols(r.Cluster) {
 		if name == "interserver" || name == "management" {
@@ -382,6 +383,7 @@ func networkConfigGenerator(tmpl *template.Template, r *clickhouseReconciler, _ 
 	controllerutil.SortKey(protocols, func(p namedProtocol) string { return p.Name })
 
 	params := networkConfigParams{
+		InterserverHTTPHost:           r.Cluster.InternalHostnameByID(id),
 		InterserverHTTPPort:           PortInterserver,
 		InterserverHTTPUser:           InterserverUserName,
 		InterserverHTTPPasswordEnvVar: EnvInterserverPassword,

--- a/internal/controller/clickhouse/config_test.go
+++ b/internal/controller/clickhouse/config_test.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"fmt"
 	"strings"
+	"text/template"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -112,6 +113,22 @@ var _ = Describe("ConfigGenerator", func() {
 
 		Expect(cfg.StorageConfiguration.Policies[ctx.Cluster.Spec.Settings.Encryption.PolicyName].Volumes["main"].Disk).To(ConsistOf(encryptedDisks))
 		Expect(cfg.StorageConfiguration.Policies["default"].Volumes["main"].Disk).To(ConsistOf(disks))
+	})
+
+	It("should use internal replica hostnames for remote servers", func() {
+		data, err := clusterConfigGenerator(template.Must(template.New("").Parse(clusterConfigTemplateStr)), &ctx, v1.ClickHouseReplicaID{})
+		Expect(err).ToNot(HaveOccurred())
+
+		for id := range ctx.Cluster.ReplicaIDs() {
+			Expect(data).To(ContainSubstring("host: " + ctx.Cluster.InternalHostnameByID(id)))
+		}
+	})
+
+	It("should set the internal hostname as the interserver HTTP host", func() {
+		id := v1.ClickHouseReplicaID{ShardID: 1, Index: 2}
+		data, err := networkConfigGenerator(template.Must(template.New("").Parse(networkConfigTemplateStr)), &ctx, id)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(data).To(ContainSubstring("interserver_http_host: " + ctx.Cluster.InternalHostnameByID(id)))
 	})
 })
 

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -149,7 +149,18 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 		})
 
 		Expect(suite.Client.List(ctx, &services, listOpts)).To(Succeed())
-		Expect(services.Items).To(HaveLen(1))
+		Expect(services.Items).To(HaveLen(1 + int(cr.Replicas()*cr.Shards())))
+
+		serviceNames := make(map[string]struct{}, len(services.Items))
+		for _, service := range services.Items {
+			serviceNames[service.Name] = struct{}{}
+		}
+
+		Expect(serviceNames).To(HaveKey(cr.HeadlessServiceName()))
+
+		for id := range cr.ReplicaIDs() {
+			Expect(serviceNames).To(HaveKey(cr.InternalServiceNameByReplicaID(id)))
+		}
 
 		Expect(suite.Client.List(ctx, &pdbs, listOpts)).To(Succeed())
 		Expect(pdbs.Items).To(HaveLen(2))

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -126,7 +126,7 @@ func (r *clickhouseReconciler) sync(ctx context.Context, log ctrlutil.Logger) (c
 
 	steps := []chctrl.ReconcileStep{
 		{Name: "VersionProbe", Fn: r.reconcileVersionProbe, Always: true},
-		{Name: "Service", Fn: r.reconcileService, Always: true},
+		{Name: "Services", Fn: r.reconcileService, Always: true},
 		{Name: "ClusterSecret", Fn: r.reconcileClusterSecret, Always: true},
 		{Name: "ExternalSecret", Fn: r.reconcileExternalSecret, Always: true},
 		{Name: "ActiveReplicaStatus", Fn: r.reconcileActiveReplicaStatus, Always: true},
@@ -187,9 +187,15 @@ func (r *clickhouseReconciler) sync(ctx context.Context, log ctrlutil.Logger) (c
 }
 
 func (r *clickhouseReconciler) reconcileService(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	service := templateHeadlessService(r.Cluster)
-	if _, err := r.ReconcileService(ctx, log, service, v1.EventActionReconciling); err != nil {
-		return chctrl.StepResult{}, fmt.Errorf("reconcile service resource: %w", err)
+	services := []*corev1.Service{templateHeadlessService(r.Cluster)}
+	for id := range r.Cluster.ReplicaIDs() {
+		services = append(services, templateInternalService(r.Cluster, id))
+	}
+
+	for _, service := range services {
+		if _, err := r.ReconcileService(ctx, log, service, v1.EventActionReconciling); err != nil {
+			return chctrl.StepResult{}, fmt.Errorf("reconcile service %q: %w", service.Name, err)
+		}
 	}
 
 	return chctrl.StepContinue(), nil
@@ -879,8 +885,14 @@ func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ct
 	return chctrl.StepContinue(), nil
 }
 
+type resourcesWithService struct {
+	chctrl.ReplicaResources
+
+	Service *corev1.Service
+}
+
 func (r *clickhouseReconciler) reconcileCleanUp(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	var replicasToRemove = map[v1.ClickHouseReplicaID]chctrl.ReplicaResources{}
+	var replicasToRemove = map[v1.ClickHouseReplicaID]resourcesWithService{}
 
 	configMaps, err := chctrl.ListReplicaResources[v1.ClickHouseReplicaID, *corev1.ConfigMap, *corev1.ConfigMapList](ctx, &r.ResourceManager, v1.ClickHouseIDFromLabels)
 	if err != nil {
@@ -892,8 +904,30 @@ func (r *clickhouseReconciler) reconcileCleanUp(ctx context.Context, log ctrluti
 			continue
 		}
 
-		replicasToRemove[id] = chctrl.ReplicaResources{
-			CFG: configMap,
+		replicasToRemove[id] = resourcesWithService{
+			ReplicaResources: chctrl.ReplicaResources{
+				CFG: configMap,
+			},
+		}
+	}
+
+	services, err := chctrl.ListReplicaResources[v1.ClickHouseReplicaID, *corev1.Service, *corev1.ServiceList](ctx, &r.ResourceManager, v1.ClickHouseIDFromLabels)
+	if err != nil {
+		return chctrl.StepResult{}, fmt.Errorf("list internal Services: %w", err)
+	}
+
+	for id, service := range services {
+		if id.ShardID < r.Cluster.Shards() && id.Index < r.Cluster.Replicas() {
+			continue
+		}
+
+		if res, ok := replicasToRemove[id]; ok {
+			res.Service = service
+			replicasToRemove[id] = res
+		} else {
+			replicasToRemove[id] = resourcesWithService{
+				Service: service,
+			}
 		}
 	}
 
@@ -915,8 +949,13 @@ func (r *clickhouseReconciler) reconcileCleanUp(ctx context.Context, log ctrluti
 	for id, res := range replicasToRemove {
 		inSync := !r.unsyncedShards[id.ShardID]
 
-		// Always delete orphaned ConfigMaps.
-		if res.CFG != nil && (inSync || res.STS == nil) {
+		// Delete StatefulSets only after the shard synced surviving replicas.
+		if res.STS != nil && !inSync {
+			log.Info("shard sync failed, skipping replica deletion", "replica_id", id)
+			continue
+		}
+
+		if res.CFG != nil {
 			log.Info("removing replica configmap", "replica_id", id, "configmap", res.CFG.Name)
 
 			if err := r.Delete(ctx, res.CFG, v1.EventActionReconciling); err != nil {
@@ -924,20 +963,20 @@ func (r *clickhouseReconciler) reconcileCleanUp(ctx context.Context, log ctrluti
 			}
 		}
 
-		// Delete StatefulSets only if the entire shard is removed or shard sync succeeded.
-		if res.STS == nil {
-			continue
+		if res.STS != nil {
+			log.Info("removing replica statefulset", "replica_id", id, "statefulset", res.STS.Name)
+
+			if err := r.Delete(ctx, res.STS, v1.EventActionReconciling); err != nil {
+				log.Error(err, "failed to delete replica statefulset", "replica_id", id, "statefulset", res.STS.Name)
+			}
 		}
 
-		if !inSync {
-			log.Info("shard sync failed, skipping replica deletion", "replica_id", id)
-			continue
-		}
+		if res.Service != nil {
+			log.Info("removing replica service", "replica_id", id, "service", res.Service.Name)
 
-		log.Info("removing replica statefulset", "replica_id", id, "statefulset", res.STS.Name)
-
-		if err := r.Delete(ctx, res.STS, v1.EventActionReconciling); err != nil {
-			log.Error(err, "failed to delete replica statefulset", "replica_id", id, "statefulset", res.STS.Name)
+			if err := r.Delete(ctx, res.Service, v1.EventActionReconciling); err != nil {
+				log.Error(err, "failed to delete replica service", "replica_id", id, "service", res.Service.Name)
+			}
 		}
 	}
 

--- a/internal/controller/clickhouse/templates.go
+++ b/internal/controller/clickhouse/templates.go
@@ -19,11 +19,23 @@ import (
 )
 
 func templateHeadlessService(cr *v1.ClickHouseCluster) *corev1.Service {
+	return templateService(cr, cr.HeadlessServiceName(), false)
+}
+
+func templateInternalService(cr *v1.ClickHouseCluster, id v1.ClickHouseReplicaID) *corev1.Service {
+	service := templateService(cr, cr.InternalServiceNameByReplicaID(id), true)
+	maps.Copy(service.Labels, id.Labels())
+	maps.Copy(service.Spec.Selector, id.Labels())
+
+	return service
+}
+
+func templateService(cr *v1.ClickHouseCluster, name string, internal bool) *corev1.Service {
 	protocols := buildProtocols(cr)
 
 	ports := make([]corev1.ServicePort, 0, len(protocols))
 	for name, proto := range protocols {
-		if proto.Port == 0 {
+		if proto.Port == 0 || proto.Internal != internal {
 			continue
 		}
 
@@ -35,13 +47,15 @@ func templateHeadlessService(cr *v1.ClickHouseCluster) *corev1.Service {
 		})
 	}
 
-	for _, p := range cr.Spec.AdditionalPorts {
-		ports = append(ports, corev1.ServicePort{
-			Protocol:   corev1.ProtocolTCP,
-			Name:       p.Name,
-			Port:       p.Port,
-			TargetPort: intstr.FromInt32(p.Port),
-		})
+	if !internal {
+		for _, p := range cr.Spec.AdditionalPorts {
+			ports = append(ports, corev1.ServicePort{
+				Protocol:   corev1.ProtocolTCP,
+				Name:       p.Name,
+				Port:       p.Port,
+				TargetPort: intstr.FromInt32(p.Port),
+			})
+		}
 	}
 
 	controllerutil.SortKey(ports, func(port corev1.ServicePort) string {
@@ -54,7 +68,7 @@ func templateHeadlessService(cr *v1.ClickHouseCluster) *corev1.Service {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.HeadlessServiceName(),
+			Name:      name,
 			Namespace: cr.Namespace,
 			Labels: controllerutil.MergeMaps(cr.Spec.Labels, map[string]string{
 				controllerutil.LabelAppKey: cr.SpecificName(),
@@ -63,11 +77,12 @@ func templateHeadlessService(cr *v1.ClickHouseCluster) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Ports:     ports,
-			ClusterIP: "None",
+			ClusterIP: corev1.ClusterIPNone,
 			// Publish not-yet-ready pod addresses so replicas can resolve and reach peers before they report Ready
 			PublishNotReadyAddresses: true,
 			Selector: map[string]string{
-				controllerutil.LabelAppKey: cr.SpecificName(),
+				controllerutil.LabelAppKey:  cr.SpecificName(),
+				controllerutil.LabelRoleKey: controllerutil.LabelClickHouseValue,
 			},
 		},
 	}
@@ -586,6 +601,7 @@ type protocol struct {
 	Port        int32  `yaml:"port,omitempty"`
 	Impl        string `yaml:"impl,omitempty"`
 	Description string `yaml:"description,omitempty"`
+	Internal    bool   `yaml:"-"`
 }
 
 func buildProtocols(cr *v1.ClickHouseCluster) map[protocolType]protocol {
@@ -594,6 +610,7 @@ func buildProtocols(cr *v1.ClickHouseCluster) map[protocolType]protocol {
 			Type:        protocolTypeInterserver,
 			Port:        PortInterserver,
 			Description: protocolTypeInterserver,
+			Internal:    true,
 		},
 		protocolTypePrometheus: {
 			Type:        protocolTypePrometheus,
@@ -604,11 +621,13 @@ func buildProtocols(cr *v1.ClickHouseCluster) map[protocolType]protocol {
 			Type:        protocolTypeTCP,
 			Port:        PortManagement,
 			Description: "tcp-management",
+			Internal:    true,
 		},
 		protocolTypeManagementHTTP: {
 			Type:        protocolTypeHTTP,
 			Port:        PortManagementHTTP,
 			Description: "http-management",
+			Internal:    true,
 		},
 		protocolTypeTCP: {
 			Type: protocolTypeTCP,

--- a/internal/controller/clickhouse/templates/network.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/network.yaml.tmpl
@@ -5,6 +5,7 @@ listen_try: 1
 {{- /* can't use composable protocol for interserver, because server disables replication,
       if interserver_http_port is not set */}}
 interserver_http_port: {{ .InterserverHTTPPort }}
+interserver_http_host: {{ .InterserverHTTPHost }}
 interserver_http_credentials:
   user: {{ .InterserverHTTPUser }}
   password:

--- a/internal/controller/clickhouse/templates_test.go
+++ b/internal/controller/clickhouse/templates_test.go
@@ -346,6 +346,89 @@ var _ = Describe("SecurityContext defaults", func() {
 	})
 })
 
+var _ = Describe("Service templates", func() {
+	cr := &v1.ClickHouseCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: v1.ClickHouseClusterSpec{
+			AdditionalPorts: []v1.AdditionalPort{{
+				Name: "extra",
+				Port: 19000,
+			}},
+		},
+	}
+
+	It("should expose internal ports through a per-replica internal service", func() {
+		id := v1.ClickHouseReplicaID{ShardID: 0, Index: 1}
+		service := templateInternalService(cr, id)
+
+		ports := map[string]int32{}
+		for _, port := range service.Spec.Ports {
+			ports[port.Name] = port.Port
+		}
+
+		Expect(service.Name).To(Equal(cr.InternalServiceNameByReplicaID(id)))
+		Expect(service.Spec.ClusterIP).To(Equal(corev1.ClusterIPNone))
+		Expect(service.Spec.PublishNotReadyAddresses).To(BeTrue())
+		Expect(service.Labels).To(SatisfyAll(
+			HaveKeyWithValue(controllerutil.LabelClickHouseShardID, "0"),
+			HaveKeyWithValue(controllerutil.LabelClickHouseReplicaID, "1"),
+		))
+		Expect(service.Spec.Selector).To(SatisfyAll(
+			HaveKeyWithValue(controllerutil.LabelAppKey, cr.SpecificName()),
+			HaveKeyWithValue(controllerutil.LabelRoleKey, controllerutil.LabelClickHouseValue),
+			HaveKeyWithValue(controllerutil.LabelClickHouseShardID, "0"),
+			HaveKeyWithValue(controllerutil.LabelClickHouseReplicaID, "1"),
+		))
+		Expect(ports).To(Equal(map[string]int32{
+			protocolTypeInterserver:    PortInterserver,
+			protocolTypeManagement:     PortManagement,
+			protocolTypeManagementHTTP: PortManagementHTTP,
+		}))
+
+		for index := 1; index < len(service.Spec.Ports); index++ {
+			Expect(service.Spec.Ports[index-1].Name < service.Spec.Ports[index].Name).To(BeTrue())
+		}
+	})
+
+	It("should keep the public headless service as the StatefulSet governing service", func() {
+		r := &clickhouseReconciler{Cluster: cr}
+		sts, err := templateStatefulSet(r, v1.ClickHouseReplicaID{}, "fixed-cfg-rev")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sts.Spec.ServiceName).To(Equal(cr.HeadlessServiceName()))
+	})
+
+	It("should expose secure user ports only through the public headless service", func() {
+		secure := cr.DeepCopy()
+		secure.Spec.Settings.TLS.Enabled = true
+		secure.Spec.Settings.TLS.Required = true
+
+		publicPorts := map[string]int32{}
+		for _, port := range templateHeadlessService(secure).Spec.Ports {
+			publicPorts[port.Name] = port.Port
+		}
+
+		Expect(publicPorts).To(HaveKeyWithValue(protocolTypeTCPSecure, int32(PortNativeSecure)))
+		Expect(publicPorts).To(HaveKeyWithValue(protocolTypeHTTPSecure, int32(PortHTTPSecure)))
+		Expect(publicPorts).NotTo(HaveKey(protocolTypeTCP))
+		Expect(publicPorts).NotTo(HaveKey(protocolTypeHTTP))
+	})
+
+	It("should not expose internal ports through the public headless service", func() {
+		publicPorts := map[string]int32{}
+		for _, port := range templateHeadlessService(cr).Spec.Ports {
+			publicPorts[port.Name] = port.Port
+		}
+
+		Expect(publicPorts).To(HaveKeyWithValue("extra", int32(19000)))
+		Expect(publicPorts).NotTo(HaveKey(protocolTypeInterserver))
+		Expect(publicPorts).NotTo(HaveKey(protocolTypeManagement))
+		Expect(publicPorts).NotTo(HaveKey(protocolTypeManagementHTTP))
+	})
+})
+
 var _ = Describe("PDB", func() {
 	var cr *v1.ClickHouseCluster
 

--- a/internal/webhook/v1alpha1/clickhousecluster_webhook.go
+++ b/internal/webhook/v1alpha1/clickhousecluster_webhook.go
@@ -26,6 +26,7 @@ const (
 	reservedClickHousePortInterserver      = 9009
 	reservedClickHousePortPrometheusScrape = 9363
 	reservedClickHousePortManagement       = 9001
+	reservedClickHousePortManagementHTTP   = 9002
 )
 
 // SetupClickHouseWebhookWithManager registers the webhook for ClickHouseCluster in the manager.
@@ -164,16 +165,18 @@ func (w *ClickHouseClusterWebhook) validateImpl(obj *chv1.ClickHouseCluster) (ad
 		reservedClickHousePortInterserver:      "interserver",
 		reservedClickHousePortPrometheusScrape: "Prometheus metrics",
 		reservedClickHousePortManagement:       "management",
+		reservedClickHousePortManagementHTTP:   "management HTTP",
 	}
 
 	reservedPortNames := map[string]struct{}{
-		"http":        {},
-		"http-secure": {},
-		"tcp":         {},
-		"tcp-secure":  {},
-		"interserver": {},
-		"prometheus":  {},
-		"management":  {},
+		"http":            {},
+		"http-secure":     {},
+		"tcp":             {},
+		"tcp-secure":      {},
+		"interserver":     {},
+		"prometheus":      {},
+		"management":      {},
+		"management-http": {},
 	}
 
 	for i, p := range obj.Spec.AdditionalPorts {

--- a/test/testutil/clickhouse_client.go
+++ b/test/testutil/clickhouse_client.go
@@ -263,6 +263,25 @@ func (c *ClickHouseClient) QueryRowReplica(
 	return nil
 }
 
+// ExecReplica executes a query on the specified ClickHouse replica.
+func (c *ClickHouseClient) ExecReplica(
+	ctx context.Context,
+	id v1.ClickHouseReplicaID,
+	query string,
+	args ...any,
+) error {
+	conn, ok := c.clients[id]
+	if !ok {
+		return fmt.Errorf("replica %v not found", id)
+	}
+
+	if err := conn.Exec(ctx, query, args...); err != nil {
+		return fmt.Errorf("exec query: %w", err)
+	}
+
+	return nil
+}
+
 // Query executes a query on one of the ClickHouse cluster nodes.
 func (c *ClickHouseClient) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
 	if len(c.clients) == 0 {

--- a/test/testutil/dialer.go
+++ b/test/testutil/dialer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,7 +20,9 @@ import (
 )
 
 const (
-	portForwardProtocol = "portforward.k8s.io"
+	portForwardProtocol             = "portforward.k8s.io"
+	maxKubernetesResourceNameLength = 63
+	resourceNameHashLength          = 4
 )
 
 // streamConn wraps an httpstream.Stream (SPDY data stream) as a net.Conn.
@@ -56,7 +59,7 @@ func (a spdyAddr) String() string  { return string(a) }
 
 // NewPortForwardDialer returns a DialContextFunc that connects to pods inside a Kubernetes cluster
 // by creating SPDY port-forward streams through the API server.
-// Pod hostnames are expected in the format: {podName}.{serviceName}.{namespace}.svc.{domain}.
+// It resolves both Pod and Service hostnames to their target Pod.
 func NewPortForwardDialer(config *rest.Config) controllerutil.DialContextFunc {
 	return func(_ context.Context, addr string) (net.Conn, error) {
 		host, portStr, err := net.SplitHostPort(addr)
@@ -64,21 +67,14 @@ func NewPortForwardDialer(config *rest.Config) controllerutil.DialContextFunc {
 			return nil, fmt.Errorf("split host port %q: %w", addr, err)
 		}
 
-		// Parse pod hostname: {podName}.{serviceName}.{namespace}.svc.{domain}
-		parts := strings.SplitN(host, ".", 4)
-		if len(parts) < 3 {
-			return nil, fmt.Errorf(
-				"can't parse pod hostname %q: expected {pod}.{service}.{namespace}[.svc.domain]",
-				host,
-			)
-		}
-
-		podName := parts[0]
-		namespace := parts[2]
-
 		clientset, err := kubernetes.NewForConfig(config)
 		if err != nil {
 			return nil, fmt.Errorf("create k8s client: %w", err)
+		}
+
+		namespace, podName, err := podForHostname(host)
+		if err != nil {
+			return nil, err
 		}
 
 		transport, upgrader, err := spdy.RoundTripperFor(config)
@@ -144,4 +140,40 @@ func NewPortForwardDialer(config *rest.Config) controllerutil.DialContextFunc {
 			addr:     addr,
 		}, nil
 	}
+}
+
+// podForHostname returns the Pod addressed by a Kubernetes Pod or Service hostname.
+func podForHostname(hostname string) (string, string, error) {
+	parts := strings.Split(hostname, ".")
+	if len(parts) < 3 {
+		return "", "", fmt.Errorf("can't parse Kubernetes hostname %q", hostname)
+	}
+
+	// Pod hostname {pod}.{service}.{namespace}.svc.{domain}: the fourth label
+	// distinguishes it from a Service in a namespace named "svc".
+	if (len(parts) >= 4 && parts[3] == "svc") || parts[2] != "svc" {
+		return parts[2], parts[0], nil
+	}
+
+	// Service hostname: {service}.{namespace}.svc.{domain}.
+	serviceName, namespace := parts[0], parts[1]
+
+	internalServiceIndex := strings.LastIndex(serviceName, "-internal-")
+	if internalServiceIndex < 1 || internalServiceIndex+len("-internal-") == len(serviceName) {
+		return "", "", fmt.Errorf("can't parse internal service hostname %q", hostname)
+	}
+
+	hashStart := internalServiceIndex - resourceNameHashLength
+	if len(serviceName) == maxKubernetesResourceNameLength && hashStart > 0 && serviceName[hashStart-1] == '-' {
+		_, err := strconv.ParseUint(
+			serviceName[hashStart:internalServiceIndex], 16, resourceNameHashLength*4,
+		)
+		if err == nil {
+			return "", "", fmt.Errorf("can't reconstruct Pod from truncated Service %q", serviceName)
+		}
+	}
+
+	podName := serviceName[:internalServiceIndex] + "-" + serviceName[internalServiceIndex+len("-internal-"):] + "-0"
+
+	return namespace, podName, nil
 }

--- a/test/testutil/dialer_test.go
+++ b/test/testutil/dialer_test.go
@@ -1,0 +1,75 @@
+package testutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPodForHostname(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		hostname  string
+		namespace string
+		podName   string
+	}{
+		{
+			name:      "pod service hostname",
+			hostname:  "test-clickhouse-0-0-0.test-clickhouse-headless.default.svc.cluster.local",
+			namespace: "default",
+			podName:   "test-clickhouse-0-0-0",
+		},
+		{
+			name:      "internal service hostname",
+			hostname:  "test-clickhouse-internal-0-0.default.svc.cluster.local",
+			namespace: "default",
+			podName:   "test-clickhouse-0-0-0",
+		},
+		{
+			name:      "internal service hostname with internal in cluster name",
+			hostname:  "test-internal-clickhouse-internal-0-0.default.svc.cluster.local",
+			namespace: "default",
+			podName:   "test-internal-clickhouse-0-0-0",
+		},
+		{
+			name:      "pod hostname in svc namespace",
+			hostname:  "test-clickhouse-0-0-0.test-clickhouse-headless.svc.svc.cluster.local",
+			namespace: "svc",
+			podName:   "test-clickhouse-0-0-0",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			namespace, podName, err := podForHostname(test.hostname)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if namespace != test.namespace || podName != test.podName {
+				t.Fatalf("podForHostname() = %s/%s, want %s/%s", namespace, podName, test.namespace, test.podName)
+			}
+		})
+	}
+}
+
+func TestPodForHostnameRejectsPotentiallyTruncatedService(t *testing.T) {
+	suffix := "-abcd-internal-0-0"
+	serviceName := strings.Repeat("a", maxKubernetesResourceNameLength-len(suffix)) + suffix
+
+	_, _, err := podForHostname(serviceName + ".default.svc.cluster.local")
+	if err == nil {
+		t.Fatal("podForHostname() succeeded, want error")
+	}
+}
+
+func TestPodForHostnameAcceptsMaxLengthUntruncatedService(t *testing.T) {
+	suffix := "-clickhouse-internal-0-0"
+	serviceName := strings.Repeat("a", maxKubernetesResourceNameLength-len(suffix)) + suffix
+
+	namespace, podName, err := podForHostname(serviceName + ".default.svc.cluster.local")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if namespace != "default" || podName != strings.TrimSuffix(serviceName, "-internal-0-0")+"-0-0-0" {
+		t.Fatalf("podForHostname() = %s/%s", namespace, podName)
+	}
+}


### PR DESCRIPTION
## Why

It is the first stage for #266
Need to separate internal and client traffic to control it separately later.

It may make more sense to use a governing service for internal traffic, but it already exists and serves client traffic

## What

Add per-replica services with internal-only ports and configure clickhouse to use it for internal replication and operator access
