### PR TITLE
test: unify e2e utils across e2e/deployment/openshift tests

### DIFF
--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	. "github.com/onsi/ginkgo/v2"
@@ -21,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 
@@ -46,7 +46,7 @@ var (
 	//go:embed olm_manifests.yaml.tmpl
 	olmManifests string
 
-	config               *rest.Config
+	env                  *testutil.Env
 	k8sClient            client.Client
 	currentTestNamespace string
 	versionEntries       []any
@@ -98,9 +98,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 
 	kubeconfig := filepath.Join(homedir.HomeDir(), ".kube", "config")
 
-	var err error
-
-	config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	Expect(err).NotTo(HaveOccurred())
 
 	dc, err := discovery.NewDiscoveryClientForConfig(config)
@@ -118,6 +116,8 @@ var _ = BeforeSuite(func(ctx context.Context) {
 		Scheme: scheme.Scheme,
 	})
 	Expect(err).NotTo(HaveOccurred())
+
+	env = &testutil.Env{Client: k8sClient, Config: config, Dialer: testutil.NewPortForwardDialer(config)}
 })
 
 var _ = JustAfterEach(func(ctx context.Context) {
@@ -129,7 +129,7 @@ var _ = JustAfterEach(func(ctx context.Context) {
 	ns := currentTestNamespace
 	currentTestNamespace = ""
 
-	testutil.DumpNamespaceDiagnostics(ctx, config, k8sClient, ns, reportDir)
+	testutil.DumpNamespaceDiagnostics(ctx, env, ns, reportDir)
 })
 
 var _ = Describe("Manifests deployment", Ordered, ContinueOnFailure, Label("manifest"), func() {
@@ -151,11 +151,7 @@ var _ = Describe("Manifests deployment", Ordered, ContinueOnFailure, Label("mani
 		})
 
 		By("Waiting controller to be ready")
-		Eventually(func(g Gomega) {
-			out, err := testutil.Run(exec.CommandContext(ctx, "kubectl", "wait", "-n", namespace,
-				"--timeout=120s", "--for=condition=Available", "deployment/clickhouse-operator-controller-manager"))
-			g.Expect(err).ToNot(HaveOccurred(), string(out))
-		}, "2m", "100ms").Should(Succeed())
+		env.WaitDeploymentAvailable(ctx, namespace, "clickhouse-operator-controller-manager", 2*time.Minute)
 	})
 
 	testDeployment(namespace)
@@ -189,7 +185,7 @@ var _ = Describe("OLM deployment", Ordered, ContinueOnFailure, Label("olm"), fun
 		})
 
 		By("creating test namespace")
-		testutil.EnsureNamespace(ctx, k8sClient, namespace)
+		testutil.EnsureNamespace(ctx, env, namespace)
 
 		// Enforce upstream Pod Security Admission at "restricted" level on the OLM test namespace.
 		By("labeling test namespace with PSA enforce=restricted")
@@ -236,8 +232,11 @@ var _ = Describe("OLM deployment", Ordered, ContinueOnFailure, Label("olm"), fun
 		})
 
 		By("waiting for catalog server to be ready")
-		Expect(testutil.MustRun(ctx, "kubectl", "wait", "-n", namespace, "--timeout=120s",
-			"--for=condition=Ready", "pod/test-catalog-server")).To(Succeed())
+		Eventually(func(g Gomega) {
+			var pod corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: "test-catalog-server"}, &pod)).To(Succeed())
+			g.Expect(testutil.CheckPodReady(&pod)).To(BeTrue())
+		}, "2m", testutil.PollInterval).Should(Succeed())
 
 		By("waiting for ClusterServiceVersion to succeed")
 		Eventually(func(g Gomega) {
@@ -248,11 +247,7 @@ var _ = Describe("OLM deployment", Ordered, ContinueOnFailure, Label("olm"), fun
 		}, "5m", "5s").Should(Succeed())
 
 		By("Waiting controller to be ready")
-		Eventually(func(g Gomega) {
-			out, err := testutil.Run(exec.CommandContext(ctx, "kubectl", "wait", "-n", namespace,
-				"--timeout=120s", "--for=condition=Available", "deployment/clickhouse-operator-controller-manager"))
-			g.Expect(err).ToNot(HaveOccurred(), string(out))
-		}, "2m", "100ms").Should(Succeed())
+		env.WaitDeploymentAvailable(ctx, namespace, "clickhouse-operator-controller-manager", 2*time.Minute)
 	})
 
 	testDeployment(namespace)
@@ -300,11 +295,7 @@ var _ = Describe("Helm deployment", Ordered, ContinueOnFailure, Label("helm"), f
 			})
 
 			By("Waiting controller to be ready")
-			Eventually(func(g Gomega) {
-				out, err := testutil.Run(exec.CommandContext(ctx, "kubectl", "wait", "-n", namespace,
-					"--timeout=120s", "--for=condition=Available", "deployment/"+namespace+"-controller-manager"))
-				g.Expect(err).ToNot(HaveOccurred(), string(out))
-			}, "2m", "100ms").Should(Succeed())
+			env.WaitDeploymentAvailable(ctx, namespace, namespace+"-controller-manager", 2*time.Minute)
 		})
 
 		testHelmCluster(namespace)
@@ -385,15 +376,11 @@ var _ = Describe("Operator upgrade", Ordered, ContinueOnFailure, Label("upgrade"
 		})
 
 		By("waiting for the released operator to be ready")
-		Eventually(func(g Gomega) {
-			out, err := testutil.Run(exec.CommandContext(ctx, "kubectl", "wait", "-n", namespace,
-				"--timeout=120s", "--for=condition=Available", "deployment/"+deploymentName))
-			g.Expect(err).ToNot(HaveOccurred(), string(out))
-		}, "2m", "100ms").Should(Succeed())
+		env.WaitDeploymentAvailable(ctx, namespace, deploymentName, 2*time.Minute)
 	})
 
 	It("should reconcile cluster after upgrade without data loss", func(ctx context.Context) {
-		dialer := testutil.NewPortForwardDialer(config)
+		dialer := env.Dialer
 
 		keeperCR := v1.KeeperCluster{
 			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: keeperName},
@@ -419,9 +406,9 @@ var _ = Describe("Operator upgrade", Ordered, ContinueOnFailure, Label("upgrade"
 		DeferCleanup(func(ctx context.Context) {
 			Expect(k8sClient.Delete(ctx, &keeperCR)).To(Succeed())
 		})
-		waitClusterReady(ctx, &keeperCR)
+		env.WaitClusterReady(ctx, &keeperCR, 5*time.Minute)
 		Expect(k8sClient.Create(ctx, &chCR)).To(Succeed())
-		waitClusterReady(ctx, &chCR)
+		env.WaitClusterReady(ctx, &chCR, 5*time.Minute)
 
 		By("writing test data", func() {
 			// A freshly formed keeper ensemble re-elects for a while, so retry through transient leader loss.
@@ -452,8 +439,7 @@ var _ = Describe("Operator upgrade", Ordered, ContinueOnFailure, Label("upgrade"
 			"--set", "manager.image.tag=" + testTag,
 			"--set", "manager.image.pullPolicy=Never",
 		}, helmArgs...)...)).To(Succeed())
-		Expect(testutil.MustRun(ctx, "kubectl", "-n", namespace, "rollout", "status",
-			"--timeout=3m", "deployment/"+deploymentName)).To(Succeed())
+		env.WaitDeploymentAvailable(ctx, namespace, deploymentName, 3*time.Minute)
 
 		By("updating keeper and verifying it stays writable", func() {
 			Expect(k8sClient.Get(ctx, keeperCR.NamespacedName(), &keeperCR)).To(Succeed())
@@ -528,14 +514,14 @@ func testHelmCluster(namespace string) {
 		})
 
 		By("Waiting for KeeperCluster to be ready")
-		waitClusterReady(ctx, &v1.KeeperCluster{
+		env.WaitClusterReady(ctx, &v1.KeeperCluster{
 			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: keeperName},
-		})
+		}, 5*time.Minute)
 
 		By("Waiting for ClickHouse to be ready")
-		waitClusterReady(ctx, &v1.ClickHouseCluster{
+		env.WaitClusterReady(ctx, &v1.ClickHouseCluster{
 			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: chName},
-		})
+		}, 5*time.Minute)
 	}
 
 	tableArgs := make([]any, 1, len(versionEntries)+1)
@@ -565,7 +551,7 @@ func testDeployment(namespace string) {
 		})
 
 		By("Waiting for KeeperCluster to be ready")
-		waitClusterReady(ctx, &keeper)
+		env.WaitClusterReady(ctx, &keeper, 5*time.Minute)
 
 		ch := v1.ClickHouseCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -590,32 +576,12 @@ func testDeployment(namespace string) {
 		})
 
 		By("Waiting for ClickHouse to be ready")
-		waitClusterReady(ctx, &ch)
+		env.WaitClusterReady(ctx, &ch, 5*time.Minute)
 	}
 
 	tableArgs := make([]any, 1, len(versionEntries)+1)
 	tableArgs[0] = body
 	DescribeTable("should successfully work with", append(tableArgs, versionEntries...)...)
-}
-
-func waitClusterReady(ctx context.Context, cluster client.Object) {
-	GinkgoHelper()
-
-	Eventually(func(g Gomega) {
-		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
-
-		var conditions []metav1.Condition
-
-		switch cr := cluster.(type) {
-		case *v1.ClickHouseCluster:
-			conditions = cr.Status.Conditions
-		case *v1.KeeperCluster:
-			conditions = cr.Status.Conditions
-		}
-
-		g.Expect(meta.IsStatusConditionTrue(conditions, v1.ConditionTypeReady)).
-			To(BeTrue(), "%T %s not ready: %s", cluster, cluster.GetName(), testutil.FormatConditions(conditions))
-	}, "5m", "5s").Should(Succeed())
 }
 
 func templateTestResources(ctx context.Context, namespace string) string {

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -46,7 +46,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 		)
 
 		BeforeEach(func(ctx context.Context) {
-			ns = testNamespace(ctx)
+			ns = testutil.EnsureTestNamespace(ctx, env)
 
 			keeper = v1.KeeperCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -67,7 +67,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, &keeper)).To(Succeed())
 			})
 
