### PR TITLE
chore: add role label to operator manager pods

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: clickhouse-operator
+        clickhouse.com/role: operator
     spec:
       affinity:
         nodeAffinity:

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -50,9 +50,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         control-plane: controller-manager
+        clickhouse.com/role: operator
         {{- with .Values.manager.pod }}
         {{- with .labels }}
-        {{- with omit . "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "app.kubernetes.io/managed-by" "control-plane" }}
+        {{- with omit . "app.kubernetes.io/name" "helm.sh/chart" "app.kubernetes.io/instance" "app.kubernetes.io/managed-by" "control-plane" "clickhouse.com/role" }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- end }}

--- a/internal/controllerutil/labels.go
+++ b/internal/controllerutil/labels.go
@@ -27,6 +27,7 @@ const (
 	LabelKeeperAllReplicas = "all-replicas"
 	LabelClickHouseValue   = "clickhouse-server"
 	LabelVersionProbe      = "version-probe"
+	LabelOperatorValue     = "operator"
 )
 
 // DiskLabel returns the label set identifying a disk's volumeClaimTemplate/PVC by name.


### PR DESCRIPTION
## Why

Prerequisite for network policies support, need a stable label to create a network policy that allows operator Pods access to cluster replicas.

## What

Add a new label `clickhouse.com/role: operator` to operator Pods
