### PR TITLE
test: upgrade CH versions in tests, ensure e2e tests use pinned/prepulled images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,23 +276,23 @@ jobs:
         include:
           - name: minimal-k8s-all-deploy-methods
             k8s_image: v1.28.15
-            clickhouse_version: "26.6.2.81"
+            clickhouse_version: "26.7.5.10"
             deploy_target: test-compat-e2e
           - name: maximal-k8s-all-deploy-methods
             k8s_image: v1.36.1
-            clickhouse_version: "26.6.2.81"
+            clickhouse_version: "26.7.5.10"
             deploy_target: test-compat-e2e
           - name: olm-deploy-method
             k8s_image: v1.28.15
-            clickhouse_version: "26.6.2.81"
+            clickhouse_version: "26.7.5.10"
             deploy_target: test-compat-e2e-olm
           - name: supported-clickhouse-compatibility
             k8s_image: v1.30.13
-            clickhouse_version: "26.6.2.81-distroless,26.5.5.8,26.4.5.143,26.3.17.56,25.8.28.1"
+            clickhouse_version: "26.7.5.10-distroless,26.6.3.62,26.5.7.64,26.3.21.7,25.8.32.4"
             deploy_target: test-compat-e2e-manifest
           - name: operator-upgrade
             k8s_image: v1.30.13
-            clickhouse_version: "26.6.2.81"
+            clickhouse_version: "26.7.5.10"
             deploy_target: test-compat-e2e-upgrade
     steps:
       - name: Checkout code

--- a/internal/controller/clickhouse/commands_test.go
+++ b/internal/controller/clickhouse/commands_test.go
@@ -31,8 +31,8 @@ const (
 	keeperHostname                 = "test-keeper"
 	clickhouseHostnameFormat       = "test-clickhouse-0-%d-0"
 	testPassword                   = "test-password"
-	keeperImage                    = "clickhouse/clickhouse-keeper:26.6.2.81"
-	clickhouseImage                = "clickhouse/clickhouse-server:26.6.2.81"
+	keeperImage                    = "clickhouse/clickhouse-keeper:26.7.5.10"
+	clickhouseImage                = "clickhouse/clickhouse-server:26.7.5.10"
 	testConfigRevision             = "test-revision-v1"
 )
 

--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -132,7 +132,7 @@ var _ = JustAfterEach(func(ctx context.Context) {
 	testutil.DumpNamespaceDiagnostics(ctx, config, k8sClient, ns, reportDir)
 })
 