-			WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
+			env.WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
 		})
 
 		DescribeTable("standalone ClickHouse updates", func(ctx context.Context, specUpdate v1.ClickHouseClusterSpec) {
@@ -97,8 +97,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute)
-			ClickHouseRWChecks(ctx, &cr, &checks)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute)
+			env.ClickHouseRWChecks(ctx, &cr, &checks)
 
 			By("updating cluster CR")
 			Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
@@ -106,10 +106,10 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			cr.Spec = specUpdate
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute, validateUpdateOrder)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute, validateUpdateOrder)
 			ExpectWithOffset(1, k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
 			Expect(cr.Status.Version).To(HavePrefix(cr.Spec.ContainerTemplate.Image.Tag))
-			ClickHouseRWChecks(ctx, &cr, &checks)
+			env.ClickHouseRWChecks(ctx, &cr, &checks)
 		},
 			Entry("update log level", v1.ClickHouseClusterSpec{Settings: v1.ClickHouseSettings{
 				Logger: v1.LoggerConfig{Level: "warning"},
@@ -154,8 +154,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
-			ClickHouseRWChecks(ctx, &cr, &checks)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
+			env.ClickHouseRWChecks(ctx, &cr, &checks)
 
 			By("updating cluster CR")
 			Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
@@ -163,8 +163,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			cr.Spec = specUpdate
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 5*time.Minute, validateUpdateOrder)
-			ClickHouseRWChecks(ctx, &cr, &checks)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 5*time.Minute, validateUpdateOrder)
+			env.ClickHouseRWChecks(ctx, &cr, &checks)
 		},
 			Entry("update log level", 3, v1.ClickHouseClusterSpec{Settings: v1.ClickHouseSettings{
 				Logger: v1.LoggerConfig{Level: "warning"},
@@ -204,7 +204,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 
 			By("creating enough tables to exceed max_table_num_to_warn")
 
@@ -278,7 +278,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, validateReadyIsInitialized)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, validateReadyIsInitialized)
 
 			survivor, removed := v1.ClickHouseReplicaID{Index: 0}, v1.ClickHouseReplicaID{Index: 1}
 
@@ -312,13 +312,13 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				)
 
 				Eventually(func(g Gomega) {
-					Expect(k8sClient.Get(ctx, podKey, &pod)).To(Succeed())
+					g.Expect(k8sClient.Get(ctx, podKey, &pod)).To(Succeed())
 					g.Expect(ctrl.PodConditionTrue(&pod, v1.ReplicaInitializedCondition)).To(BeFalse())
 					podUID = pod.UID
 				}).WithPolling(pollingInterval).WithTimeout(time.Minute).Should(Succeed())
 
 				Consistently(func(g Gomega) {
-					Expect(k8sClient.Get(ctx, podKey, &pod)).To(Succeed())
+					g.Expect(k8sClient.Get(ctx, podKey, &pod)).To(Succeed())
 					g.Expect(pod.UID).To(Equal(podUID))
 				}).WithPolling(pollingInterval).WithTimeout(20 * time.Second).Should(Succeed())
 			})
@@ -330,7 +330,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				defer chClient.Close()
 
 				Expect(chClient.ExecReplica(ctx, survivor, "SYSTEM START FETCHES default.test")).To(Succeed())
-				WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, validateUpdateOrder, validateReadyIsInitialized)
+				env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, validateUpdateOrder, validateReadyIsInitialized)
 
 				var survivorRows uint64
 				Expect(chClient.QueryRowReplica(ctx, survivor, "SELECT count() FROM default.test", &survivorRows)).To(Succeed())
@@ -377,8 +377,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
-			ClickHouseRWChecks(ctx, &cr, new(0))
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
+			env.ClickHouseRWChecks(ctx, &cr, new(0))
 		})
 
 		It("should recreate stuck pods", func(ctx context.Context) {
@@ -421,8 +421,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 
 			cr.Spec.ContainerTemplate.Env = nil
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
-			ClickHouseRWChecks(ctx, &cr, new(0))
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
+			env.ClickHouseRWChecks(ctx, &cr, new(0))
 		})
 
 		It("should resize PVCs on every replica", func(ctx context.Context) {
@@ -474,7 +474,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute)
 
 			By("recording initial PVC sizes")
 
@@ -498,7 +498,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
 			cr.Spec.DataVolumeClaimSpec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("2Gi")
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute)
 
 			Expect(k8sClient.List(ctx, &pvcs, listOpts...)).To(Succeed())
 			Expect(pvcs.Items).To(HaveLen(int(cr.Replicas())), "expected one PVC per replica")
@@ -583,8 +583,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
-			ClickHouseRWChecks(ctx, &cr, &checks)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
+			env.ClickHouseRWChecks(ctx, &cr, &checks)
 			verifyDisks(resource.MustParse("1Gi"))
 
 			By("resizing disks")
@@ -597,8 +597,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			cr.Spec.AdditionalVolumeClaimTemplates[1].Spec = diskSpec
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
-			ClickHouseRWChecks(ctx, &cr, &checks)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
+			env.ClickHouseRWChecks(ctx, &cr, &checks)
 			verifyDisks(resource.MustParse("2Gi"))
 		})
 
@@ -622,7 +622,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 
 			chClient, err := testutil.NewClickHouseClient(ctx, podDialer, &cr)
 			Expect(err).NotTo(HaveOccurred())
@@ -700,12 +700,12 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
+			env.WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
 
 			checks := 0
 
 			By("checking accessible with default user credentials")
-			ClickHouseRWChecks(ctx, cr, &checks, auth)
+			env.ClickHouseRWChecks(ctx, cr, &checks, auth)
 
 			By("checking accessible with operator management user credentials")
 
@@ -714,13 +714,13 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Name:      cr.SecretName(),
 				Namespace: cr.Namespace,
 			}, &managementSecret)).To(Succeed())
-			ClickHouseRWChecks(ctx, cr, &checks, clickhouse.Auth{
+			env.ClickHouseRWChecks(ctx, cr, &checks, clickhouse.Auth{
 				Username: chctrl.OperatorManagementUsername,
 				Password: string(managementSecret.Data[chctrl.SecretKeyManagementPassword]),
 			})
 
 			By("checking accessible with custom user credentials")
-			ClickHouseRWChecks(ctx, cr, &checks, clickhouse.Auth{
+			env.ClickHouseRWChecks(ctx, cr, &checks, clickhouse.Auth{
 				Username: "custom",
 				Password: password,
 			})
@@ -739,7 +739,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			})
 
 			By("checking accessible with sql user credentials")
-			ClickHouseRWChecks(ctx, cr, &checks, clickhouse.Auth{
+			env.ClickHouseRWChecks(ctx, cr, &checks, clickhouse.Auth{
 				Username: "sql_test",
 				Password: newPassword,
 			})
@@ -839,10 +839,10 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
+			env.WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
 
 			By("checking custom user access works")
-			ClickHouseRWChecks(ctx, cr, new(0), auth)
+			env.ClickHouseRWChecks(ctx, cr, new(0), auth)
 
 			chClient, err := testutil.NewClickHouseClient(ctx, podDialer, cr, auth)
 			Expect(err).NotTo(HaveOccurred())
@@ -899,7 +899,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, cr, 3*time.Minute)
+			env.WaitClickHouseUpdatedAndReady(ctx, cr, 3*time.Minute)
 
 			By("asserting the headless Service carries the user-declared port")
 			Expect(k8sClient.Get(ctx, cr.NamespacedName(), cr)).To(Succeed())
@@ -978,7 +978,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, &ch)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &ch, 2*time.Minute)
+			env.WaitClickHouseUpdatedAndReady(ctx, &ch, 2*time.Minute)
 
 			chClient, err := testutil.NewClickHouseClient(ctx, podDialer, &ch, clickhouse.Auth{
 				Username: "default",
@@ -1049,7 +1049,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute)
 
 			By("verifying named collections secret key exists")
 
@@ -1158,8 +1158,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			})
 
 			By("waiting for cluster to become ready")
-			WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
-			ClickHouseRWChecks(ctx, &cr, new(0))
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
+			env.ClickHouseRWChecks(ctx, &cr, new(0))
 
 			By("verifying ExternalSecretValid=True")
 			Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
@@ -1176,7 +1176,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 		It("should reload config without pod restart when possible", func(ctx context.Context) {
 			cr := v1.ClickHouseCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace(ctx),
+					Namespace: testutil.EnsureTestNamespace(ctx, env),
 					Name:      fmt.Sprintf("test-%d", rand.Uint32()), //nolint:gosec
 				},
 				Spec: v1.ClickHouseClusterSpec{
@@ -1198,8 +1198,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				DeferCleanup(func(ctx context.Context) {
 					Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 				})
-				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute)
-				ClickHouseRWChecks(ctx, &cr, &checks)
+				env.WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute)
+				env.ClickHouseRWChecks(ctx, &cr, &checks)
 			})
 
 			uidBefore := podUIDsByName(ctx, &cr)
@@ -1214,12 +1214,12 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				))
 				Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2)
+				env.WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2)
 
 				Expect(podUIDsByName(ctx, &cr)).To(Equal(uidBefore), "pod was restarted (UID changed)")
-				ClickHouseRWChecks(ctx, &cr, &checks)
+				env.ClickHouseRWChecks(ctx, &cr, &checks)
 
-				ClickHouseRWChecks(ctx, &cr, &checks, clickhouse.Auth{
+				env.ClickHouseRWChecks(ctx, &cr, &checks, clickhouse.Auth{
 					Username: "e2e_test_user",
 					Password: password,
 				})
@@ -1230,8 +1230,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				*cr.Spec.Replicas = 2
 				Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-				WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2)
-				ClickHouseRWChecks(ctx, &cr, &checks)
+				env.WaitClickHouseUpdatedAndReady(ctx, &cr, time.Minute*2)
+				env.ClickHouseRWChecks(ctx, &cr, &checks)
 				uidAfter := podUIDsByName(ctx, &cr)
 
 				for pod, uid := range uidBefore {
@@ -1294,7 +1294,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			chCertName     = fmt.Sprintf("ch-cert-%d", suffix)
 		)
 
-		ns := testNamespace(ctx)
+		ns := testutil.EnsureTestNamespace(ctx, env)
 		testutil.SetupCA(ctx, k8sClient, ns, suffix)
 
 		keeperCR := &v1.KeeperCluster{
@@ -1404,7 +1404,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, keeperCR)).To(Succeed())
 			})
