### PR TITLE
feat: gate client traffic until replica initialization completes

### DIFF
--- a/api/v1alpha1/clickhousecluster_types.go
+++ b/api/v1alpha1/clickhousecluster_types.go
@@ -212,6 +212,11 @@ type ClickHouseSettings struct {
 	ExtraUsersConfig runtime.RawExtension `json:"extraUsersConfig,omitempty"`
 }
 
+// DatabaseSyncEnabled reports whether database schema synchronization is enabled.
+func (s *ClickHouseSettings) DatabaseSyncEnabled() bool {
+	return s.EnableDatabaseSync == nil || *s.EnableDatabaseSync
+}
+
 // EncryptionSettings enables at-rest encryption of table data. When present, the operator generates an
 // encrypted ClickHouse storage policy wrapping every data disk; tables opt in via `SETTINGS storage_policy`.
 // Encryption cannot be disabled once enabled.

--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -1,5 +1,7 @@
 package v1alpha1
 
+import corev1 "k8s.io/api/core/v1"
+
 // ConditionType represents the type of condition.
 type ConditionType = string
 
@@ -73,10 +75,11 @@ const (
 	// should operate normally after scale down, but it does not mean that all replicas have the same schema.
 	ClickHouseConditionTypeSchemaInSync ConditionType = "SchemaInSync"
 
-	ClickHouseConditionSchemaSyncDisabled   ConditionReason = "SchemaSyncDisabled"
-	ClickHouseConditionReplicasInSync       ConditionReason = "ReplicasInSync"
-	ClickHouseConditionDatabasesNotCreated  ConditionReason = "DatabasesNotCreated"
-	ClickHouseConditionReplicasNotCleanedUp ConditionReason = "ReplicasNotCleanedUp"
+	ClickHouseConditionSchemaSyncDisabled           ConditionReason = "SchemaSyncDisabled"
+	ClickHouseConditionReplicasInSync               ConditionReason = "ReplicasInSync"
+	ClickHouseConditionDatabasesNotCreated          ConditionReason = "DatabasesNotCreated"
+	ClickHouseConditionDefaultDatabaseNotReplicated ConditionReason = "DefaultDatabaseNotReplicated"
+	ClickHouseConditionReplicasNotCleanedUp         ConditionReason = "ReplicasNotCleanedUp"
 
 	// ClickHouseConditionTypeExternalSecretValid indicates whether the externally managed Secret contains all required keys.
 	// This condition is present only when spec.externalSecret is configured; it is removed when externalSecret is unset.
@@ -100,4 +103,11 @@ const (
 	KeeperConditionReasonNoQuorum                 ConditionReason = "NoQuorum"
 	KeeperConditionReasonWaitingFollowers         ConditionReason = "WaitingFollowers"
 	KeeperConditionReasonReadyToScale             ConditionReason = "ReadyToScale"
+)
+
+// Special condition added to the ClickHouseCluster pods to indicate that replica is initialized by the operator.
+const (
+	ReplicaInitializedCondition corev1.PodConditionType = "clickhouse.com/ReplicaInitialized"
+	ReplicaInitializedReason    ConditionReason         = "ReplicaInitialized"
+	ReplicaDeletionReason       ConditionReason         = "ReplicaScheduledForDeletion"
 )

--- a/api/v1alpha1/types_test.go
+++ b/api/v1alpha1/types_test.go
@@ -58,6 +58,15 @@ var _ = Describe("KeeperCluster", func() {
 })
 
 var _ = Describe("ClickHouseCluster", func() {
+	DescribeTable("DatabaseSyncEnabled", func(value *bool, expected bool) {
+		settings := ClickHouseSettings{EnableDatabaseSync: value}
+		Expect(settings.DatabaseSyncEnabled()).To(Equal(expected))
+	},
+		Entry("defaults to enabled", nil, true),
+		Entry("is explicitly enabled", new(true), true),
+		Entry("is explicitly disabled", new(false), false),
+	)
+
 	Describe("KeeperClusterNamespacedName", func() {
 		It("should default the keeper namespace to the ClickHouseCluster namespace", func() {
 			cluster := &ClickHouseCluster{

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - apps
   resources:
   - statefulsets

--- a/dist/chart/templates/rbac/manager-role.yaml
+++ b/dist/chart/templates/rbac/manager-role.yaml
@@ -26,6 +26,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - apps
   resources:
   - statefulsets

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -106,14 +106,11 @@ spec:
   clusterDomain: cluster.local   # default; override only for a custom domain
 ```
 
-The operator addresses every pod through the headless Service as
-`<pod>.<headless-service>.<namespace>.svc.<clusterDomain>`. That suffix flows into
-two parts of the generated configuration:
+For ClickHouse replicas the operator creates a governing headless Service `<cluster-name>-clickhouse-headless` that serves client traffic.
+And per-replica services `<cluster-name>-clickhouse-internal-<shard>-<index>` that publish unready Pods for internal traffic
+and management requests from the operator. This can be used for replica recovery if it cannot become ready itself.
 
-- On a `ClickHouseCluster`, its value is used for the replica host names in
-  `remote_servers` (cross-replica and `Distributed` queries).
-- On a `KeeperCluster`, its value builds the Keeper node host names that
-  ClickHouse uses for coordination.
+Keeper nodes use pod names through their headless Service: `<pod>.<headless-service>.<namespace>.svc.<clusterDomain>`.
 
 <Note>
 Only override this when your cluster's `kubelet` runs with a `--cluster-domain`
@@ -459,7 +456,7 @@ The set of required keys depends on the running ClickHouse version. `named-colle
 
 ## Additional ports {#additional-ports}
 
-The operator exposes a fixed set of ports on every ClickHouse Pod and its headless Service: `8123` HTTP, `9000` native, `9009` interserver, `9001` management, `9363` Prometheus metrics, and the TLS variants `8443`/`9440` when TLS is enabled. To make ClickHouse listen on additional protocols — MySQL, PostgreSQL, gRPC, or any custom port — declare them in `spec.additionalPorts`:
+The operator exposes a fixed set of ports on every ClickHouse Pod and its public headless Service: `8123` HTTP, `9000` native, `9009` interserver, `9001`/`9002` management, `9363` Prometheus metrics, and the TLS variants `8443`/`9440` when TLS is enabled. The `interserver` and management ports are additionally exposed through the per-replica internal Services so replicas and the operator can communicate before a replica becomes ready. To make ClickHouse listen on additional protocols — MySQL, PostgreSQL, gRPC, or any custom port — declare them in `spec.additionalPorts`:
 
 ```yaml
 spec:
@@ -472,7 +469,8 @@ spec:
       port: 9100
 ```
 
-The operator adds those ports to the Pod's `containerPorts` and to the headless Service. The complete example lives at [`examples/custom_protocols.yaml`](https://github.com/ClickHouse/clickhouse-operator/blob/main/examples/custom_protocols.yaml).
+The operator adds those ports to the Pod's `containerPorts` and the public headless Service.
+The complete example lives at [`examples/custom_protocols.yaml`](https://github.com/ClickHouse/clickhouse-operator/blob/main/examples/custom_protocols.yaml).
 
 <Warning>
 `additionalPorts` only opens the ports on the Kubernetes side. It does **not** configure the ClickHouse server to listen on them. You also have to enable the matching protocol in `spec.settings.extraConfig.protocols`. Without that, the port is open on the Service but nothing inside the pod is answering.
@@ -496,7 +494,7 @@ spec:
       requests:
         storage: 2Gi
 
-  # 1) Open the port on the Pod and the headless Service.
+  # 1) Open the port on the Pod and the public headless Service.
   additionalPorts:
     - name: mysql
       port: 9004
@@ -809,6 +807,12 @@ spec:
 ```
 
 When enabled, the operator synchronizes Replicated and integration tables to new replicas.
+
+Every replica Pod carries the `clickhouse.com/ReplicaInitialized` readiness gate, so a new replica is published through the public headless Service only after the operator completes its initialization: the `default` database is converted to the Replicated engine and the schema is synchronized. Until then, the operator and the other replicas reach it through its internal Service. With `enableDatabaseSync: false`, the operator marks replicas initialized immediately, so readiness follows the container probes alone.
+
+The operator never drops a populated non-Replicated `default` database. Such a replica still starts serving client traffic after schema preparation, but the cluster reports `SchemaInSync=False` with reason `DefaultDatabaseNotReplicated` until you resolve that database yourself.
+
+Before a replica is removed on scale-down, the operator first unloads client traffic from it, waits until it stops being published, replicates its remaining data to the surviving replicas, and only then deletes it.
 
 ### Server logging {#server-logging}
 

--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -114,7 +114,7 @@ func (cmd *commander) Probe(ctx context.Context, id v1.ClickHouseReplicaID) (rep
 	return probe, nil
 }
 
-// Reads system warnings from the server.
+// Warnings reads system warnings from the server.
 func (cmd *commander) Warnings(ctx context.Context, id v1.ClickHouseReplicaID) ([]string, error) {
 	conn, err := cmd.getConn(id)
 	if err != nil {
@@ -270,23 +270,55 @@ func (cmd *commander) CreateDatabases(ctx context.Context, log controllerutil.Lo
 	return nil
 }
 
-// EnsureDefaultDatabaseEngine ensures that the default database engine is set to the Replicated.
-func (cmd *commander) EnsureDefaultDatabaseEngine(ctx context.Context, log controllerutil.Logger, replicas []v1.ClickHouseReplicaID) bool {
-	res := controllerutil.ExecuteParallel(replicas, func(id v1.ClickHouseReplicaID) (v1.ClickHouseReplicaID, struct{}, error) {
-		err := cmd.ensureReplicaDefaultDatabaseEngine(ctx, log, id)
-		return id, struct{}{}, err
-	})
+// EnsureReplicaDefaultDatabaseEngine makes the default database Replicated when safe; it returns false without an error when a populated non-Replicated default database is preserved.
+func (cmd *commander) EnsureReplicaDefaultDatabaseEngine(ctx context.Context, log controllerutil.Logger, id v1.ClickHouseReplicaID) (bool, error) {
+	log = log.With("replica_id", id)
 
-	result := true
-	for id, repl := range res {
-		if repl.Err != nil {
-			log.Info("failed to recreate default database as Replicated", "replica_id", id, "error", repl.Err)
+	conn, err := cmd.getConn(id)
+	if err != nil {
+		return false, fmt.Errorf("failed to get connection for replica %s: %w", id, err)
+	}
 
-			result = false
+	var engine string
+
+	rows := conn.QueryRow(ctx, "SELECT engine FROM system.databases WHERE name='default' ")
+	if err = rows.Scan(&engine); err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return false, fmt.Errorf("failed to scan default database engine for replica %s: %w", id, err)
+		}
+
+		log.Debug("no default database found")
+	} else {
+		if engine == "Replicated" {
+			return true, nil
+		}
+
+		var count uint64
+		if err = conn.QueryRow(ctx, "SELECT COUNT() FROM system.tables WHERE database='default'").Scan(&count); err != nil {
+			log.Error(err, "error checking if database 'default' has tables")
+			return false, fmt.Errorf("check tables in  %s: %w", id, err)
+		}
+
+		if count > 0 {
+			log.Warn("database `default` has tables, but its engine is not Replicated; refusing to drop it to avoid data loss")
+			return false, nil
+		}
+
+		log.Debug("dropping default database")
+
+		if err := conn.Exec(ctx, "DROP DATABASE default SYNC"); err != nil {
+			return false, fmt.Errorf("failed to drop default database on replica %s: %w", id, err)
 		}
 	}
 
-	return result
+	log.Debug("creating replicated default database")
+
+	defaultDatabaseUUID := uuid.NewSHA1(uuid.Nil, []byte(cmd.cluster.SpecificName())).String()
+	if err = conn.Exec(ctx, createDefaultDatabaseQuery, defaultDatabaseUUID); err != nil {
+		return false, fmt.Errorf("create default replicated database %s: %w", id, err)
+	}
+
+	return true, nil
 }
 
 func (cmd *commander) SyncShard(ctx context.Context, log controllerutil.Logger, shardID int32) error {
@@ -484,60 +516,6 @@ func (cmd *commander) getConn(id v1.ClickHouseReplicaID) (clickhouse.Conn, error
 
 func (cmd *commander) getAnyConn(ctx context.Context) (v1.ClickHouseReplicaID, clickhouse.Conn, error) {
 	return cmd.entry.AnyConn(ctx)
-}
-
-func (cmd *commander) ensureReplicaDefaultDatabaseEngine(ctx context.Context, log controllerutil.Logger, id v1.ClickHouseReplicaID) error {
-	log = log.With("replica_id", id)
-
-	conn, err := cmd.getConn(id)
-	if err != nil {
-		return fmt.Errorf("failed to get connection for replica %s: %w", id, err)
-	}
-
-	var engine string
-
-	rows := conn.QueryRow(ctx, "SELECT engine FROM system.databases WHERE name='default' ")
-	if err = rows.Scan(&engine); err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("failed to scan default database engine for replica %s: %w", id, err)
-		}
-
-		log.Debug("no default database found")
-	} else {
-		if engine == "Replicated" {
-			return nil
-		}
-
-		var count uint64
-		if err = conn.QueryRow(ctx, "SELECT COUNT() FROM system.tables WHERE database='default'").Scan(&count); err != nil {
-			log.Error(err, "error checking if database 'default' has tables")
-			return fmt.Errorf("check tables in  %s: %w", id, err)
-		}
-
-		// Never drop a populated `default`: converting it to Replicated would
-		// destroy existing tables. Leave it as-is and surface the problem as an
-		// error so the operator reports SchemaInSync=false; the engine is only
-		// switched on an empty `default` below.
-		if count > 0 {
-			log.Warn("database `default` has tables, but its engine is not Replicated; refusing to drop it to avoid data loss")
-			return fmt.Errorf("refusing to recreate non-empty `default` database as Replicated on replica %s: it has %d table(s), dropping it would lose data", id, count)
-		}
-
-		log.Debug("dropping default database")
-
-		if err := conn.Exec(ctx, "DROP DATABASE default SYNC"); err != nil {
-			return fmt.Errorf("failed to drop default database on replica %s: %w", id, err)
-		}
-	}
-
-	log.Debug("creating replicated default database")
-
-	defaultDatabaseUUID := uuid.NewSHA1(uuid.Nil, []byte(cmd.cluster.SpecificName())).String()
-	if err = conn.Exec(ctx, createDefaultDatabaseQuery, defaultDatabaseUUID); err != nil {
-		return fmt.Errorf("create default replicated database %s: %w", id, err)
-	}
-
-	return nil
 }
 
 func dbCtx(ctx context.Context, db string) context.Context {

--- a/internal/controller/clickhouse/commands_test.go
+++ b/internal/controller/clickhouse/commands_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -257,9 +256,10 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 
 		By("running EnsureDefaultDatabaseEngine")
 
-		// A non-empty Atomic `default` must not be dropped; the operator should
-		// report failure (SchemaInSync=false) rather than destroy data.
-		Expect(cmd.EnsureDefaultDatabaseEngine(ctx, cmd.log, slices.Collect(cmd.cluster.ReplicaIDs()))).To(BeFalse())
+		// A non-empty Atomic `default` must not be dropped: the cluster reports SchemaInSync=False until the user resolves it.
+		replicated, err := cmd.EnsureReplicaDefaultDatabaseEngine(ctx, cmd.log, id0)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(replicated).To(BeFalse())
 
 		By("verifying default database is still Atomic and the seeded table survived")
 
@@ -279,7 +279,11 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 	It("converts default database from Atomic to Replicated", func(ctx context.Context) {
 		By("running EnsureDefaultDatabaseEngine")
 
-		Expect(cmd.EnsureDefaultDatabaseEngine(ctx, cmd.log, slices.Collect(cmd.cluster.ReplicaIDs()))).To(BeTrue())
+		for id := range cmd.cluster.ReplicaIDs() {
+			replicated, err := cmd.EnsureReplicaDefaultDatabaseEngine(ctx, cmd.log, id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(replicated).To(BeTrue())
+		}
 
 		By("verifying default database is now Replicated")
 

--- a/internal/controller/clickhouse/controller.go
+++ b/internal/controller/clickhouse/controller.go
@@ -58,6 +58,7 @@ func keeperReferenceFieldValue(cluster *v1.ClickHouseCluster) []string {
 // +kubebuilder:rbac:groups=clickhouse.com,resources=clickhouseclusters/finalizers,verbs=update
 
 // +kubebuilder:rbac:groups="",resources=configmaps;services;pods,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups="",resources=pods/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets;persistentvolumeclaims,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get
@@ -190,11 +191,14 @@ func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgr
 			&v1.KeeperCluster{},
 			handler.EnqueueRequestsFromMapFunc(clickhouseController.clickHouseClustersForKeeper),
 		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(clickhouseController.clickHouseClustersForPod),
+		).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.Pod{}).
 		Owns(&batchv1.Job{})
 
 	if enablePDB {
@@ -246,4 +250,16 @@ func (cc *ClusterController) clickHouseClustersForKeeper(ctx context.Context, ob
 	}
 
 	return requests
+}
+
+func (cc *ClusterController) clickHouseClustersForPod(_ context.Context, obj client.Object) []reconcile.Request {
+	cluster := obj.GetLabels()[controllerutil.LabelClusterKey]
+	if cluster == "" || obj.GetLabels()[controllerutil.LabelRoleKey] != controllerutil.LabelClickHouseValue {
+		return nil
+	}
+
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      cluster,
+	}}}
 }

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -746,3 +746,41 @@ var _ = Describe("keeper watch mapping", func() {
 		}))
 	})
 })
+
+var _ = Describe("pod watch mapping", func() {
+	It("should enqueue the ClickHouse cluster that owns a labeled Pod", func(ctx context.Context) {
+		cluster := &v1.ClickHouseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "clickhouse-ns",
+			},
+		}
+
+		requests := (&ClusterController{}).clickHouseClustersForPod(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Namespace,
+				Labels: map[string]string{
+					controllerutil.LabelClusterKey: cluster.Name,
+					controllerutil.LabelRoleKey:    controllerutil.LabelClickHouseValue,
+				},
+			},
+		})
+
+		Expect(requests).To(ConsistOf(reconcile.Request{NamespacedName: cluster.NamespacedName()}))
+	})
+
+	It("should ignore Pods without the ClickHouse role or cluster label", func(ctx context.Context) {
+		Expect((&ClusterController{}).clickHouseClustersForPod(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				controllerutil.LabelClusterKey: "example",
+				controllerutil.LabelRoleKey:    controllerutil.LabelVersionProbe,
+			}},
+		})).To(BeEmpty())
+
+		Expect((&ClusterController{}).clickHouseClustersForPod(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				controllerutil.LabelRoleKey: controllerutil.LabelClickHouseValue,
+			}},
+		})).To(BeEmpty())
+	})
+})

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"maps"
@@ -41,12 +42,23 @@ type replicaState struct {
 	ReloadError error
 }
 
+// Queryable reports whether the replica can process queries.
+func (r replicaState) Queryable() bool {
+	return r.Version != ""
+}
+
+// Initialized reports whether the operator completed replica initialization.
+func (r replicaState) Initialized() bool {
+	return chctrl.PodConditionTrue(r.Pod, v1.ReplicaInitializedCondition)
+}
+
+// Ready reports whether the replica is serving client traffic.
 func (r replicaState) Ready() bool {
-	if r.STS == nil {
+	if !r.Queryable() || r.Pod == nil {
 		return false
 	}
 
-	return r.Version != "" && r.STS.Status.ReadyReplicas == 1 // Not reliable, but allows to wait until pod is `green`
+	return chctrl.PodConditionTrue(r.Pod, corev1.PodReady)
 }
 
 func (r replicaState) HasDiff(rev chctrl.RevisionState) bool {
@@ -103,10 +115,11 @@ type clickhouseReconciler struct {
 	secret    corev1.Secret
 	commander *commander
 
-	versionProbe   chctrl.VersionProbeResult
-	readyReplicas  []v1.ClickHouseReplicaID
-	revs           chctrl.RevisionState
-	unsyncedShards map[int32]bool // Populated by reconcileDatabaseSync, consumed by reconcileCleanUp.
+	versionProbe      chctrl.VersionProbeResult
+	reachableReplicas []v1.ClickHouseReplicaID
+	readyReplicas     []v1.ClickHouseReplicaID
+	revs              chctrl.RevisionState
+	unsyncedShards    map[int32]bool // Populated by reconcileDatabaseSync, consumed by reconcileCleanUp.
 }
 
 func (r *clickhouseReconciler) sync(ctx context.Context, log ctrlutil.Logger) (ctrl.Result, error) {
@@ -482,7 +495,7 @@ func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context,
 			reloadErr error
 		)
 
-		if startupErr == nil && sts.Status.ReadyReplicas > 0 && r.commander != nil {
+		if startupErr == nil && chctrl.PodConditionTrue(pod, corev1.ContainersReady) && r.commander != nil {
 			ctx, cancel := context.WithTimeout(ctx, chctrl.LoadReplicaStateTimeout)
 			defer cancel()
 
@@ -553,7 +566,7 @@ func (r *clickhouseReconciler) reconcileWarnings(ctx context.Context, log ctrlut
 
 	results := ctrlutil.ExecuteParallel(ids, func(id v1.ClickHouseReplicaID) (v1.ClickHouseReplicaID, struct{}, error) {
 		replica := r.ReplicaState[id]
-		if replica.StartupError != nil || replica.STS == nil || replica.STS.Status.ReadyReplicas == 0 {
+		if !replica.Queryable() {
 			return id, struct{}{}, nil
 		}
 
@@ -774,8 +787,21 @@ func (r *clickhouseReconciler) reconcileReplicaResources(ctx context.Context, lo
 }
 
 func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	if enabled := r.Cluster.Spec.Settings.EnableDatabaseSync; enabled != nil && !*enabled {
+	if !r.Cluster.Spec.Settings.DatabaseSyncEnabled() {
 		log.Debug("database sync is disabled, skipping")
+
+		ids := make([]v1.ClickHouseReplicaID, 0, len(r.ReplicaState))
+		for id := range r.ReplicaState {
+			if id.ShardID < r.Cluster.Shards() && id.Index < r.Cluster.Replicas() {
+				ids = append(ids, id)
+			}
+		}
+
+		result := chctrl.StepContinue()
+		if !r.initializeReplicas(ctx, log, ids) {
+			result = chctrl.StepRequeue(chctrl.RequeueProbePoll)
+		}
+
 		r.SetCondition(metav1.Condition{
 			Type:    v1.ClickHouseConditionTypeSchemaInSync,
 			Status:  metav1.ConditionTrue,
@@ -783,7 +809,7 @@ func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ct
 			Message: "Database schema sync is disabled",
 		})
 
-		return chctrl.StepContinue(), nil
+		return result, nil
 	}
 
 	if r.commander == nil {
@@ -792,59 +818,65 @@ func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ct
 	}
 
 	var (
-		allReplicasReady       = len(r.readyReplicas) == len(r.ReplicaState)
-		allDefaultDatabaseSet  = allReplicasReady
-		allDatabasesSynced     = allReplicasReady
-		staleReplicasCleanedUp = true
+		allReplicasReachable            = len(r.reachableReplicas) == len(r.ReplicaState)
+		allDatabasesSynced              = allReplicasReachable
+		allReplicasInitialized          = allReplicasReachable
+		staleReplicasCleanedUp          = true
+		nonReplicatedDefaultDatabaseIDs []string
+		initializationCandidates        []v1.ClickHouseReplicaID
 	)
 
-	if !r.commander.EnsureDefaultDatabaseEngine(ctx, log, r.readyReplicas) {
-		allDefaultDatabaseSet = false
+	desiredReplicas := make([]v1.ClickHouseReplicaID, 0, len(r.reachableReplicas))
+	for _, id := range r.reachableReplicas {
+		if id.ShardID < r.Cluster.Shards() && id.Index < r.Cluster.Replicas() {
+			desiredReplicas = append(desiredReplicas, id)
+		}
 	}
 
-	if len(r.readyReplicas) >= 2 {
-		if !r.commander.SyncDatabases(ctx, log, r.readyReplicas) {
+	defaultDBRes := ctrlutil.ExecuteParallel(desiredReplicas, func(id v1.ClickHouseReplicaID) (v1.ClickHouseReplicaID, bool, error) {
+		if r.ReplicaState[id].Initialized() {
+			return id, true, nil
+		}
+
+		replicated, err := r.commander.EnsureReplicaDefaultDatabaseEngine(ctx, log, id)
+
+		return id, replicated, err
+	})
+	for id, res := range defaultDBRes {
+		if res.Err != nil {
+			log.Info("failed to recreate default database as Replicated", "replica_id", id, "error", res.Err)
+
+			allReplicasInitialized = false
+
+			continue
+		}
+
+		if !res.Result {
+			nonReplicatedDefaultDatabaseIDs = append(nonReplicatedDefaultDatabaseIDs, id.String())
+		}
+
+		initializationCandidates = append(initializationCandidates, id)
+	}
+
+	schemaSynced := true
+
+	if len(r.reachableReplicas) >= 2 {
+		if !r.commander.SyncDatabases(ctx, log, r.reachableReplicas) {
+			schemaSynced = false
 			allDatabasesSynced = false
 		}
 	} else {
 		log.Info("no replicas to replicate schema, skipping")
 	}
 
-	shardHasReadyReplica := map[int32]bool{}
-	for _, id := range r.readyReplicas {
-		shardHasReadyReplica[id.ShardID] = true
+	if schemaSynced && !r.initializeReplicas(ctx, log, initializationCandidates) {
+		allReplicasInitialized = false
 	}
 
-	// Sync only shards that are going to drop some replicas.
-	runningReplicas := map[v1.ClickHouseReplicaID]struct{}{}
-	shardsToSyncSet := map[int32]struct{}{}
+	drainingShards := r.unloadRemovedReplicas(ctx, log)
+	runningReplicas := r.syncShardsPendingRemoval(ctx, log, drainingShards)
 
-	for id := range r.ReplicaState {
-		runningReplicas[id] = struct{}{}
-
-		if id.ShardID < r.Cluster.Shards() && id.Index >= r.Cluster.Replicas() {
-			if shardHasReadyReplica[id.ShardID] {
-				shardsToSyncSet[id.ShardID] = struct{}{}
-			} else {
-				log.Debug("no ready replicas in shard, skipping sync", "shard", id.ShardID)
-				r.unsyncedShards[id.ShardID] = true
-			}
-		}
-	}
-
-	syncRes := ctrlutil.ExecuteParallel(slices.Collect(maps.Keys(shardsToSyncSet)), func(shardID int32) (int32, struct{}, error) {
-		log.Info("pre scale-down shard sync", "shard_id", shardID)
-		return shardID, struct{}{}, r.commander.SyncShard(ctx, log, shardID)
-	})
-
-	for id, res := range syncRes {
-		if res.Err != nil {
-			log.Info("failed to sync shard", "shard_id", id, "error", res.Err)
-			r.unsyncedShards[id] = true
-		}
-	}
-
-	if len(r.readyReplicas) > 0 {
+	if len(r.reachableReplicas) > 0 {
 		if err := r.commander.CleanupDatabaseReplicas(ctx, log, runningReplicas); err != nil {
 			log.Warn("failed to cleanup database replicas", "error", err)
 
@@ -853,7 +885,18 @@ func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ct
 	}
 
 	switch {
-	case !allDefaultDatabaseSet || !allDatabasesSynced:
+	case len(nonReplicatedDefaultDatabaseIDs) > 0:
+		slices.Sort(nonReplicatedDefaultDatabaseIDs)
+		r.SetCondition(metav1.Condition{
+			Type:    v1.ClickHouseConditionTypeSchemaInSync,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1.ClickHouseConditionDefaultDatabaseNotReplicated,
+			Message: "Default database is not Replicated on replicas: " + strings.Join(nonReplicatedDefaultDatabaseIDs, ", "),
+		})
+
+		return chctrl.StepRequeue(chctrl.RequeueProbePoll), nil
+
+	case !allReplicasInitialized || !allDatabasesSynced:
 		r.SetCondition(metav1.Condition{
 			Type:    v1.ClickHouseConditionTypeSchemaInSync,
 			Status:  metav1.ConditionFalse,
@@ -882,7 +925,148 @@ func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ct
 		})
 	}
 
+	if len(drainingShards) > 0 {
+		log.Info("waiting for replicas scheduled for deletion to stop serving client traffic", "shards", slices.Sorted(maps.Keys(drainingShards)))
+
+		return chctrl.StepRequeue(chctrl.RequeueProbePoll), nil
+	}
+
 	return chctrl.StepContinue(), nil
+}
+
+// initializeReplicas marks the gated replicas as initialized to open client traffic; it reports whether all succeeded.
+func (r *clickhouseReconciler) initializeReplicas(ctx context.Context, log ctrlutil.Logger, ids []v1.ClickHouseReplicaID) bool {
+	res := ctrlutil.ExecuteParallel(ids, func(id v1.ClickHouseReplicaID) (v1.ClickHouseReplicaID, struct{}, error) {
+		state := r.ReplicaState[id]
+		if state.Initialized() {
+			return id, struct{}{}, nil
+		}
+
+		if state.Pod == nil {
+			return id, struct{}{}, errors.New("pod does not exist yet")
+		}
+
+		if err := r.UpdatePodCondition(ctx, state.Pod, corev1.PodCondition{
+			Type:               v1.ReplicaInitializedCondition,
+			LastTransitionTime: metav1.Now(),
+			Status:             corev1.ConditionTrue,
+			Reason:             v1.ReplicaInitializedReason,
+			Message:            "Replica initialization completed",
+		}); err != nil {
+			return id, struct{}{}, fmt.Errorf("update Pod status with initialized condition: %w", err)
+		}
+
+		return id, struct{}{}, nil
+	})
+
+	initialized := true
+
+	for id, repl := range res {
+		if repl.Err != nil {
+			log.Info("failed to mark replica initialized", "replica_id", id, "error", repl.Err)
+
+			initialized = false
+		}
+	}
+
+	return initialized
+}
+
+// unloadRemovedReplicas withdraws client traffic from replicas scheduled for deletion, returns the shards whose replicas are still being unpublished.
+func (r *clickhouseReconciler) unloadRemovedReplicas(ctx context.Context, log ctrlutil.Logger) map[int32]bool {
+	drainingShards := map[int32]bool{}
+	replicasToDrain := make([]v1.ClickHouseReplicaID, 0, len(r.ReplicaState))
+	removedReplicas := make([]v1.ClickHouseReplicaID, 0, len(r.ReplicaState))
+
+	for id, state := range r.ReplicaState {
+		if id.ShardID < r.Cluster.Shards() && id.Index < r.Cluster.Replicas() {
+			continue
+		}
+
+		removedReplicas = append(removedReplicas, id)
+
+		if state.Initialized() {
+			replicasToDrain = append(replicasToDrain, id)
+		}
+	}
+
+	if len(removedReplicas) == 0 {
+		return drainingShards
+	}
+
+	drainRes := ctrlutil.ExecuteParallel(replicasToDrain, func(id v1.ClickHouseReplicaID) (v1.ClickHouseReplicaID, struct{}, error) {
+		if err := r.UpdatePodCondition(ctx, r.ReplicaState[id].Pod, corev1.PodCondition{
+			Type:               v1.ReplicaInitializedCondition,
+			LastTransitionTime: metav1.Now(),
+			Status:             corev1.ConditionFalse,
+			Reason:             v1.ReplicaDeletionReason,
+			Message:            "Replica is scheduled for deletion",
+		}); err != nil {
+			return id, struct{}{}, fmt.Errorf("update Pod status with deletion condition: %w", err)
+		}
+
+		return id, struct{}{}, nil
+	})
+	for id, res := range drainRes {
+		if res.Err != nil {
+			log.Info("failed to unload client traffic from replica scheduled for deletion", "replica_id", id, "error", res.Err)
+
+			r.unsyncedShards[id.ShardID] = true
+
+			continue
+		}
+
+		drainingShards[id.ShardID] = true
+	}
+
+	return drainingShards
+}
+
+// syncShardsPendingRemoval syncs shards that are about to drop replicas and reports the replicas still running.
+func (r *clickhouseReconciler) syncShardsPendingRemoval(ctx context.Context, log ctrlutil.Logger, drainingShards map[int32]bool) map[v1.ClickHouseReplicaID]struct{} {
+	shardHasReachableReplica := map[int32]bool{}
+	for _, id := range r.reachableReplicas {
+		shardHasReachableReplica[id.ShardID] = true
+	}
+
+	// Sync only shards that are going to drop replicas partially.
+	runningReplicas := map[v1.ClickHouseReplicaID]struct{}{}
+	shardsToSyncSet := map[int32]struct{}{}
+
+	for id := range r.ReplicaState {
+		runningReplicas[id] = struct{}{}
+
+		if id.ShardID < r.Cluster.Shards() && id.Index < r.Cluster.Replicas() {
+			continue
+		}
+
+		switch {
+		case drainingShards[id.ShardID]:
+			log.Debug("replica scheduled for deletion is still serving client traffic, delaying sync", "shard", id.ShardID)
+			r.unsyncedShards[id.ShardID] = true
+		case id.ShardID >= r.Cluster.Shards():
+			// Whole shard removal drops the shard data by design, no surviving replicas to sync.
+		case shardHasReachableReplica[id.ShardID]:
+			shardsToSyncSet[id.ShardID] = struct{}{}
+		default:
+			log.Debug("no reachable replicas in shard, skipping sync", "shard", id.ShardID)
+			r.unsyncedShards[id.ShardID] = true
+		}
+	}
+
+	syncRes := ctrlutil.ExecuteParallel(slices.Collect(maps.Keys(shardsToSyncSet)), func(shardID int32) (int32, struct{}, error) {
+		log.Info("pre scale-down shard sync", "shard_id", shardID)
+		return shardID, struct{}{}, r.commander.SyncShard(ctx, log, shardID)
+	})
+
+	for id, res := range syncRes {
+		if res.Err != nil {
+			log.Info("failed to sync shard", "shard_id", id, "error", res.Err)
+			r.unsyncedShards[id] = true
+		}
+	}
+
+	return runningReplicas
 }
 
 type resourcesWithService struct {
@@ -949,7 +1133,7 @@ func (r *clickhouseReconciler) reconcileCleanUp(ctx context.Context, log ctrluti
 	for id, res := range replicasToRemove {
 		inSync := !r.unsyncedShards[id.ShardID]
 
-		// Delete StatefulSets only after the shard synced surviving replicas.
+		// Delete StatefulSets only after the shard unloaded client traffic and synced surviving replicas.
 		if res.STS != nil && !inSync {
 			log.Info("shard sync failed, skipping replica deletion", "replica_id", id)
 			continue
@@ -998,6 +1182,10 @@ func (r *clickhouseReconciler) evaluateReplicaConditions() {
 
 			if replica.StartupError != nil {
 				startupErrors[id.String()] = *replica.StartupError
+			}
+
+			if replica.Queryable() {
+				r.reachableReplicas = append(r.reachableReplicas, id)
 			}
 
 			if !replica.Ready() {

--- a/internal/controller/clickhouse/sync_test.go
+++ b/internal/controller/clickhouse/sync_test.go
@@ -46,6 +46,14 @@ var _ = Describe("UpdateStage", func() {
 		cfg := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-0-0-configmap"}}
 		ctrlutil.AddObjectConfigHash(cfg, rev.ConfigurationRevision)
 
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-0-0-0"},
+			Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}}},
+		}
+
 		return replicaState{
 			replicaProbe: replicaProbe{
 				Version:                   "26.5.1.1",
@@ -54,6 +62,7 @@ var _ = Describe("UpdateStage", func() {
 			},
 			ReplicaState: chctrl.ReplicaState{
 				ReplicaResources: chctrl.ReplicaResources{STS: sts, CFG: cfg},
+				Pod:              pod,
 			},
 		}
 	}

--- a/internal/controller/clickhouse/templates.go
+++ b/internal/controller/clickhouse/templates.go
@@ -71,15 +71,17 @@ func templateService(cr *v1.ClickHouseCluster, name string, internal bool) *core
 			Name:      name,
 			Namespace: cr.Namespace,
 			Labels: controllerutil.MergeMaps(cr.Spec.Labels, map[string]string{
-				controllerutil.LabelAppKey: cr.SpecificName(),
+				controllerutil.LabelAppKey:     cr.SpecificName(),
+				controllerutil.LabelClusterKey: cr.Name,
 			}),
 			Annotations: controllerutil.MergeMaps(cr.Spec.Annotations),
 		},
 		Spec: corev1.ServiceSpec{
 			Ports:     ports,
 			ClusterIP: corev1.ClusterIPNone,
-			// Publish not-yet-ready pod addresses so replicas can resolve and reach peers before they report Ready
-			PublishNotReadyAddresses: true,
+			// Internal Services publish not-yet-ready addresses so replicas and the operator can
+			// reach peers before they report Ready; the public Service gates client traffic on readiness.
+			PublishNotReadyAddresses: internal,
 			Selector: map[string]string{
 				controllerutil.LabelAppKey:  cr.SpecificName(),
 				controllerutil.LabelRoleKey: controllerutil.LabelClickHouseValue,
@@ -99,6 +101,7 @@ func templatePodDisruptionBudget(cr *v1.ClickHouseCluster, shardID int32) *polic
 			Namespace: cr.Namespace,
 			Labels: controllerutil.MergeMaps(cr.Spec.Labels, map[string]string{
 				controllerutil.LabelAppKey:            cr.SpecificName(),
+				controllerutil.LabelClusterKey:        cr.Name,
 				controllerutil.LabelClickHouseShardID: strconv.Itoa(int(shardID)),
 			}),
 			Annotations: controllerutil.MergeMaps(cr.Spec.Annotations),
@@ -136,7 +139,8 @@ func templateClusterSecrets(cr *v1.ClickHouseCluster, existing corev1.Secret) (c
 	secret.Name = cr.SecretName()
 	secret.Namespace = cr.Namespace
 	secret.Labels = controllerutil.MergeMaps(cr.Spec.Labels, map[string]string{
-		controllerutil.LabelAppKey: cr.SpecificName(),
+		controllerutil.LabelAppKey:     cr.SpecificName(),
+		controllerutil.LabelClusterKey: cr.Name,
 	})
 	secret.Annotations = controllerutil.MergeMaps(cr.Spec.Annotations)
 	changed := !maps.Equal(secret.Labels, existing.Labels) || !maps.Equal(secret.Annotations, existing.Annotations)
@@ -244,7 +248,8 @@ func templateConfigMap(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (*cor
 			Name:      r.Cluster.ConfigMapNameByReplicaID(id),
 			Namespace: r.Cluster.Namespace,
 			Labels: controllerutil.MergeMaps(r.Cluster.Spec.Labels, id.Labels(), map[string]string{
-				controllerutil.LabelAppKey: r.Cluster.SpecificName(),
+				controllerutil.LabelAppKey:     r.Cluster.SpecificName(),
+				controllerutil.LabelClusterKey: r.Cluster.Name,
 			}),
 			Annotations: r.Cluster.Spec.Annotations,
 		},
@@ -260,6 +265,7 @@ func templateStatefulSet(r *clickhouseReconciler, id v1.ClickHouseReplicaID, cfg
 
 	resourceLabels := controllerutil.MergeMaps(r.Cluster.Spec.Labels, id.Labels(), map[string]string{
 		controllerutil.LabelAppKey:         r.Cluster.SpecificName(),
+		controllerutil.LabelClusterKey:     r.Cluster.Name,
 		controllerutil.LabelInstanceK8sKey: r.Cluster.SpecificName(),
 		controllerutil.LabelRoleKey:        controllerutil.LabelClickHouseValue,
 		controllerutil.LabelAppK8sKey:      controllerutil.LabelClickHouseValue,
@@ -366,6 +372,9 @@ func templatePodSpec(r *clickhouseReconciler, id v1.ClickHouseReplicaID) (corev1
 		Volumes:         volumes,
 		Containers:      []corev1.Container{container},
 		SecurityContext: controller.DefaultPodSecurityContext(),
+		ReadinessGates: []corev1.PodReadinessGate{{
+			ConditionType: v1.ReplicaInitializedCondition,
+		}},
 	}
 
 	if cr.Spec.PodTemplate.TopologyZoneKey != nil && *cr.Spec.PodTemplate.TopologyZoneKey != "" {

--- a/internal/controller/clickhouse/templates_test.go
+++ b/internal/controller/clickhouse/templates_test.go
@@ -360,6 +360,26 @@ var _ = Describe("Service templates", func() {
 		},
 	}
 
+	It("should expose client ports through the public headless service and gate them on readiness", func() {
+		service := templateHeadlessService(cr)
+
+		ports := map[string]int32{}
+		for _, port := range service.Spec.Ports {
+			ports[port.Name] = port.Port
+		}
+
+		Expect(service.Name).To(Equal(cr.HeadlessServiceName()))
+		Expect(service.Spec.PublishNotReadyAddresses).To(BeFalse())
+		Expect(service.Spec.Selector).To(SatisfyAll(
+			HaveKeyWithValue(controllerutil.LabelAppKey, cr.SpecificName()),
+			HaveKeyWithValue(controllerutil.LabelRoleKey, controllerutil.LabelClickHouseValue),
+		))
+		Expect(ports).To(HaveKeyWithValue(protocolTypeTCP, int32(PortNative)))
+		Expect(ports).To(HaveKeyWithValue(protocolTypeHTTP, int32(PortHTTP)))
+		Expect(ports).To(HaveKeyWithValue(protocolTypePrometheus, int32(PortPrometheusScrape)))
+		Expect(ports).To(HaveKeyWithValue("extra", int32(19000)))
+	})
+
 	It("should expose internal ports through a per-replica internal service", func() {
 		id := v1.ClickHouseReplicaID{ShardID: 0, Index: 1}
 		service := templateInternalService(cr, id)
@@ -373,6 +393,7 @@ var _ = Describe("Service templates", func() {
 		Expect(service.Spec.ClusterIP).To(Equal(corev1.ClusterIPNone))
 		Expect(service.Spec.PublishNotReadyAddresses).To(BeTrue())
 		Expect(service.Labels).To(SatisfyAll(
+			HaveKeyWithValue(controllerutil.LabelClusterKey, cr.Name),
 			HaveKeyWithValue(controllerutil.LabelClickHouseShardID, "0"),
 			HaveKeyWithValue(controllerutil.LabelClickHouseReplicaID, "1"),
 		))
@@ -398,6 +419,22 @@ var _ = Describe("Service templates", func() {
 		sts, err := templateStatefulSet(r, v1.ClickHouseReplicaID{}, "fixed-cfg-rev")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sts.Spec.ServiceName).To(Equal(cr.HeadlessServiceName()))
+	})
+
+	It("should always add the initialization readiness gate", func() {
+		gate := corev1.PodReadinessGate{ConditionType: v1.ReplicaInitializedCondition}
+
+		sts, err := templateStatefulSet(&clickhouseReconciler{Cluster: cr}, v1.ClickHouseReplicaID{}, "fixed-cfg-rev")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sts.Spec.Template.Spec.ReadinessGates).To(ContainElement(gate))
+
+		// The gate must survive disabling database sync, or the pods would never become Ready.
+		disabled := cr.DeepCopy()
+		disabled.Spec.Settings.EnableDatabaseSync = new(false)
+
+		sts, err = templateStatefulSet(&clickhouseReconciler{Cluster: disabled}, v1.ClickHouseReplicaID{}, "fixed-cfg-rev")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sts.Spec.Template.Spec.ReadinessGates).To(ContainElement(gate))
 	})
 
 	It("should expose secure user ports only through the public headless service", func() {

--- a/internal/controller/resourcemanager.go
+++ b/internal/controller/resourcemanager.go
@@ -211,6 +211,61 @@ func (rm *ResourceManager) Delete(ctx context.Context, resource client.Object, a
 	return nil
 }
 
+// UpdatePodCondition patches a condition in the Pod status.
+func (rm *ResourceManager) UpdatePodCondition(ctx context.Context, pod *corev1.Pod, cond corev1.PodCondition) error {
+	cli := rm.ctrl.GetClient()
+	key := client.ObjectKeyFromObject(pod)
+	uid := pod.GetUID()
+	first := true
+
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if !first {
+			if err := cli.Get(ctx, key, pod); err != nil {
+				if k8serrors.IsNotFound(err) {
+					return nil
+				}
+
+				return fmt.Errorf("get pod %q: %w", key, err)
+			}
+
+			// Pod is changed or terminating, canceling
+			if uid != pod.UID || !pod.DeletionTimestamp.IsZero() {
+				return nil
+			}
+		}
+
+		before := pod.DeepCopy()
+		first = false
+		found := false
+
+		for i := range pod.Status.Conditions {
+			if pod.Status.Conditions[i].Type != cond.Type {
+				continue
+			}
+
+			if pod.Status.Conditions[i].Status == cond.Status {
+				return nil
+			}
+
+			pod.Status.Conditions[i] = cond
+			found = true
+
+			break
+		}
+
+		if !found {
+			pod.Status.Conditions = append(pod.Status.Conditions, cond)
+		}
+
+		return cli.Status().Patch(ctx, pod, client.StrategicMergeFrom(before, client.MergeFromWithOptimisticLock{}))
+	})
+	if err != nil {
+		return fmt.Errorf("update pod %q condition: %w", key, err)
+	}
+
+	return nil
+}
+
 // ReplicaUpdateInput contains the parameters needed to reconcile a StatefulSet for a replica.
 type ReplicaUpdateInput struct {
 	Revisions RevisionState
@@ -386,4 +441,19 @@ func ListReplicaResources[
 	}
 
 	return result, nil
+}
+
+// PodConditionTrue reports whether the Pod condition is true.
+func PodConditionTrue(pod *corev1.Pod, conditionType corev1.PodConditionType) bool {
+	if pod == nil {
+		return false
+	}
+
+	for _, c := range pod.Status.Conditions {
+		if c.Type == conditionType {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
 }

--- a/internal/controller/versionprobe.go
+++ b/internal/controller/versionprobe.go
@@ -310,8 +310,9 @@ func (rm *ResourceManager) buildVersionProbeJob(cfg VersionProbeConfig, revision
 
 	// Set reserved labels after overrides to ensure they are not modified by user overrides.
 	job.Labels = controllerutil.MergeMaps(job.Labels, map[string]string{
-		controllerutil.LabelAppKey:  rm.owner.SpecificName(),
-		controllerutil.LabelRoleKey: controllerutil.LabelVersionProbe,
+		controllerutil.LabelAppKey:     rm.owner.SpecificName(),
+		controllerutil.LabelClusterKey: rm.owner.GetName(),
+		controllerutil.LabelRoleKey:    controllerutil.LabelVersionProbe,
 	})
 
 	specHash, err := controllerutil.DeepHashObject(job.Spec)

--- a/internal/controllerutil/labels.go
+++ b/internal/controllerutil/labels.go
@@ -15,6 +15,7 @@ const (
 	LabelInstanceK8sKey = "app.kubernetes.io/instance"
 
 	LabelRoleKey             = "clickhouse.com/role"
+	LabelClusterKey          = "clickhouse.com/cluster"
 	LabelKeeperReplicaID     = "clickhouse.com/keeper-replica-id"
 	LabelClickHouseShardID   = "clickhouse.com/shard-id"
 	LabelClickHouseReplicaID = "clickhouse.com/replica-id"

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
 	"github.com/ClickHouse/clickhouse-operator/internal"
+	ctrl "github.com/ClickHouse/clickhouse-operator/internal/controller"
 	chctrl "github.com/ClickHouse/clickhouse-operator/internal/controller/clickhouse"
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
 	"github.com/ClickHouse/clickhouse-operator/test/testutil"
@@ -91,7 +92,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute)
 			ClickHouseRWChecks(ctx, &cr, &checks)
 
 			By("updating cluster CR")
@@ -100,7 +101,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			cr.Spec = specUpdate
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute, true)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute, validateUpdateOrder)
 			ExpectWithOffset(1, k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
 			Expect(cr.Status.Version).To(HavePrefix(cr.Spec.ContainerTemplate.Image.Tag))
 			ClickHouseRWChecks(ctx, &cr, &checks)
@@ -148,7 +149,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 			ClickHouseRWChecks(ctx, &cr, &checks)
 
 			By("updating cluster CR")
@@ -157,7 +158,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			cr.Spec = specUpdate
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 5*time.Minute, true)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 5*time.Minute, validateUpdateOrder)
 			ClickHouseRWChecks(ctx, &cr, &checks)
 		},
 			Entry("update log level", 3, v1.ClickHouseClusterSpec{Settings: v1.ClickHouseSettings{
@@ -198,7 +199,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 
 			By("creating enough tables to exceed max_table_num_to_warn")
 
@@ -250,6 +251,88 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			}).WithPolling(pollingInterval).WithTimeout(2 * time.Minute).Should(Succeed())
 		})
 
+		It("controls Pod readiness gate to allow client traffic only for initialized replicas", func(ctx context.Context) {
+			cr := v1.ClickHouseCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+					Name:      fmt.Sprintf("gate-%d", time.Now().UnixNano()),
+				},
+				Spec: v1.ClickHouseClusterSpec{
+					Replicas: new(int32(2)),
+					ContainerTemplate: v1.ContainerTemplateSpec{
+						Image: v1.ContainerImage{Tag: BaseVersion},
+					},
+					DataVolumeClaimSpec: &defaultStorage,
+					KeeperClusterRef:    v1.KeeperClusterReference{Name: keeper.Name},
+				},
+			}
+
+			By("creating cluster CR")
+			Expect(k8sClient.Create(ctx, &cr)).To(Succeed())
+			DeferCleanup(func(ctx context.Context) {
+				By("deleting cluster CR")
+				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
+			})
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, validateReadyIsInitialized)
+
+			survivor, removed := v1.ClickHouseReplicaID{Index: 0}, v1.ClickHouseReplicaID{Index: 1}
+
+			By("creating unreplicated test data", func() {
+				chClient, err := testutil.NewClickHouseClient(ctx, podDialer, &cr)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer chClient.Close()
+
+				Expect(chClient.Exec(ctx, "CREATE TABLE default.test (a Int) Engine=ReplicatedMergeTree")).To(Succeed())
+				Expect(chClient.ExecReplica(ctx, survivor, "SYSTEM STOP FETCHES default.test")).To(Succeed())
+				Expect(chClient.ExecReplica(ctx, removed,
+					"INSERT INTO default.test SELECT number FROM numbers(1000)")).To(Succeed())
+
+				var survivorRows uint64
+				Expect(chClient.QueryRowReplica(ctx, survivor, "SELECT count() FROM default.test", &survivorRows)).To(Succeed())
+				Expect(survivorRows).To(Equal(uint64(0)))
+			})
+
+			By("scheduling replica 1 deletion", func() {
+				Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
+				*cr.Spec.Replicas = 1
+				Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
+			})
+
+			By("ensuring replica 1 is unpublished, but not removed", func() {
+				var (
+					pod    corev1.Pod
+					podUID types.UID
+					podKey = types.NamespacedName{Namespace: ns, Name: cr.StatefulSetNameByReplicaID(removed) + "-0"}
+				)
+
+				Eventually(func(g Gomega) {
+					Expect(k8sClient.Get(ctx, podKey, &pod)).To(Succeed())
+					g.Expect(ctrl.PodConditionTrue(&pod, v1.ReplicaInitializedCondition)).To(BeFalse())
+					podUID = pod.UID
+				}).WithPolling(pollingInterval).WithTimeout(time.Minute).Should(Succeed())
+
+				Consistently(func(g Gomega) {
+					Expect(k8sClient.Get(ctx, podKey, &pod)).To(Succeed())
+					g.Expect(pod.UID).To(Equal(podUID))
+				}).WithPolling(pollingInterval).WithTimeout(20 * time.Second).Should(Succeed())
+			})
+
+			By("ensuring replica 1 is deleted, after replication is enabled", func() {
+				chClient, err := testutil.NewClickHouseClient(ctx, podDialer, &cr)
+				Expect(err).NotTo(HaveOccurred())
+
+				defer chClient.Close()
+
+				Expect(chClient.ExecReplica(ctx, survivor, "SYSTEM START FETCHES default.test")).To(Succeed())
+				WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, validateUpdateOrder, validateReadyIsInitialized)
+
+				var survivorRows uint64
+				Expect(chClient.QueryRowReplica(ctx, survivor, "SELECT count() FROM default.test", &survivorRows)).To(Succeed())
+				Expect(survivorRows).To(Equal(uint64(1000)))
+			})
+		})
+
 		It("should work with custom data folder mount", func(ctx context.Context) {
 			cr := v1.ClickHouseCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -289,7 +372,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 			ClickHouseRWChecks(ctx, &cr, new(0))
 		})
 
@@ -333,7 +416,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 
 			cr.Spec.ContainerTemplate.Env = nil
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, true)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 			ClickHouseRWChecks(ctx, &cr, new(0))
 		})
 
@@ -386,7 +469,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute)
 
 			By("recording initial PVC sizes")
 
@@ -410,7 +493,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
 			cr.Spec.DataVolumeClaimSpec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("2Gi")
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute)
 
 			Expect(k8sClient.List(ctx, &pvcs, listOpts...)).To(Succeed())
 			Expect(pvcs.Items).To(HaveLen(int(cr.Replicas())), "expected one PVC per replica")
@@ -495,7 +578,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 			ClickHouseRWChecks(ctx, &cr, &checks)
 			verifyDisks(resource.MustParse("1Gi"))
 
@@ -509,7 +592,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			cr.Spec.AdditionalVolumeClaimTemplates[1].Spec = diskSpec
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 			ClickHouseRWChecks(ctx, &cr, &checks)
 			verifyDisks(resource.MustParse("2Gi"))
 		})
@@ -534,7 +617,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 
 			chClient, err := testutil.NewClickHouseClient(ctx, podDialer, &cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -612,7 +695,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
 
 			checks := 0
 
@@ -751,7 +834,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
 
 			By("checking custom user access works")
 			ClickHouseRWChecks(ctx, cr, new(0), auth)
@@ -811,7 +894,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, cr, 3*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, cr, 3*time.Minute)
 
 			By("asserting the headless Service carries the user-declared port")
 			Expect(k8sClient.Get(ctx, cr.NamespacedName(), cr)).To(Succeed())
@@ -890,7 +973,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, &ch)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &ch, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &ch, 2*time.Minute)
 
 			chClient, err := testutil.NewClickHouseClient(ctx, podDialer, &ch, clickhouse.Auth{
 				Username: "default",
@@ -961,7 +1044,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute)
 
 			By("verifying named collections secret key exists")
 
@@ -1070,7 +1153,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			})
 
 			By("waiting for cluster to become ready")
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 			ClickHouseRWChecks(ctx, &cr, new(0))
 
 			By("verifying ExternalSecretValid=True")
@@ -1110,7 +1193,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				DeferCleanup(func(ctx context.Context) {
 					Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 				})
-				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute, false)
+				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute)
 				ClickHouseRWChecks(ctx, &cr, &checks)
 			})
 
@@ -1126,7 +1209,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				))
 				Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2, false)
+				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2)
 
 				Expect(podUIDsByName(ctx, &cr)).To(Equal(uidBefore), "pod was restarted (UID changed)")
 				ClickHouseRWChecks(ctx, &cr, &checks)
@@ -1142,7 +1225,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				*cr.Spec.Replicas = 2
 				Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2, false)
+				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2)
 				ClickHouseRWChecks(ctx, &cr, &checks)
 				uidAfter := podUIDsByName(ctx, &cr)
 
@@ -1328,7 +1411,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute, false)
+			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
 			ClickHouseRWChecks(ctx, cr, &checks)
 		})
 
@@ -1342,7 +1425,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			}
 			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 
-			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute, true)
+			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute, validateUpdateOrder)
 			ClickHouseRWChecks(ctx, cr, &checks)
 		})
 	})
@@ -1438,7 +1521,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 		DeferCleanup(func(ctx context.Context) {
 			Expect(k8sClient.Delete(ctx, &cluster)).To(Succeed())
 		})
-		WaitClickHouseUpdatedAndReady(ctx, &cluster, 2*time.Minute, false)
+		WaitClickHouseUpdatedAndReady(ctx, &cluster, 2*time.Minute)
 
 		By("checking clickhouse pod affinity")
 
@@ -1463,11 +1546,15 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 	})
 })
 
+// validator checks invariants on every polling tick of WaitClickHouseUpdatedAndReady: violations fail hard (Expect).
+// Non-informative errors are skipped.
+type validator func(ctx context.Context, cr *v1.ClickHouseCluster)
+
 func WaitClickHouseUpdatedAndReady(
 	ctx context.Context,
 	cr *v1.ClickHouseCluster,
 	timeout time.Duration,
-	isUpdate bool,
+	validators ...validator,
 ) {
 	By(fmt.Sprintf("waiting for cluster %s to be ready", cr.Name))
 	EventuallyWithOffset(1, func(g Gomega) {
@@ -1475,23 +1562,22 @@ func WaitClickHouseUpdatedAndReady(
 		g.Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
 		g.Expect(cluster.Generation).To(Equal(cluster.Status.ObservedGeneration))
 
-		if isUpdate {
-			for shard := range cluster.Shards() {
-				// Intentional global assertion to fail suite if update order is wrong.
-				Expect(CheckUpdateOrder(ctx, &client.ListOptions{
-					Namespace: cluster.Namespace,
-					LabelSelector: labels.SelectorFromSet(map[string]string{
-						controllerutil.LabelAppKey:            cluster.SpecificName(),
-						controllerutil.LabelClickHouseShardID: strconv.FormatInt(int64(shard), 10),
-					}),
-				}, controllerutil.LabelClickHouseReplicaID, cluster.Status.StatefulSetRevision)).To(Succeed())
-			}
+		for _, val := range validators {
+			val(ctx, &cluster)
 		}
+
+		count := int(cr.Replicas() * cr.Shards())
 
 		g.Expect(cluster.Status.CurrentRevision).
 			To(Equal(cluster.Status.UpdateRevision), "rollout should eventually complete")
 		g.Expect(cluster.Status.ReadyReplicas).
-			To(Equal(cluster.Replicas()*cluster.Shards()), "all replicas should be ready")
+			To(BeEquivalentTo(count), "all replicas should be ready")
+
+		var pods corev1.PodList
+		Expect(k8sClient.List(ctx, &pods, client.InNamespace(cr.Namespace), client.MatchingLabels{
+			controllerutil.LabelAppKey: cr.SpecificName(),
+		})).To(Succeed())
+		Expect(pods.Items).To(HaveLen(count))
 
 		for _, conditionType := range []v1.ConditionType{
 			v1.ConditionTypeReady,
@@ -1507,21 +1593,11 @@ func WaitClickHouseUpdatedAndReady(
 				fmt.Sprintf("condition %s is false: %s", cond.Type, cond.Message),
 			)
 		}
-	}, timeout).WithPolling(pollingInterval).Should(Succeed())
-	// Needed for replica deletion to not forward deleting pods.
-	By(fmt.Sprintf("waiting for cluster %s replicas count match", cr.Name))
-	count := int(cr.Replicas() * cr.Shards())
-	WaitReplicaCount(ctx, k8sClient, cr.Namespace, cr.SpecificName(), count)
-	By(fmt.Sprintf("waiting for cluster %s all replicas ready", cr.Name))
-	EventuallyWithOffset(1, func(g Gomega) {
-		var pods corev1.PodList
-		g.Expect(k8sClient.List(ctx, &pods, client.InNamespace(cr.Namespace),
-			client.MatchingLabels{controllerutil.LabelAppKey: cr.SpecificName()})).To(Succeed())
 
 		for _, pod := range pods.Items {
 			g.Expect(CheckPodReady(&pod)).To(BeTrue(), fmt.Sprintf("pod %s is not ready", pod.Name))
 		}
-	}).WithPolling(pollingInterval).Should(Succeed())
+	}, timeout).WithPolling(pollingInterval).Should(Succeed())
 }
 
 func ClickHouseRWChecks(ctx context.Context, cr *v1.ClickHouseCluster, checksDone *int, auth ...clickhouse.Auth) {
@@ -1563,4 +1639,64 @@ func podUIDsByName(ctx context.Context, cr *v1.ClickHouseCluster) map[string]typ
 	}
 
 	return out
+}
+
+func validateUpdateOrder(ctx context.Context, cr *v1.ClickHouseCluster) {
+	// CheckUpdateOrder returns an error only for update-order invariant violations: fail hard.
+	for shard := range cr.Shards() {
+		Expect(CheckUpdateOrder(ctx, &client.ListOptions{
+			Namespace: cr.Namespace,
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				controllerutil.LabelAppKey:            cr.SpecificName(),
+				controllerutil.LabelClickHouseShardID: strconv.FormatInt(int64(shard), 10),
+			}),
+		}, controllerutil.LabelClickHouseReplicaID, cr.Status.StatefulSetRevision)).To(Succeed())
+	}
+}
+
+func validateReadyIsInitialized(ctx context.Context, cr *v1.ClickHouseCluster) {
+	pods := corev1.PodList{}
+	if err := k8sClient.List(ctx, &pods, client.InNamespace(cr.Namespace), client.MatchingLabels{
+		controllerutil.LabelAppKey: cr.SpecificName(),
+	}); err != nil {
+		GinkgoWriter.Printf("validateReadyIsInitialized: skipping tick, list Pods: %s\n", err)
+		return
+	}
+
+	initialized := make([]v1.ClickHouseReplicaID, 0, len(pods.Items))
+
+	for _, pod := range pods.Items {
+		if !ctrl.PodConditionTrue(&pod, v1.ReplicaInitializedCondition) {
+			continue
+		}
+
+		id, err := v1.ClickHouseIDFromLabels(pod.Labels)
+		Expect(err).NotTo(HaveOccurred())
+
+		initialized = append(initialized, id)
+	}
+
+	if len(initialized) == 0 {
+		return
+	}
+
+	// The client pings every replica, which fails while Pods are still being provisioned: skip the tick.
+	chClient, err := testutil.NewClickHouseClient(ctx, podDialer, cr)
+	if err != nil {
+		GinkgoWriter.Printf("validateReadyIsInitialized: skipping tick, connect: %s\n", err)
+		return
+	}
+
+	defer chClient.Close()
+
+	for _, id := range initialized {
+		var isReplicated bool
+		if err := chClient.QueryRowReplica(ctx, id,
+			"SELECT engine='Replicated' FROM system.databases WHERE name='default'", &isReplicated); err != nil {
+			GinkgoWriter.Printf("validateReadyIsInitialized: skipping replica %s: %s\n", id, err)
+			continue
+		}
+
+		Expect(isReplicated).To(BeTrue(), "replica should not be ready until it initialized")
+	}
 }


### PR DESCRIPTION
## Why

- Replicas are user-queriable before the operator initializes them
- Replicas may need time to replicate all data before deletion

## What

Add a Pod readiness gate based on the operator-managed condition.

## Related Issues

Fixes #266