-var _ = Describe("Manifests deployment", Ordered, Label("manifest"), func() {
+var _ = Describe("Manifests deployment", Ordered, ContinueOnFailure, Label("manifest"), func() {
 	namespace := "clickhouse-operator-system"
 
 	BeforeAll(func(ctx context.Context) {
@@ -161,7 +161,7 @@ var _ = Describe("Manifests deployment", Ordered, Label("manifest"), func() {
 	testDeployment(namespace)
 })
 
-var _ = Describe("OLM deployment", Ordered, Label("olm"), func() {
+var _ = Describe("OLM deployment", Ordered, ContinueOnFailure, Label("olm"), func() {
 	namespace := "clickhouse-operator-olm"
 
 	BeforeAll(func(ctx context.Context) {
@@ -258,7 +258,7 @@ var _ = Describe("OLM deployment", Ordered, Label("olm"), func() {
 	testDeployment(namespace)
 })
 
-var _ = Describe("Helm deployment", Ordered, Label("helm"), func() {
+var _ = Describe("Helm deployment", Ordered, ContinueOnFailure, Label("helm"), func() {
 	DescribeTableSubtree("with", func(name string, values map[string]any) {
 		namespace := "clickhouse-operator-" + name
 		BeforeAll(func(ctx context.Context) {
@@ -343,7 +343,7 @@ spec:
 	)
 })
 
-var _ = Describe("Operator upgrade", Ordered, Label("upgrade"), func() {
+var _ = Describe("Operator upgrade", Ordered, ContinueOnFailure, Label("upgrade"), func() {
 	const (
 		namespace      = "clickhouse-operator-upgrade"
 		releaseName    = namespace

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -55,6 +55,9 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 					// Use standalone keeper for ClickHouse tests to save resources in CI
 					Replicas:            new(int32(1)),
 					DataVolumeClaimSpec: &defaultStorage,
+					ContainerTemplate: v1.ContainerTemplateSpec{
+						Image: v1.ContainerImage{Tag: BaseVersion},
+					},
 				},
 			}
 			Expect(k8sClient.Create(ctx, &keeper)).To(Succeed())
@@ -1467,6 +1470,9 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			Spec: v1.KeeperClusterSpec{
 				Replicas:            new(int32(3)),
 				DataVolumeClaimSpec: &defaultStorage,
+				ContainerTemplate: v1.ContainerTemplateSpec{
+					Image: v1.ContainerImage{Tag: BaseVersion},
+				},
 				PodTemplate: v1.PodTemplateSpec{
 					TopologyZoneKey: new("topology.kubernetes.io/zone"),
 					NodeHostnameKey: new("kubernetes.io/hostname"),
@@ -1509,6 +1515,9 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				DataVolumeClaimSpec: &defaultStorage,
 				KeeperClusterRef: v1.KeeperClusterReference{
 					Name: keeperName,
+				},
+				ContainerTemplate: v1.ContainerTemplateSpec{
+					Image: v1.ContainerImage{Tag: BaseVersion},
 				},
 				PodTemplate: v1.PodTemplateSpec{
 					TopologyZoneKey: new("topology.kubernetes.io/zone"),

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -27,6 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -47,12 +48,12 @@ const (
 
 var releases = map[string][]upgrade.ClickHouseVersion{
 	upgrade.ChannelStable: {
-		{Major: 26, Minor: 6, Patch: 2, Build: 81},
-		{Major: 26, Minor: 5, Patch: 5, Build: 8},
+		{Major: 26, Minor: 7, Patch: 5, Build: 10},
+		{Major: 26, Minor: 6, Patch: 3, Build: 62},
 	},
 	upgrade.ChannelLTS: {
-		{Major: 26, Minor: 3, Patch: 17, Build: 56},
-		{Major: 25, Minor: 8, Patch: 28, Build: 1},
+		{Major: 26, Minor: 3, Patch: 21, Build: 7},
+		{Major: 25, Minor: 8, Patch: 32, Build: 4},
 	},
 }
 
@@ -170,10 +171,14 @@ var _ = BeforeSuite(func(ctx context.Context) {
 
 	// +kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(config, client.Options{
+	baseClient, err := client.NewWithWatch(config, client.Options{
 		Scheme: scheme.Scheme,
 	})
 	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient = interceptor.NewClient(baseClient, interceptor.Funcs{
+		Create: requireExplicitImageTag,
+	})
 
 	By("pre-loading clickhouse images into kind")
 
@@ -250,6 +255,27 @@ var _ = JustAfterEach(func(ctx context.Context) {
 
 	testutil.DumpNamespaceDiagnostics(ctx, config, k8sClient, testNamespace(ctx), "report")
 })
+
+func requireExplicitImageTag(
+	ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.CreateOption,
+) error {
+	switch cr := obj.(type) {
+	case *clickhousecomv1alpha1.ClickHouseCluster:
+		if cr.Spec.ContainerTemplate.Image.Tag == "" {
+			return fmt.Errorf("refusing to create ClickHouseCluster %q without an explicit image tag", cr.Name)
+		}
+	case *clickhousecomv1alpha1.KeeperCluster:
+		if cr.Spec.ContainerTemplate.Image.Tag == "" {
+			return fmt.Errorf("refusing to create KeeperCluster %q without an explicit image tag", cr.Name)
+		}
+	}
+
+	if err := cli.Create(ctx, obj, opts...); err != nil {
+		return fmt.Errorf("create %T: %w", obj, err)
+	}
+
+	return nil
+}
 
 func WaitReplicaCount(ctx context.Context, k8sClient client.Client, namespace, app string, replicas int) {
 	Eventually(func() int {

--- a/test/e2e/keeper_e2e_test.go
+++ b/test/e2e/keeper_e2e_test.go
@@ -268,6 +268,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 				ContainerTemplate: v1.ContainerTemplateSpec{
 					Image: v1.ContainerImage{
 						Repository: "invalid",
+						Tag:        BaseVersion,
 					},
 				},
 			},

--- a/test/testutil/utils.go
+++ b/test/testutil/utils.go
@@ -43,8 +43,8 @@ const (
 	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 
 	logTailLines  = 10
-	BaseVersion   = "26.3.17.56"
-	UpdateVersion = "26.6.2.81"
+	BaseVersion   = "26.3.21.7"
+	UpdateVersion = "26.7.5.10"
 )
 
 var (


### PR DESCRIPTION
## Why

Regular test versions upgrade.
Some e2e tests used the default `latest` image tag, which resulted in timeouts and unstable CI.

## What

Upgrade ClickHouse versions used in tests, and add a k8s client interceptor in tests to ensure all tests use pinned versions.
Add `ContinueOnFailure` for compatibility tests to distinguish generic failure from a single version issue.