-			WaitKeeperUpdatedAndReady(ctx, keeperCR, 2*time.Minute, false)
+			env.WaitKeeperUpdatedAndReady(ctx, keeperCR, 2*time.Minute, false)
 		})
 
 		cr := baseCr.DeepCopy()
@@ -1416,8 +1416,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 			})
 
-			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
-			ClickHouseRWChecks(ctx, cr, &checks)
+			env.WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
+			env.ClickHouseRWChecks(ctx, cr, &checks)
 		})
 
 		By("checking custom ca bundle is used to connect to the keeper", func() {
@@ -1430,14 +1430,14 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			}
 			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 
-			WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute, validateUpdateOrder)
-			ClickHouseRWChecks(ctx, cr, &checks)
+			env.WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute, validateUpdateOrder)
+			env.ClickHouseRWChecks(ctx, cr, &checks)
 		})
 	})
 
 	It("should set default affinity settings", func(ctx context.Context) {
 		var (
-			ns          = testNamespace(ctx)
+			ns          = testutil.EnsureTestNamespace(ctx, env)
 			nodeToZone  = map[string]string{}
 			keeperName  = fmt.Sprintf("test-%d", rand.Uint32()) //nolint:gosec
 			keeperZones = map[string]struct{}{}
@@ -1486,7 +1486,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 		DeferCleanup(func(ctx context.Context) {
 			Expect(k8sClient.Delete(ctx, &keeper)).To(Succeed())
 		})
-		WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
+		env.WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
 
 		By("checking keeper pod affinity")
 
@@ -1532,7 +1532,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 		DeferCleanup(func(ctx context.Context) {
 			Expect(k8sClient.Delete(ctx, &cluster)).To(Succeed())
 		})
-		WaitClickHouseUpdatedAndReady(ctx, &cluster, 2*time.Minute)
+		env.WaitClickHouseUpdatedAndReady(ctx, &cluster, 2*time.Minute)
 
 		By("checking clickhouse pod affinity")
 
@@ -1658,88 +1658,6 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 	})
 })
 
-// validator checks invariants on every polling tick of WaitClickHouseUpdatedAndReady: violations fail hard (Expect).
-// Non-informative errors are skipped.
-type validator func(ctx context.Context, cr *v1.ClickHouseCluster)
-
-func WaitClickHouseUpdatedAndReady(
-	ctx context.Context,
-	cr *v1.ClickHouseCluster,
-	timeout time.Duration,
-	validators ...validator,
-) {
-	By(fmt.Sprintf("waiting for cluster %s to be ready", cr.Name))
-	EventuallyWithOffset(1, func(g Gomega) {
-		var cluster v1.ClickHouseCluster
-		g.Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
-		g.Expect(cluster.Generation).To(Equal(cluster.Status.ObservedGeneration))
-
-		for _, val := range validators {
-			val(ctx, &cluster)
-		}
-
-		count := int(cr.Replicas() * cr.Shards())
-
-		g.Expect(cluster.Status.CurrentRevision).
-			To(Equal(cluster.Status.UpdateRevision), "rollout should eventually complete")
-		g.Expect(cluster.Status.ReadyReplicas).
-			To(BeEquivalentTo(count), "all replicas should be ready")
-
-		var pods corev1.PodList
-		Expect(k8sClient.List(ctx, &pods, client.InNamespace(cr.Namespace), client.MatchingLabels{
-			controllerutil.LabelAppKey: cr.SpecificName(),
-		})).To(Succeed())
-		Expect(pods.Items).To(HaveLen(count))
-
-		for _, conditionType := range []v1.ConditionType{
-			v1.ConditionTypeReady,
-			v1.ConditionTypeHealthy,
-			v1.ConditionTypeClusterSizeAligned,
-			v1.ConditionTypeConfigurationInSync,
-			v1.ClickHouseConditionTypeSchemaInSync,
-		} {
-			cond := meta.FindStatusCondition(cluster.Status.Conditions, conditionType)
-			g.Expect(cond).ToNot(BeNil())
-			g.Expect(cond.Status).To(
-				Equal(metav1.ConditionTrue),
-				fmt.Sprintf("condition %s is false: %s", cond.Type, cond.Message),
-			)
-		}
-
-		for _, pod := range pods.Items {
-			g.Expect(CheckPodReady(&pod)).To(BeTrue(), fmt.Sprintf("pod %s is not ready", pod.Name))
-		}
-	}, timeout).WithPolling(pollingInterval).Should(Succeed())
-}
-
-func ClickHouseRWChecks(ctx context.Context, cr *v1.ClickHouseCluster, checksDone *int, auth ...clickhouse.Auth) {
-	ExpectWithOffset(1, k8sClient.Get(ctx, cr.NamespacedName(), cr)).To(Succeed())
-
-	By("connecting to cluster")
-	Expect(len(auth)).To(Or(Equal(0), Equal(1)))
-	chClient, err := testutil.NewClickHouseClient(ctx, podDialer, cr, auth...)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	defer chClient.Close()
-
-	if *checksDone == 0 {
-		By("creating test database")
-		Expect(chClient.CreateDatabase(ctx)).To(Succeed())
-		By("checking default database replicated")
-		Expect(chClient.CheckDefaultDatabasesReplicated(ctx)).To(Succeed())
-	}
-
-	By("writing new test data")
-	ExpectWithOffset(1, chClient.CheckWrite(ctx, *checksDone)).To(Succeed())
-	*checksDone++
-
-	By("reading all test data")
-
-	for i := range *checksDone {
-		ExpectWithOffset(1, chClient.CheckRead(ctx, i)).To(Succeed(), "check read %d failed", i)
-	}
-}
-
 func podUIDsByName(ctx context.Context, cr *v1.ClickHouseCluster) map[string]types.UID {
 	var pods corev1.PodList
 	ExpectWithOffset(1, k8sClient.List(ctx, &pods, client.InNamespace(cr.Namespace),
@@ -1756,7 +1674,7 @@ func podUIDsByName(ctx context.Context, cr *v1.ClickHouseCluster) map[string]typ
 func validateUpdateOrder(ctx context.Context, cr *v1.ClickHouseCluster) {
 	// CheckUpdateOrder returns an error only for update-order invariant violations: fail hard.
 	for shard := range cr.Shards() {
-		Expect(CheckUpdateOrder(ctx, &client.ListOptions{
+		Expect(env.CheckUpdateOrder(ctx, &client.ListOptions{
 			Namespace: cr.Namespace,
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				controllerutil.LabelAppKey:            cr.SpecificName(),

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -1558,7 +1558,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 
 	It("should manage the cluster NetworkPolicies", func(ctx context.Context) {
 		var (
-			ns   = testNamespace(ctx)
+			ns   = testutil.EnsureTestNamespace(ctx, env)
 			name = fmt.Sprintf("np-test-%d", rand.Uint32()) //nolint:gosec
 		)
 
@@ -1598,7 +1598,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, &keeper)).To(Succeed())
 			})
-			WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
+			env.WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
 		})
 
 		By("creating ClickHouse cluster with NetworkPolicies", func() {
@@ -1606,8 +1606,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, &cluster)).To(Succeed())
 			})
-			WaitClickHouseUpdatedAndReady(ctx, &cluster, 2*time.Minute)
-			ClickHouseRWChecks(ctx, &cluster, new(0))
+			env.WaitClickHouseUpdatedAndReady(ctx, &cluster, 2*time.Minute)
+			env.ClickHouseRWChecks(ctx, &cluster, new(0))
 		})
 
 		By("operator creates the NetworkPolicy with the expected shape")

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -17,7 +16,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sethvargo/go-envconfig"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -40,7 +38,7 @@ import (
 )
 
 const (
-	pollingInterval = time.Millisecond * 100
+	pollingInterval = testutil.PollInterval
 
 	BaseVersion   = testutil.BaseVersion
 	UpdateVersion = testutil.UpdateVersion
@@ -113,6 +111,7 @@ func (c *shardingConfig) Enabled(spec string) (bool, error) {
 
 var (
 	sharding       shardingConfig
+	env            *testutil.Env
 	k8sClient      client.Client
 	config         *rest.Config
 	podDialer      controllerutil.DialContextFunc
@@ -216,6 +215,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 
 	upgradeChecker := upgrade.NewChecker(updater)
 	podDialer = testutil.NewPortForwardDialer(config)
+	env = &testutil.Env{Client: k8sClient, Config: config, Dialer: podDialer}
 	Expect(keeper.SetupWithManager(mgr, zapLogger, upgradeChecker, podDialer, true, true)).To(Succeed())
 	Expect(clickhouse.SetupWithManager(mgr, zapLogger, upgradeChecker, podDialer, true, true)).To(Succeed())
 	// +kubebuilder:scaffold:builder
@@ -253,7 +253,7 @@ var _ = JustAfterEach(func(ctx context.Context) {
 		return
 	}
 
-	testutil.DumpNamespaceDiagnostics(ctx, config, k8sClient, testNamespace(ctx), "report")
+	testutil.DumpNamespaceDiagnostics(ctx, env, testutil.TestNamespace(), "report")
 })
 
 func requireExplicitImageTag(
@@ -275,86 +275,4 @@ func requireExplicitImageTag(
 	}
 
 	return nil
-}
-
-func WaitReplicaCount(ctx context.Context, k8sClient client.Client, namespace, app string, replicas int) {
-	Eventually(func() int {
-		var pods corev1.PodList
-		Expect(k8sClient.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{
-			controllerutil.LabelAppKey: app,
-		})).To(Succeed())
-
-		return len(pods.Items)
-	}).WithTimeout(time.Minute).WithPolling(pollingInterval).Should(Equal(replicas))
-}
-
-func CheckPodReady(pod *corev1.Pod) bool {
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-
-	return false
-}
-
-// CheckUpdateOrder lists StatefulSets for the given app and validates rolling update invariants:
-// 1. Updated StatefulSets form a contiguous group from the highest replica ID
-// 2. At most one StatefulSet has zero ready replicas (the one currently being updated).
-func CheckUpdateOrder(ctx context.Context, selector *client.ListOptions, replicaLabel, stsRev string) error {
-	var stsList appsv1.StatefulSetList
-	Expect(k8sClient.List(ctx, &stsList, selector)).To(Succeed())
-
-	if len(stsList.Items) < 2 {
-		return nil
-	}
-
-	notReadyCount := 0
-	updated := make([]bool, len(stsList.Items))
-
-	for _, sts := range stsList.Items {
-		index, err := strconv.Atoi(sts.Labels[replicaLabel])
-		Expect(err).NotTo(HaveOccurred())
-
-		if sts.Status.ReadyReplicas != 1 {
-			notReadyCount++
-		}
-
-		updated[index] = controllerutil.GetSpecHashFromObject(&sts) == stsRev
-	}
-
-	if notReadyCount > 1 {
-		return fmt.Errorf("%d replicas not ready, expected at most 1", notReadyCount)
-	}
-
-	// The controller updates the highest-index replica first.
-	// If it doesn't match the target revisions, either the rollout hasn't started
-	// or the revisions are stale (cluster status read before the STS list) — skip.
-	if !updated[len(updated)-1] {
-		return nil
-	}
-
-	// find the first updated replica (lowest index that matches target)
-	updatedID := 0
-	for i, isUpdated := range updated {
-		if isUpdated {
-			updatedID = i
-			break
-		}
-	}
-
-	// all replicas above the first updated one must also be updated
-	for i := updatedID + 1; i < len(updated); i++ {
-		if !updated[i] {
-			return fmt.Errorf("replica %d updated before %d", updatedID, i)
-		}
-	}
-
-	return nil
-}
-
-func testNamespace(ctx context.Context) string {
-	ns := "e2e-" + testutil.CurrentSpecHash()
-	testutil.EnsureNamespace(ctx, k8sClient, ns)
-	return ns
 }

--- a/test/e2e/keeper_e2e_test.go
+++ b/test/e2e/keeper_e2e_test.go
@@ -13,9 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
@@ -24,7 +22,7 @@ import (
 
 var _ = Describe("Keeper controller", Label("keeper"), func() {
 	DescribeTable("standalone keeper updates", func(ctx context.Context, specUpdate v1.KeeperClusterSpec) {
-		ns := testNamespace(ctx)
+		ns := testutil.EnsureTestNamespace(ctx, env)
 
 		cr := v1.KeeperCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -49,8 +47,8 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 			By("deleting cluster CR")
 			Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 		})
-		WaitKeeperUpdatedAndReady(ctx, &cr, time.Minute, false)
-		KeeperRWChecks(ctx, &cr, &checks)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, time.Minute, false)
+		env.KeeperRWChecks(ctx, &cr, &checks)
 
 		By("updating cluster CR")
 		Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
@@ -58,10 +56,10 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 		cr.Spec = specUpdate
 		Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-		WaitKeeperUpdatedAndReady(ctx, &cr, 5*time.Minute, true)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 5*time.Minute, true)
 		ExpectWithOffset(1, k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
 		Expect(cr.Status.Version).To(HavePrefix(cr.Spec.ContainerTemplate.Image.Tag))
-		KeeperRWChecks(ctx, &cr, &checks)
+		env.KeeperRWChecks(ctx, &cr, &checks)
 	},
 		Entry("update log level", v1.KeeperClusterSpec{Settings: v1.KeeperSettings{
 			Logger: v1.LoggerConfig{Level: "warning"},
@@ -78,7 +76,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 	)
 
 	DescribeTable("keeper cluster updates", func(ctx context.Context, baseReplicas int, specUpdate v1.KeeperClusterSpec) {
-		ns := testNamespace(ctx)
+		ns := testutil.EnsureTestNamespace(ctx, env)
 
 		cr := v1.KeeperCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -103,8 +101,8 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 			By("deleting cluster CR")
 			Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 		})
-		WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
-		KeeperRWChecks(ctx, &cr, &checks)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+		env.KeeperRWChecks(ctx, &cr, &checks)
 
 		By("updating cluster CR")
 		Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
@@ -112,8 +110,8 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 		cr.Spec = specUpdate
 		Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-		WaitKeeperUpdatedAndReady(ctx, &cr, 5*time.Minute, true)
-		KeeperRWChecks(ctx, &cr, &checks)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 5*time.Minute, true)
+		env.KeeperRWChecks(ctx, &cr, &checks)
 	},
 		Entry("update log level", 3, v1.KeeperClusterSpec{Settings: v1.KeeperSettings{
 			Logger: v1.LoggerConfig{Level: "warning"},
@@ -132,7 +130,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 
 	Describe("secure keeper cluster", func() {
 		It("should create secure cluster", func(ctx context.Context) {
-			ns := testNamespace(ctx)
+			ns := testutil.EnsureTestNamespace(ctx, env)
 
 			suffix := rand.Uint32() //nolint:gosec
 			certName := fmt.Sprintf("keeper-cert-%d", suffix)
@@ -205,13 +203,13 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 			By("creating secure keeper cluster CR")
 			Expect(k8sClient.Create(ctx, &cr)).To(Succeed())
 			By("ensuring secure port is working")
-			WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
-			KeeperRWChecks(ctx, &cr, new(0))
+			env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+			env.KeeperRWChecks(ctx, &cr, new(0))
 		})
 	})
 
 	It("should work with custom data folder mount", func(ctx context.Context) {
-		ns := testNamespace(ctx)
+		ns := testutil.EnsureTestNamespace(ctx, env)
 
 		cr := v1.KeeperCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -249,14 +247,14 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 		})
 
 		By("waiting for diskless keeper to be ready")
-		WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
 
 		By("verifying keeper is functional with basic read/write")
-		KeeperRWChecks(ctx, &cr, new(0))
+		env.KeeperRWChecks(ctx, &cr, new(0))
 	})
 
 	It("should recreate stuck pods", func(ctx context.Context) {
-		ns := testNamespace(ctx)
+		ns := testutil.EnsureTestNamespace(ctx, env)
 
 		cr := v1.KeeperCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -286,68 +284,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 			Tag: BaseVersion,
 		}
 		Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
-		WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, true)
-		KeeperRWChecks(ctx, &cr, new(0))
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, true)
+		env.KeeperRWChecks(ctx, &cr, new(0))
 	})
 })
-
-func WaitKeeperUpdatedAndReady(ctx context.Context, cr *v1.KeeperCluster, timeout time.Duration, isUpdate bool) {
-	By(fmt.Sprintf("waiting for cluster %s to be ready", cr.Name))
-	EventuallyWithOffset(1, func(g Gomega) {
-		var cluster v1.KeeperCluster
-		g.Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
-		g.Expect(cluster.Generation).To(Equal(cluster.Status.ObservedGeneration))
-
-		if isUpdate {
-			// Intentional global assertion to fail suite if update order is wrong.
-			Expect(CheckUpdateOrder(ctx, &client.ListOptions{
-				Namespace: cluster.Namespace,
-				LabelSelector: labels.SelectorFromSet(map[string]string{
-					controllerutil.LabelAppKey: cluster.SpecificName(),
-				}),
-			}, controllerutil.LabelKeeperReplicaID, cluster.Status.StatefulSetRevision)).To(Succeed())
-		}
-
-		g.Expect(cluster.Status.CurrentRevision).To(Equal(cluster.Status.UpdateRevision))
-		g.Expect(cluster.Status.ReadyReplicas).To(Equal(cluster.Replicas()))
-
-		for _, conditionType := range []v1.ConditionType{
-			v1.ConditionTypeReady,
-			v1.ConditionTypeHealthy,
-			v1.ConditionTypeClusterSizeAligned,
-			v1.ConditionTypeConfigurationInSync,
-		} {
-			cond := meta.FindStatusCondition(cluster.Status.Conditions, conditionType)
-			g.Expect(cond).ToNot(BeNil())
-			g.Expect(cond.Status).To(
-				Equal(metav1.ConditionTrue),
-				fmt.Sprintf("condition %s is false: %s", cond.Type, cond.Message),
-			)
-		}
-	}, timeout).WithPolling(pollingInterval).Should(Succeed())
-	// Needed for replica deletion to not forward deleting pods.
-	By(fmt.Sprintf("waiting for cluster %s replicas count match", cr.Name))
-	count := int(cr.Replicas())
-	WaitReplicaCount(ctx, k8sClient, cr.Namespace, cr.SpecificName(), count)
-}
-
-func KeeperRWChecks(ctx context.Context, cr *v1.KeeperCluster, checksDone *int) {
-	ExpectWithOffset(1, k8sClient.Get(ctx, cr.NamespacedName(), cr)).To(Succeed())
-
-	By("connecting to cluster")
-
-	cli, err := testutil.NewKeeperClient(ctx, podDialer, cr)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	defer cli.Close()
-
-	By("writing new test data")
-	ExpectWithOffset(1, cli.CheckWrite(*checksDone)).To(Succeed())
-	*checksDone++
-
-	By("reading all test data")
-
-	for i := range *checksDone {
-		ExpectWithOffset(1, cli.CheckRead(i)).To(Succeed(), "check read %d failed", i)
-	}
-}

--- a/test/openshift/openshift_test.go
+++ b/test/openshift/openshift_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -61,6 +62,7 @@ spec:
 var (
 	k8sClient      client.Client
 	config         *rest.Config
+	env            *testutil.Env
 	namespace      = "e2e-" + testutil.CurrentSpecHash()
 	versionEntries []any
 )
@@ -93,6 +95,8 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	Expect(v1.AddToScheme(scheme.Scheme)).To(Succeed())
 	k8sClient, err = client.New(config, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
+
+	env = &testutil.Env{Client: k8sClient, Config: config, Dialer: testutil.NewPortForwardDialer(config)}
 
 	By("waiting for project API service")
 	Expect(testutil.MustRun(ctx, "oc", "wait",
@@ -162,8 +166,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	}, "5m", "5s").Should(Succeed())
 
 	By("waiting controller to be ready")
-	Expect(testutil.MustRun(ctx, "kubectl", "wait", "-n", namespace, "--timeout=2m",
-		"--for=condition=Available", "deployment/clickhouse-operator-controller-manager")).To(Succeed())
+	env.WaitDeploymentAvailable(ctx, namespace, "clickhouse-operator-controller-manager", 2*time.Minute)
 })
 
 func envOrDefault(key, def string) string {
@@ -188,7 +191,7 @@ var _ = JustAfterEach(func(ctx context.Context) {
 		"-n", "openshift-operator-lifecycle-manager", "-l", "app=catalog-operator", "--tail=100"))
 	AddReportEntry("=== catalog-operator log", string(catalogLog))
 
-	testutil.DumpNamespaceDiagnostics(ctx, config, k8sClient, namespace, "report")
+	testutil.DumpNamespaceDiagnostics(ctx, env, namespace, "report")
 })
 
 var _ = Describe("OLM deployment on OpenShift", func() {
@@ -209,8 +212,7 @@ var _ = Describe("OLM deployment on OpenShift", func() {
 		DeferCleanup(func(ctx context.Context) { _ = k8sClient.Delete(ctx, &keeper) })
 
 		By("Waiting for KeeperCluster to be ready")
-		Expect(testutil.MustRun(ctx, "kubectl", "-n", namespace, "wait", "--timeout=15m", "--for=condition=Ready",
-			"keepercluster/"+keeper.Name)).To(Succeed())
+		env.WaitClusterReady(ctx, &keeper, 15*time.Minute)
 
 		ch := v1.ClickHouseCluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -229,7 +231,6 @@ var _ = Describe("OLM deployment on OpenShift", func() {
 		DeferCleanup(func(ctx context.Context) { _ = k8sClient.Delete(ctx, &ch) })
 
 		By("Waiting for ClickHouse to be ready")
-		Expect(testutil.MustRun(ctx, "kubectl", "-n", namespace, "wait", "--timeout=15m", "--for=condition=Ready",
-			"clickhousecluster/"+ch.Name)).To(Succeed())
+		env.WaitClusterReady(ctx, &ch, 15*time.Minute)
 	})
 })

--- a/test/testutil/checks.go
+++ b/test/testutil/checks.go
@@ -1,0 +1,64 @@
+package testutil
+
+import (
+	"context"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+)
+
+// ClickHouseRWChecks writes a new data batch and reads back all batches written so far.
+func (e *Env) ClickHouseRWChecks(
+	ctx context.Context, cr *v1.ClickHouseCluster, checksDone *int, auth ...clickhouse.Auth,
+) {
+	ExpectWithOffset(1, e.Client.Get(ctx, cr.NamespacedName(), cr)).To(Succeed())
+
+	By("connecting to cluster")
+	Expect(len(auth)).To(Or(Equal(0), Equal(1)))
+	chClient, err := NewClickHouseClient(ctx, e.Dialer, cr, auth...)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	defer chClient.Close()
+
+	if *checksDone == 0 {
+		By("creating test database")
+		Expect(chClient.CreateDatabase(ctx)).To(Succeed())
+		By("checking default database replicated")
+		Expect(chClient.CheckDefaultDatabasesReplicated(ctx)).To(Succeed())
+	}
+
+	runRWChecks(
+		func(order int) error { return chClient.CheckWrite(ctx, order) },
+		func(order int) error { return chClient.CheckRead(ctx, order) },
+		checksDone,
+	)
+}
+
+// KeeperRWChecks writes a new data batch and reads back all batches written so far.
+func (e *Env) KeeperRWChecks(ctx context.Context, cr *v1.KeeperCluster, checksDone *int) {
+	ExpectWithOffset(1, e.Client.Get(ctx, cr.NamespacedName(), cr)).To(Succeed())
+
+	By("connecting to cluster")
+
+	cli, err := NewKeeperClient(ctx, e.Dialer, cr)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	defer cli.Close()
+
+	runRWChecks(cli.CheckWrite, cli.CheckRead, checksDone)
+}
+
+func runRWChecks(write, read func(order int) error, checksDone *int) {
+	By("writing new test data")
+	ExpectWithOffset(2, write(*checksDone)).To(Succeed())
+	*checksDone++
+
+	By("reading all test data")
+
+	for i := range *checksDone {
+		ExpectWithOffset(2, read(i)).To(Succeed(), "check read %d failed", i)
+	}
+}

--- a/test/testutil/env.go
+++ b/test/testutil/env.go
@@ -1,0 +1,20 @@
+package testutil
+
+import (
+	"time"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+// PollInterval is the default polling interval for Eventually-style waits.
+const PollInterval = 100 * time.Millisecond
+
+// Env bundles the suite-level handles shared by the test helpers.
+type Env struct {
+	Client client.Client
+	Config *rest.Config
+	Dialer controllerutil.DialContextFunc
+}

--- a/test/testutil/report.go
+++ b/test/testutil/report.go
@@ -1,0 +1,404 @@
+package testutil
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+)
+
+var (
+	unsafeFileNameChars = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+)
+
+// DumpResult holds a short summary and the full dump content.
+type DumpResult struct {
+	Short string
+	Full  string
+}
+
+// Empty returns true if no data dumped.
+func (d *DumpResult) Empty() bool {
+	return len(d.Full) == 0
+}
+
+// WriteFull writes the full dump to a file inside dir and returns the file path.
+func (d *DumpResult) WriteFull(dir, filename string) (string, error) {
+	if d.Full == "" {
+		return "", nil
+	}
+
+	filename = unsafeFileNameChars.ReplaceAllString(filename, "")
+
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return "", fmt.Errorf("create dump dir %s: %w", dir, err)
+	}
+
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte(d.Full), 0o600); err != nil {
+		return "", fmt.Errorf("write dump file %s: %w", path, err)
+	}
+
+	return path, nil
+}
+
+// DumpNamespaceDiagnostics dumps resources, pod logs and events from namespace.
+func DumpNamespaceDiagnostics(ctx context.Context, env *Env, ns, dir string) {
+	By("collecting diagnostics report")
+
+	report := CurrentSpecReport()
+
+	resDump, err := dumpNamespaceResources(ctx, env.Client, ns)
+	if err != nil {
+		GinkgoWriter.Printf("failed to dump namespace resources: %v\n", err)
+	}
+
+	if !resDump.Empty() {
+		path, writeErr := resDump.WriteFull(dir, fmt.Sprintf("resources-%s.log", report.FullText()))
+		if writeErr != nil {
+			GinkgoWriter.Printf("failed to write resources dump: %v\n", writeErr)
+		}
+
+		GinkgoWriter.Printf("\n=== Namespace Resources ===\n%s", resDump.Short)
+
+		if path != "" {
+			GinkgoWriter.Printf("Full resources dump: %s\n", path)
+		}
+	}
+
+	logsDump, err := dumpNamespacePodLogs(ctx, env.Config, ns)
+	if err != nil {
+		GinkgoWriter.Printf("failed to dump pod logs: %v\n", err)
+	}
+
+	if !logsDump.Empty() {
+		path, writeErr := logsDump.WriteFull(dir, fmt.Sprintf("pod-logs-%s.log", report.FullText()))
+		if writeErr != nil {
+			GinkgoWriter.Printf("failed to write pod logs dump: %v\n", writeErr)
+		}
+
+		GinkgoWriter.Printf("\n=== Pod Logs (last 10 lines per container) ===\n%s", logsDump.Short)
+
+		if path != "" {
+			GinkgoWriter.Printf("Full pod logs dump: %s\n", path)
+		}
+	}
+
+	events, err := dumpNamespaceEvents(ctx, env.Client, ns, report.StartTime)
+	if err != nil {
+		GinkgoWriter.Printf("failed to dump namespace events: %v\n", err)
+	}
+
+	if strings.TrimSpace(events) != "" {
+		path, writeErr := (&DumpResult{Full: events}).WriteFull(dir, fmt.Sprintf("events-%s.log", report.FullText()))
+		if writeErr != nil {
+			GinkgoWriter.Printf("failed to write events dump: %v\n", writeErr)
+		}
+
+		GinkgoWriter.Printf("\n=== Namespace Events (since test start) ===\n%s\n", events)
+
+		if path != "" {
+			GinkgoWriter.Printf("Full events dump: %s\n", path)
+		}
+	}
+}
+
+func formatPodState(pod *corev1.Pod) string {
+	containers := slices.Concat(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses)
+
+	parts := make([]string, 0, 1+len(containers))
+	parts = append(parts, "phase="+string(pod.Status.Phase))
+
+	for _, cs := range containers {
+		state := fmt.Sprintf("ready=%t", cs.Ready)
+
+		switch {
+		case cs.State.Waiting != nil:
+			state = "waiting=" + cs.State.Waiting.Reason
+		case cs.State.Terminated != nil:
+			state = "terminated=" + cs.State.Terminated.Reason
+		}
+
+		parts = append(parts, fmt.Sprintf("%s[%s restarts=%d]", cs.Name, state, cs.RestartCount))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// FormatConditions renders conditions as "Type=Status(Reason): message" entries.
+func formatConditions(conditions []metav1.Condition) string {
+	if len(conditions) == 0 {
+		return "<no conditions>"
+	}
+
+	parts := make([]string, 0, len(conditions))
+
+	for _, cond := range conditions {
+		part := fmt.Sprintf("%s=%s(%s)", cond.Type, cond.Status, cond.Reason)
+		if cond.Status != metav1.ConditionTrue && cond.Message != "" {
+			part += ": " + cond.Message
+		}
+
+		parts = append(parts, part)
+	}
+
+	return strings.Join(parts, "; ")
+}
+
+// DumpNamespaceResources collects all resources in the namespace.
+// The full dump contains the complete JSON representation of each resource,
+// while the short dump contains only the resource type and object names.
+func dumpNamespaceResources(ctx context.Context, cli client.Client, namespace string) (DumpResult, error) {
+	resources := []client.ObjectList{
+		&v1.ClickHouseClusterList{},
+		&v1.KeeperClusterList{},
+		&corev1.ConfigMapList{},
+		&corev1.SecretList{},
+		&corev1.ServiceList{},
+		&corev1.PodList{},
+		&batchv1.JobList{},
+		&appsv1.StatefulSetList{},
+		&policyv1.PodDisruptionBudgetList{},
+		&networkingv1.NetworkPolicyList{},
+	}
+
+	var errs []error
+
+	full := strings.Builder{}
+	short := strings.Builder{}
+
+	for _, resource := range resources {
+		if err := cli.List(ctx, resource, &client.ListOptions{
+			Namespace: namespace,
+		}); err != nil {
+			errs = append(errs, fmt.Errorf("list %T: %w", resource, err))
+			continue
+		}
+
+		marshalled, err := json.MarshalIndent(resource, "", "  ")
+		if err != nil {
+			errs = append(errs, fmt.Errorf("marshal %T: %w", resource, err))
+			continue
+		}
+
+		_, _ = fmt.Fprintf(&full, "Dump %T:\n", resource)
+		full.Write(marshalled)
+		full.WriteString("\n\n")
+
+		// Short dump: one state line per object where a summary exists,
+		// resource type + object names otherwise.
+		states, names := summarizeObjects(resource)
+		for _, state := range states {
+			short.WriteString(state)
+			short.WriteString("\n")
+		}
+
+		if len(names) > 0 {
+			_, _ = fmt.Fprintf(&short, "%T: %s\n", resource, strings.Join(names, ", "))
+		}
+	}
+
+	return DumpResult{Short: short.String(), Full: full.String()}, errors.Join(errs...)
+}
+
+func summarizeObjects(list client.ObjectList) (states, names []string) {
+	items := reflect.ValueOf(list).Elem().FieldByName("Items")
+
+	for i := range items.Len() {
+		obj := items.Index(i).Addr().Interface().(client.Object) //nolint:forcetypeassert
+
+		if state := summarizeObject(obj); state != "" {
+			states = append(states, state)
+		} else {
+			names = append(names, obj.GetName())
+		}
+	}
+
+	return states, names
+}
+
+func summarizeObject(obj client.Object) string {
+	switch o := obj.(type) {
+	case *v1.ClickHouseCluster:
+		return fmt.Sprintf("ClickHouseCluster %s: %s", o.Name, formatConditions(o.Status.Conditions))
+	case *v1.KeeperCluster:
+		return fmt.Sprintf("KeeperCluster %s: %s", o.Name, formatConditions(o.Status.Conditions))
+	case *batchv1.Job:
+		return fmt.Sprintf("Job %s: active=%d succeeded=%d failed=%d",
+			o.Name, o.Status.Active, o.Status.Succeeded, o.Status.Failed)
+	case *corev1.Pod:
+		return fmt.Sprintf("Pod %s: %s", o.Name, formatPodState(o))
+	}
+
+	return ""
+}
+
+func dumpPodLogs(
+	ctx context.Context, clientset kubernetes.Clientset, ns, name, container string, previous bool,
+) (string, error) {
+	stream, err := clientset.CoreV1().Pods(ns).GetLogs(name, &corev1.PodLogOptions{
+		Container: container,
+		Previous:  previous,
+	}).Stream(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get %s/%s/%s logs: %w", ns, name, container, err)
+	}
+
+	defer func() {
+		_ = stream.Close()
+	}()
+
+	logs, err := io.ReadAll(stream)
+	if err != nil {
+		return "", fmt.Errorf("read %s/%s/%s logs: %w", ns, name, container, err)
+	}
+
+	return string(logs), nil
+}
+
+// DumpNamespacePodLogs collects logs for all pod containers in the given namespace.
+// The short dump contains only the last logTailLines lines per container.
+func dumpNamespacePodLogs(ctx context.Context, config *rest.Config, namespace string) (DumpResult, error) {
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return DumpResult{}, fmt.Errorf("unable to create k8s client: %w", err)
+	}
+
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return DumpResult{}, fmt.Errorf("list pods in namespace %s: %w", namespace, err)
+	}
+
+	var errs []error
+
+	full := strings.Builder{}
+	short := strings.Builder{}
+
+	processContainer := func(name, container string, previous bool) {
+		logs, err := dumpPodLogs(ctx, *clientset, namespace, name, container, previous)
+		if err != nil {
+			errs = append(errs, err)
+			return
+		}
+
+		suffix := ""
+		if previous {
+			suffix = " (previous)"
+		}
+
+		header := fmt.Sprintf("Container logs %s/%s/%s%s:\n", namespace, name, container, suffix)
+		full.WriteString(header)
+		short.WriteString(header)
+
+		if len(logs) == 0 {
+			full.WriteString("<empty>\n\n")
+			short.WriteString("<empty>\n\n")
+			return
+		}
+
+		full.WriteString(logs)
+		full.WriteString("\n\n")
+
+		short.WriteString(tailLines(logs, logTailLines))
+		short.WriteString("\n\n")
+	}
+
+	for _, pod := range pods.Items {
+		restarted := map[string]bool{}
+		for _, cs := range slices.Concat(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses) {
+			restarted[cs.Name] = cs.RestartCount > 0
+		}
+
+		processPodContainer := func(name, container string) {
+			processContainer(name, container, false)
+
+			if restarted[container] {
+				processContainer(name, container, true)
+			}
+		}
+
+		for _, container := range pod.Spec.InitContainers {
+			processPodContainer(pod.Name, container.Name)
+		}
+
+		for _, container := range pod.Spec.Containers {
+			processPodContainer(pod.Name, container.Name)
+		}
+
+		for _, container := range pod.Spec.EphemeralContainers {
+			processPodContainer(pod.Name, container.Name)
+		}
+	}
+
+	return DumpResult{Short: short.String(), Full: full.String()}, errors.Join(errs...)
+}
+
+// tailLines returns the last n lines from s.
+func tailLines(s string, n int) string {
+	if len(s) == 0 {
+		return ""
+	}
+
+	truncatePos := len(s) - 1
+	for ; truncatePos > 0 && n > 0; truncatePos-- {
+		if s[truncatePos] == '\n' {
+			n--
+		}
+	}
+
+	if truncatePos == 0 {
+		return s
+	}
+
+	return "TRUNCATED" + s[truncatePos+1:]
+}
+
+// DumpNamespaceEvents fetches all events in the namespace that occurred since sinceTime.
+func dumpNamespaceEvents(ctx context.Context, cli client.Client, namespace string, since time.Time) (string, error) {
+	var events corev1.EventList
+	if err := cli.List(ctx, &events, client.InNamespace(namespace)); err != nil {
+		return "", fmt.Errorf("list events: %w", err)
+	}
+
+	slices.SortFunc(events.Items, func(a, b corev1.Event) int {
+		return cmp.Compare(a.CreationTimestamp.UnixNano(), b.CreationTimestamp.UnixNano())
+	})
+
+	var buf strings.Builder
+	for _, event := range events.Items {
+		if event.CreationTimestamp.After(since) {
+			_, _ = fmt.Fprintf(&buf, "%s\t%s\t%s/%s\t%s\t%s\n",
+				event.CreationTimestamp.Format(time.RFC3339),
+				event.Type,
+				event.InvolvedObject.Kind,
+				event.InvolvedObject.Name,
+				event.Reason,
+				event.Message,
+			)
+		}
+	}
+
+	return buf.String(), nil
+}

--- a/test/testutil/utils.go
+++ b/test/testutil/utils.go
@@ -1,42 +1,26 @@
 package testutil
 
 import (
-	"cmp"
 	"context"
 	"crypto/md5" //nolint:gosec
 	"encoding/hex"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
-	"regexp"
 	"runtime"
-	"slices"
 	"strings"
-	"time"
 
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"golang.org/x/sync/errgroup"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
 )
 
 const (
@@ -47,41 +31,6 @@ const (
 	BaseVersion   = "26.3.21.7"
 	UpdateVersion = "26.7.5.10"
 )
-
-var (
-	unsafeFileNameChars = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
-)
-
-// DumpResult holds a short summary and the full dump content.
-type DumpResult struct {
-	Short string
-	Full  string
-}
-
-// Empty returns true if no data dumped.
-func (d *DumpResult) Empty() bool {
-	return len(d.Full) == 0
-}
-
-// WriteFull writes the full dump to a file inside dir and returns the file path.
-func (d *DumpResult) WriteFull(dir, filename string) (string, error) {
-	if d.Full == "" {
-		return "", nil
-	}
-
-	filename = unsafeFileNameChars.ReplaceAllString(filename, "")
-
-	if err := os.MkdirAll(dir, 0o750); err != nil {
-		return "", fmt.Errorf("create dump dir %s: %w", dir, err)
-	}
-
-	path := filepath.Join(dir, filename)
-	if err := os.WriteFile(path, []byte(d.Full), 0o600); err != nil {
-		return "", fmt.Errorf("write dump file %s: %w", path, err)
-	}
-
-	return path, nil
-}
 
 // CurrentSpecHash returns a stable hash for the currently running Ginkgo spec.
 func CurrentSpecHash() string {
@@ -180,324 +129,6 @@ func GetProjectDir() (string, error) {
 
 		dir = parent
 	}
-}
-
-// DumpNamespaceDiagnostics dumps resources, pod logs and events from namespace.
-func DumpNamespaceDiagnostics(ctx context.Context, config *rest.Config, cli client.Client, ns, dir string) {
-	By("collecting diagnostics report")
-
-	report := CurrentSpecReport()
-
-	resDump, err := DumpNamespaceResources(ctx, cli, ns)
-	if err != nil {
-		GinkgoWriter.Printf("failed to dump namespace resources: %v\n", err)
-	}
-
-	if !resDump.Empty() {
-		path, writeErr := resDump.WriteFull(dir, fmt.Sprintf("resources-%s.log", report.FullText()))
-		if writeErr != nil {
-			GinkgoWriter.Printf("failed to write resources dump: %v\n", writeErr)
-		}
-
-		GinkgoWriter.Printf("\n=== Namespace Resources ===\n%s", resDump.Short)
-
-		if path != "" {
-			GinkgoWriter.Printf("Full resources dump: %s\n", path)
-		}
-	}
-
-	logsDump, err := DumpNamespacePodLogs(ctx, config, ns)
-	if err != nil {
-		GinkgoWriter.Printf("failed to dump pod logs: %v\n", err)
-	}
-
-	if !logsDump.Empty() {
-		path, writeErr := logsDump.WriteFull(dir, fmt.Sprintf("pod-logs-%s.log", report.FullText()))
-		if writeErr != nil {
-			GinkgoWriter.Printf("failed to write pod logs dump: %v\n", writeErr)
-		}
-
-		GinkgoWriter.Printf("\n=== Pod Logs (last 10 lines per container) ===\n%s", logsDump.Short)
-
-		if path != "" {
-			GinkgoWriter.Printf("Full pod logs dump: %s\n", path)
-		}
-	}
-
-	events, err := DumpNamespaceEvents(ctx, cli, ns, report.StartTime)
-	if err != nil {
-		GinkgoWriter.Printf("failed to dump namespace events: %v\n", err)
-	}
-
-	if strings.TrimSpace(events) != "" {
-		path, writeErr := (&DumpResult{Full: events}).WriteFull(dir, fmt.Sprintf("events-%s.log", report.FullText()))
-		if writeErr != nil {
-			GinkgoWriter.Printf("failed to write events dump: %v\n", writeErr)
-		}
-
-		GinkgoWriter.Printf("\n=== Namespace Events (since test start) ===\n%s\n", events)
-
-		if path != "" {
-			GinkgoWriter.Printf("Full events dump: %s\n", path)
-		}
-	}
-}
-
-func formatPodState(pod *corev1.Pod) string {
-	containers := slices.Concat(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses)
-
-	parts := make([]string, 0, 1+len(containers))
-	parts = append(parts, "phase="+string(pod.Status.Phase))
-
-	for _, cs := range containers {
-		state := fmt.Sprintf("ready=%t", cs.Ready)
-
-		switch {
-		case cs.State.Waiting != nil:
-			state = "waiting=" + cs.State.Waiting.Reason
-		case cs.State.Terminated != nil:
-			state = "terminated=" + cs.State.Terminated.Reason
-		}
-
-		parts = append(parts, fmt.Sprintf("%s[%s restarts=%d]", cs.Name, state, cs.RestartCount))
-	}
-
-	return strings.Join(parts, " ")
-}
-
-// FormatConditions renders conditions as "Type=Status(Reason): message" entries.
-func FormatConditions(conditions []metav1.Condition) string {
-	if len(conditions) == 0 {
-		return "<no conditions>"
-	}
-
-	parts := make([]string, 0, len(conditions))
-
-	for _, cond := range conditions {
-		part := fmt.Sprintf("%s=%s(%s)", cond.Type, cond.Status, cond.Reason)
-		if cond.Status != metav1.ConditionTrue && cond.Message != "" {
-			part += ": " + cond.Message
-		}
-
-		parts = append(parts, part)
-	}
-
-	return strings.Join(parts, "; ")
-}
-
-// DumpNamespaceResources collects all resources in the namespace.
-// The full dump contains the complete JSON representation of each resource,
-// while the short dump contains only the resource type and object names.
-func DumpNamespaceResources(ctx context.Context, cli client.Client, namespace string) (DumpResult, error) {
-	resources := []client.ObjectList{
-		&v1.ClickHouseClusterList{},
-		&v1.KeeperClusterList{},
-		&corev1.ConfigMapList{},
-		&corev1.SecretList{},
-		&corev1.ServiceList{},
-		&corev1.PodList{},
-		&batchv1.JobList{},
-		&appsv1.StatefulSetList{},
-		&policyv1.PodDisruptionBudgetList{},
-		&networkingv1.NetworkPolicyList{},
-	}
-
-	var errs []error
-
-	full := strings.Builder{}
-	short := strings.Builder{}
-
-	for _, resource := range resources {
-		if err := cli.List(ctx, resource, &client.ListOptions{
-			Namespace: namespace,
-		}); err != nil {
-			errs = append(errs, fmt.Errorf("list %T: %w", resource, err))
-			continue
-		}
-
-		marshalled, err := json.MarshalIndent(resource, "", "  ")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("marshal %T: %w", resource, err))
-			continue
-		}
-
-		_, _ = fmt.Fprintf(&full, "Dump %T:\n", resource)
-		full.Write(marshalled)
-		full.WriteString("\n\n")
-
-		// Short dump: one state line per object where a summary exists,
-		// resource type + object names otherwise.
-		states, names := summarizeObjects(resource)
-		for _, state := range states {
-			short.WriteString(state)
-			short.WriteString("\n")
-		}
-
-		if len(names) > 0 {
-			_, _ = fmt.Fprintf(&short, "%T: %s\n", resource, strings.Join(names, ", "))
-		}
-	}
-
-	return DumpResult{Short: short.String(), Full: full.String()}, errors.Join(errs...)
-}
-
-func summarizeObjects(list client.ObjectList) (states, names []string) {
-	items := reflect.ValueOf(list).Elem().FieldByName("Items")
-
-	for i := range items.Len() {
-		obj := items.Index(i).Addr().Interface().(client.Object) //nolint:forcetypeassert
-
-		if state := summarizeObject(obj); state != "" {
-			states = append(states, state)
-		} else {
-			names = append(names, obj.GetName())
-		}
-	}
-
-	return states, names
-}
-
-func summarizeObject(obj client.Object) string {
-	switch o := obj.(type) {
-	case *v1.ClickHouseCluster:
-		return fmt.Sprintf("ClickHouseCluster %s: %s", o.Name, FormatConditions(o.Status.Conditions))
-	case *v1.KeeperCluster:
-		return fmt.Sprintf("KeeperCluster %s: %s", o.Name, FormatConditions(o.Status.Conditions))
-	case *batchv1.Job:
-		return fmt.Sprintf("Job %s: active=%d succeeded=%d failed=%d",
-			o.Name, o.Status.Active, o.Status.Succeeded, o.Status.Failed)
-	case *corev1.Pod:
-		return fmt.Sprintf("Pod %s: %s", o.Name, formatPodState(o))
-	}
-
-	return ""
-}
-
-func dumpPodLogs(ctx context.Context, clientset kubernetes.Clientset, ns, name, container string) (string, error) {
-	stream, err := clientset.CoreV1().Pods(ns).GetLogs(name, &corev1.PodLogOptions{
-		Container: container,
-	}).Stream(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get %s/%s/%s logs: %w", ns, name, container, err)
-	}
-
-	defer func() {
-		_ = stream.Close()
-	}()
-
-	logs, err := io.ReadAll(stream)
-	if err != nil {
-		return "", fmt.Errorf("read %s/%s/%s logs: %w", ns, name, container, err)
-	}
-
-	return string(logs), nil
-}
-
-// DumpNamespacePodLogs collects logs for all pod containers in the given namespace.
-// The short dump contains only the last logTailLines lines per container.
-func DumpNamespacePodLogs(ctx context.Context, config *rest.Config, namespace string) (DumpResult, error) {
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return DumpResult{}, fmt.Errorf("unable to create k8s client: %w", err)
-	}
-
-	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return DumpResult{}, fmt.Errorf("list pods in namespace %s: %w", namespace, err)
-	}
-
-	var errs []error
-
-	full := strings.Builder{}
-	short := strings.Builder{}
-
-	processContainer := func(name, container string) {
-		logs, err := dumpPodLogs(ctx, *clientset, namespace, name, container)
-		if err != nil {
-			errs = append(errs, err)
-			return
-		}
-
-		header := fmt.Sprintf("Container logs %s/%s/%s:\n", namespace, name, container)
-		full.WriteString(header)
-		short.WriteString(header)
-
-		if len(logs) == 0 {
-			full.WriteString("<empty>\n\n")
-			short.WriteString("<empty>\n\n")
-			return
-		}
-
-		full.WriteString(logs)
-		full.WriteString("\n\n")
-
-		short.WriteString(tailLines(logs, logTailLines))
-		short.WriteString("\n\n")
-	}
-
-	for _, pod := range pods.Items {
-		for _, container := range pod.Spec.InitContainers {
-			processContainer(pod.Name, container.Name)
-		}
-
-		for _, container := range pod.Spec.Containers {
-			processContainer(pod.Name, container.Name)
-		}
-
-		for _, container := range pod.Spec.EphemeralContainers {
-			processContainer(pod.Name, container.Name)
-		}
-	}
-
-	return DumpResult{Short: short.String(), Full: full.String()}, errors.Join(errs...)
-}
-
-// tailLines returns the last n lines from s.
-func tailLines(s string, n int) string {
-	if len(s) == 0 {
-		return ""
-	}
-
-	truncatePos := len(s) - 1
-	for ; truncatePos > 0 && n > 0; truncatePos-- {
-		if s[truncatePos] == '\n' {
-			n--
-		}
-	}
-
-	if truncatePos == 0 {
-		return s
-	}
-
-	return "TRUNCATED" + s[truncatePos+1:]
-}
-
-// DumpNamespaceEvents fetches all events in the namespace that occurred since sinceTime.
-func DumpNamespaceEvents(ctx context.Context, cli client.Client, namespace string, since time.Time) (string, error) {
-	var events corev1.EventList
-	if err := cli.List(ctx, &events, client.InNamespace(namespace)); err != nil {
-		return "", fmt.Errorf("list events: %w", err)
-	}
-
-	slices.SortFunc(events.Items, func(a, b corev1.Event) int {
-		return cmp.Compare(a.CreationTimestamp.UnixNano(), b.CreationTimestamp.UnixNano())
-	})
-
-	var buf strings.Builder
-	for _, event := range events.Items {
-		if event.CreationTimestamp.After(since) {
-			_, _ = fmt.Fprintf(&buf, "%s\t%s\t%s/%s\t%s\t%s\n",
-				event.CreationTimestamp.Format(time.RFC3339),
-				event.Type,
-				event.InvolvedObject.Kind,
-				event.InvolvedObject.Name,
-				event.Reason,
-				event.Message,
-			)
-		}
-	}
-
-	return buf.String(), nil
 }
 
 // SetupCA sets up a self-signed CA issuer and a CA certificate in the given namespace.
@@ -600,26 +231,33 @@ func PreloadImages(ctx context.Context, images []string) *errgroup.Group {
 	return g
 }
 
+// TestNamespace returns the deterministic namespace name unique for every test.
+func TestNamespace() string {
+	return "e2e-" + CurrentSpecHash()
+}
+
 // EnsureNamespace ensures the test namespace is created and active.
-func EnsureNamespace(ctx context.Context, k8sClient client.Client, name string) {
+func EnsureNamespace(ctx context.Context, env *Env, name string) {
+	cli := env.Client
+
 	DeferCleanup(func(ctx context.Context) {
 		ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
 
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, &ns)
+		err := cli.Get(ctx, types.NamespacedName{Name: name}, &ns)
 		if err != nil {
 			return
 		}
 
-		if err := k8sClient.Delete(ctx, &ns); err != nil {
+		if err := cli.Delete(ctx, &ns); err != nil {
 			GinkgoWriter.Printf("failed to delete namespace %s: %v\n", name, err)
 		}
 	})
 
 	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
-	err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, &ns)
+	err := cli.Get(ctx, types.NamespacedName{Name: name}, &ns)
 
 	if k8serrors.IsNotFound(err) {
-		ExpectWithOffset(1, k8sClient.Create(ctx, &ns)).To(Succeed())
+		ExpectWithOffset(1, cli.Create(ctx, &ns)).To(Succeed())
 		return
 	}
 
@@ -630,9 +268,16 @@ func EnsureNamespace(ctx context.Context, k8sClient client.Client, name string) 
 	}
 
 	Eventually(func() bool {
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, &ns)
+		err := cli.Get(ctx, types.NamespacedName{Name: name}, &ns)
 		return k8serrors.IsNotFound(err)
 	}, "5s", "100ms").Should(BeTrue())
 
-	ExpectWithOffset(1, k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})).To(Succeed())
+	ExpectWithOffset(1, cli.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}})).To(Succeed())
+}
+
+// EnsureTestNamespace ensures that unique per test namespace is created and returns its name.
+func EnsureTestNamespace(ctx context.Context, env *Env) string {
+	ns := TestNamespace()
+	EnsureNamespace(ctx, env, ns)
+	return ns
 }

--- a/test/testutil/wait.go
+++ b/test/testutil/wait.go
@@ -1,0 +1,232 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+// ClickHouseValidator checks invariants on every polling tick of WaitClickHouseUpdatedAndReady:
+// violations fail hard (Expect). Non-informative errors are skipped.
+type ClickHouseValidator func(ctx context.Context, cr *v1.ClickHouseCluster)
+
+// WaitClickHouseUpdatedAndReady waits until the cluster rollout completes and all replicas are ready.
+func (e *Env) WaitClickHouseUpdatedAndReady(
+	ctx context.Context,
+	cr *v1.ClickHouseCluster,
+	timeout time.Duration,
+	validators ...ClickHouseValidator,
+) {
+	By(fmt.Sprintf("waiting for cluster %s to be ready", cr.Name))
+	EventuallyWithOffset(1, func(g Gomega) {
+		var cluster v1.ClickHouseCluster
+		g.Expect(e.Client.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
+		g.Expect(cluster.Generation).To(Equal(cluster.Status.ObservedGeneration))
+
+		for _, val := range validators {
+			val(ctx, &cluster)
+		}
+
+		count := int(cr.Replicas() * cr.Shards())
+
+		g.Expect(cluster.Status.CurrentRevision).
+			To(Equal(cluster.Status.UpdateRevision), "rollout should eventually complete")
+		g.Expect(cluster.Status.ReadyReplicas).
+			To(BeEquivalentTo(count), "all replicas should be ready")
+
+		var pods corev1.PodList
+		g.Expect(e.Client.List(ctx, &pods, client.InNamespace(cr.Namespace), client.MatchingLabels{
+			controllerutil.LabelAppKey: cr.SpecificName(),
+		})).To(Succeed())
+		g.Expect(pods.Items).To(HaveLen(count))
+
+		expectConditionsTrue(g, cluster.Status.Conditions,
+			v1.ConditionTypeReady,
+			v1.ConditionTypeHealthy,
+			v1.ConditionTypeClusterSizeAligned,
+			v1.ConditionTypeConfigurationInSync,
+			v1.ClickHouseConditionTypeSchemaInSync,
+		)
+
+		for _, pod := range pods.Items {
+			g.Expect(CheckPodReady(&pod)).To(BeTrue(), fmt.Sprintf("pod %s is not ready", pod.Name))
+		}
+	}, timeout).WithPolling(PollInterval).Should(Succeed())
+}
+
+// WaitKeeperUpdatedAndReady waits until the keeper rollout completes and all replicas are ready.
+func (e *Env) WaitKeeperUpdatedAndReady(
+	ctx context.Context, cr *v1.KeeperCluster, timeout time.Duration, isUpdate bool,
+) {
+	By(fmt.Sprintf("waiting for cluster %s to be ready", cr.Name))
+	EventuallyWithOffset(1, func(g Gomega) {
+		var cluster v1.KeeperCluster
+		g.Expect(e.Client.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
+		g.Expect(cluster.Generation).To(Equal(cluster.Status.ObservedGeneration))
+
+		if isUpdate {
+			// Intentional global assertion to fail suite if update order is wrong.
+			Expect(e.CheckUpdateOrder(ctx, &client.ListOptions{
+				Namespace: cluster.Namespace,
+				LabelSelector: labels.SelectorFromSet(map[string]string{
+					controllerutil.LabelAppKey: cluster.SpecificName(),
+				}),
+			}, controllerutil.LabelKeeperReplicaID, cluster.Status.StatefulSetRevision)).To(Succeed())
+		}
+
+		g.Expect(cluster.Status.CurrentRevision).To(Equal(cluster.Status.UpdateRevision))
+		g.Expect(cluster.Status.ReadyReplicas).To(Equal(cluster.Replicas()))
+
+		expectConditionsTrue(g, cluster.Status.Conditions,
+			v1.ConditionTypeReady,
+			v1.ConditionTypeHealthy,
+			v1.ConditionTypeClusterSizeAligned,
+			v1.ConditionTypeConfigurationInSync,
+		)
+	}, timeout).WithPolling(PollInterval).Should(Succeed())
+	// Needed for replica deletion to not forward deleting pods.
+	By(fmt.Sprintf("waiting for cluster %s replicas count match", cr.Name))
+	e.WaitReplicaCount(ctx, cr.Namespace, cr.SpecificName(), int(cr.Replicas()))
+}
+
+// WaitClusterReady waits for the Ready condition only, reporting all conditions on failure.
+func (e *Env) WaitClusterReady(ctx context.Context, cluster client.Object, timeout time.Duration) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		g.Expect(e.Client.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+
+		var conditions []metav1.Condition
+
+		switch cr := cluster.(type) {
+		case *v1.ClickHouseCluster:
+			conditions = cr.Status.Conditions
+		case *v1.KeeperCluster:
+			conditions = cr.Status.Conditions
+		}
+
+		g.Expect(meta.IsStatusConditionTrue(conditions, v1.ConditionTypeReady)).
+			To(BeTrue(), "%T %s not ready: %s", cluster, cluster.GetName(), formatConditions(conditions))
+	}, timeout, "5s").Should(Succeed())
+}
+
+// WaitDeploymentAvailable waits until the deployment rollout completes and it reports Available.
+func (e *Env) WaitDeploymentAvailable(ctx context.Context, namespace, name string, timeout time.Duration) {
+	GinkgoHelper()
+
+	Eventually(func(g Gomega) {
+		var deploy appsv1.Deployment
+		g.Expect(e.Client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, &deploy)).To(Succeed())
+
+		replicas := int32(1)
+		if deploy.Spec.Replicas != nil {
+			replicas = *deploy.Spec.Replicas
+		}
+
+		g.Expect(deploy.Status.ObservedGeneration).To(BeNumerically(">=", deploy.Generation))
+		g.Expect(deploy.Status.UpdatedReplicas).To(Equal(replicas))
+		g.Expect(deploy.Status.AvailableReplicas).To(Equal(replicas))
+	}, timeout, PollInterval).Should(Succeed())
+}
+
+// WaitReplicaCount waits until the pod count for the app label matches replicas.
+func (e *Env) WaitReplicaCount(ctx context.Context, namespace, app string, replicas int) {
+	Eventually(func(g Gomega) int {
+		var pods corev1.PodList
+		g.Expect(e.Client.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{
+			controllerutil.LabelAppKey: app,
+		})).To(Succeed())
+
+		return len(pods.Items)
+	}).WithTimeout(time.Minute).WithPolling(PollInterval).Should(Equal(replicas))
+}
+
+// CheckPodReady returns true when the pod's Ready condition is true.
+func CheckPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+// CheckUpdateOrder lists StatefulSets for the given app and validates rolling update invariants:
+// 1. Updated StatefulSets form a contiguous group from the highest replica ID
+// 2. At most one StatefulSet has zero ready replicas (the one currently being updated).
+func (e *Env) CheckUpdateOrder(ctx context.Context, selector *client.ListOptions, replicaLabel, stsRev string) error {
+	var stsList appsv1.StatefulSetList
+	Expect(e.Client.List(ctx, &stsList, selector)).To(Succeed())
+
+	if len(stsList.Items) < 2 {
+		return nil
+	}
+
+	notReadyCount := 0
+	updated := make([]bool, len(stsList.Items))
+
+	for _, sts := range stsList.Items {
+		index, err := strconv.Atoi(sts.Labels[replicaLabel])
+		Expect(err).NotTo(HaveOccurred())
+
+		if sts.Status.ReadyReplicas != 1 {
+			notReadyCount++
+		}
+
+		updated[index] = controllerutil.GetSpecHashFromObject(&sts) == stsRev
+	}
+
+	if notReadyCount > 1 {
+		return fmt.Errorf("%d replicas not ready, expected at most 1", notReadyCount)
+	}
+
+	// The controller updates the highest-index replica first.
+	// If it doesn't match the target revisions, either the rollout hasn't started
+	// or the revisions are stale (cluster status read before the STS list) — skip.
+	if !updated[len(updated)-1] {
+		return nil
+	}
+
+	// find the first updated replica (lowest index that matches target)
+	updatedID := 0
+	for i, isUpdated := range updated {
+		if isUpdated {
+			updatedID = i
+			break
+		}
+	}
+
+	// all replicas above the first updated one must also be updated
+	for i := updatedID + 1; i < len(updated); i++ {
+		if !updated[i] {
+			return fmt.Errorf("replica %d updated before %d", updatedID, i)
+		}
+	}
+
+	return nil
+}
+
+func expectConditionsTrue(g Gomega, conditions []metav1.Condition, types ...v1.ConditionType) {
+	for _, conditionType := range types {
+		cond := meta.FindStatusCondition(conditions, conditionType)
+		g.Expect(cond).ToNot(BeNil())
+		g.Expect(cond.Status).To(
+			Equal(metav1.ConditionTrue),
+			fmt.Sprintf("condition %s is false: %s", cond.Type, cond.Message),
+		)
+	}
+}

--- a/test/testutil/wait.go
+++ b/test/testutil/wait.go
@@ -137,6 +137,7 @@ func (e *Env) WaitDeploymentAvailable(ctx context.Context, namespace, name strin
 		}
 
 		g.Expect(deploy.Status.ObservedGeneration).To(BeNumerically(">=", deploy.Generation))
+		g.Expect(deploy.Status.Replicas).To(Equal(replicas))
 		g.Expect(deploy.Status.UpdatedReplicas).To(Equal(replicas))
 		g.Expect(deploy.Status.AvailableReplicas).To(Equal(replicas))
 	}, timeout, PollInterval).Should(Succeed())


### PR DESCRIPTION
## Why

E2e suites tend to have local helpers that are useful in all of them
This is a preparation step for the later E2E enhancements.

## What

Deduplicate and reuse code between different e2e tests suites