### PR TITLE
test: add max CRD size check, add version probe job retries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,8 +468,21 @@ CRD_BASE_REF ?= origin/main
 # that are structural to the k8s API, not operator design choices. These are automatically
 # suppressed by ratcheting for existing fields, but appear when adding new fields that embed core types.
 CRD_COMPAT_EMBEDDED_TYPE_RE := (securityContext|windowsOptions)\.|metadata\.(labels|annotations) |resources\.(limits|requests) |selector\.matchLabels|nodeSelector
+# Budget below etcd's ~1MiB per-object cap so CRD growth fails CI before installs break.
+CRD_MAX_BYTES ?= 800000
+.PHONY: check-crd-size
+check-crd-size: ## Fail if any CRD manifest exceeds $(CRD_MAX_BYTES) bytes.
+	@FAILED=0; \
+	for crd in config/crd/bases/*.yaml; do \
+		SIZE=$$(wc -c < "$$crd"); \
+		if [ "$$SIZE" -gt $(CRD_MAX_BYTES) ]; then \
+			echo "$$crd is $$SIZE bytes, exceeds budget of $(CRD_MAX_BYTES) (etcd object cap is ~1MiB)"; \
+			FAILED=1; \
+		fi; \
+	done; \
+	exit $$FAILED
 .PHONY: check-crd-compat
-check-crd-compat: crd-schema-checker ## Check CRD backward compatibility against $(CRD_BASE_REF).
+check-crd-compat: crd-schema-checker check-crd-size ## Check CRD backward compatibility against $(CRD_BASE_REF).
 	@FAILED=0; \
 	for crd in config/crd/bases/*.yaml; do \
 		echo "Checking $$crd against $(CRD_BASE_REF)..."; \

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -469,7 +469,7 @@ func (r *clickhouseReconciler) reconcileVersionProbe(ctx context.Context, log ct
 		meta.RemoveStatusCondition(r.Cluster.GetStatus().GetConditions(), v1.ConditionTypeVersionUpgraded)
 	}
 
-	return chctrl.StepContinue(), nil
+	return chctrl.StepRequeue(probeResult.RetryAfter), nil
 }
 
 func (r *clickhouseReconciler) reconcileActiveReplicaStatus(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {

--- a/internal/controller/versionprobe.go
+++ b/internal/controller/versionprobe.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -22,15 +25,36 @@ import (
 )
 
 const (
-	DefaultProbeCPULimit      = "1"
-	DefaultProbeCPURequest    = "250m"
-	DefaultProbeMemoryLimit   = "256Mi"
-	DefaultProbeMemoryRequest = "256Mi"
-	versionProbeBinary        = "/usr/bin/clickhouse"
-	versionProbeQuery         = "INSERT INTO FUNCTION file('/dev/termination-log', 'RawBLOB', 'version String') SELECT version()"
-	versionProbeBackoffLimit  = int32(1)
-	versionProbeDeadline      = int64(90)
+	DefaultProbeCPULimit        = "1"
+	DefaultProbeCPURequest      = "250m"
+	DefaultProbeMemoryLimit     = "256Mi"
+	DefaultProbeMemoryRequest   = "256Mi"
+	versionProbeBinary          = "/usr/bin/clickhouse"
+	versionProbeQuery           = "INSERT INTO FUNCTION file('/dev/termination-log', 'RawBLOB', 'version String') SELECT version()"
+	versionProbeBackoffLimit    = int32(4)
+	versionProbeDeadline        = int64(300)
+	versionProbeRetryAnnotation = "clickhouse.com/version-probe-retry"
+	versionProbeRetryMaxDelay   = 32 * time.Minute
 )
+
+// versionProbeRetryBackoff is a backoff config for failed version probe jobs recreation.
+var versionProbeRetryBackoff = wait.Backoff{
+	Duration: time.Minute,
+	Factor:   2,
+	Cap:      versionProbeRetryMaxDelay,
+}
+
+func versionProbeRetryDelay(attempt int) time.Duration {
+	backoff := versionProbeRetryBackoff
+	backoff.Steps = attempt + 1
+
+	delay := backoff.Duration
+	for range attempt + 1 {
+		delay = backoff.Step()
+	}
+
+	return delay
+}
 
 // VersionProbeConfig holds parameters for the version probe Job.
 type VersionProbeConfig struct {
@@ -58,6 +82,8 @@ type VersionProbeResult struct {
 	Pending bool
 	// Err if version probe failed it contains the error.
 	Err error
+	// RetryAfter is the remaining cooldown before a failed probe Job is recreated.
+	RetryAfter time.Duration
 	// Revision is the image hash of the probe, set on successful completion.
 	Revision string
 }
@@ -133,7 +159,36 @@ func (rm *ResourceManager) VersionProbe(
 			return VersionProbeResult{Pending: true}, nil
 		}
 
-		return VersionProbeResult{Err: errors.New(c.Message)}, nil
+		attempt, _ := strconv.Atoi(existingJob.Annotations[versionProbeRetryAnnotation])
+
+		if cooldown := versionProbeRetryDelay(attempt) - time.Since(c.LastTransitionTime.Time); cooldown > 0 {
+			return VersionProbeResult{Pending: true, RetryAfter: cooldown, Err: errors.New(c.Message)}, nil
+		}
+
+		log.Debug("retry cooldown elapsed, recreating failed version probe job", "attempt", attempt+1)
+
+		if delErr := rm.Delete(
+			ctx,
+			&existingJob,
+			v1.EventActionVersionCheck,
+			client.PropagationPolicy(metav1.DeletePropagationBackground),
+		); delErr != nil {
+			return VersionProbeResult{}, fmt.Errorf("delete failed version probe job: %w", delErr)
+		}
+
+		job.Annotations = controllerutil.MergeMaps(job.Annotations, map[string]string{
+			versionProbeRetryAnnotation: strconv.Itoa(attempt + 1),
+		})
+
+		if err = rm.Create(ctx, &job, v1.EventActionVersionCheck); err != nil {
+			if k8serrors.IsAlreadyExists(err) {
+				return VersionProbeResult{Pending: true}, nil
+			}
+
+			return VersionProbeResult{}, fmt.Errorf("recreate version probe job: %w", err)
+		}
+
+		return VersionProbeResult{Pending: true}, nil
 	}
 
 	if c, ok := getJobCondition(&existingJob, batchv1.JobComplete); !ok || c.Status != corev1.ConditionTrue {

--- a/internal/controller/versionprobe_test.go
+++ b/internal/controller/versionprobe_test.go
@@ -3,9 +3,12 @@ package controller
 import (
 	"context"
 
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -420,7 +423,7 @@ var _ = Describe("VersionProbe caching", func() {
 		Expect(jobs.Items).To(HaveLen(1))
 	})
 
-	It("should retain a failed probe Job with the same spec", func(ctx context.Context) {
+	It("should retain a failed probe Job during the retry cooldown", func(ctx context.Context) {
 		rm, log := setupProbeTest()
 		cfg := probeCfg("clickhouse/clickhouse-server", "", "")
 
@@ -431,15 +434,80 @@ var _ = Describe("VersionProbe caching", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		job.Status.Conditions = []batchv1.JobCondition{{
-			Type:    batchv1.JobFailed,
-			Status:  corev1.ConditionTrue,
-			Message: "deadline exceeded",
+			Type:               batchv1.JobFailed,
+			Status:             corev1.ConditionTrue,
+			Message:            "deadline exceeded",
+			LastTransitionTime: metav1.Now(),
 		}}
 		Expect(rm.ctrl.GetClient().Create(ctx, &job)).To(Succeed())
 
 		result, err := rm.VersionProbe(ctx, log, cfg)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Err).To(MatchError("deadline exceeded"))
+		Expect(result.Pending).To(BeTrue())
+		Expect(result.RetryAfter).To(BeNumerically(">", 0))
+
+		var jobs batchv1.JobList
+		Expect(rm.ctrl.GetClient().List(ctx, &jobs, client.InNamespace("default"))).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1))
+	})
+
+	It("should recreate a failed probe Job with backoff after the retry cooldown", func(ctx context.Context) {
+		rm, log := setupProbeTest()
+		cfg := probeCfg("clickhouse/clickhouse-server", "", "")
+
+		revision, err := imageRevision(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		job, err := rm.buildVersionProbeJob(cfg, revision)
+		Expect(err).NotTo(HaveOccurred())
+
+		job.Status.Conditions = []batchv1.JobCondition{{
+			Type:               batchv1.JobFailed,
+			Status:             corev1.ConditionTrue,
+			Message:            "deadline exceeded",
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Minute)),
+		}}
+		Expect(rm.ctrl.GetClient().Create(ctx, &job)).To(Succeed())
+
+		result, err := rm.VersionProbe(ctx, log, cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Err).NotTo(HaveOccurred())
+		Expect(result.Pending).To(BeTrue())
+		Expect(result.RetryAfter).To(BeZero())
+
+		var jobs batchv1.JobList
+		Expect(rm.ctrl.GetClient().List(ctx, &jobs, client.InNamespace("default"))).To(Succeed())
+		Expect(jobs.Items).To(HaveLen(1))
+		Expect(jobs.Items[0].Annotations).To(HaveKeyWithValue(versionProbeRetryAnnotation, "1"))
+	})
+
+	It("should grow the retry cooldown with the recorded attempt count", func(ctx context.Context) {
+		rm, log := setupProbeTest()
+		cfg := probeCfg("clickhouse/clickhouse-server", "", "")
+
+		revision, err := imageRevision(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		job, err := rm.buildVersionProbeJob(cfg, revision)
+		Expect(err).NotTo(HaveOccurred())
+
+		job.Annotations = controllerutil.MergeMaps(job.Annotations, map[string]string{
+			versionProbeRetryAnnotation: "3",
+		})
+		job.Status.Conditions = []batchv1.JobCondition{{
+			Type:               batchv1.JobFailed,
+			Status:             corev1.ConditionTrue,
+			Message:            "deadline exceeded",
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-2 * time.Minute)),
+		}}
+		Expect(rm.ctrl.GetClient().Create(ctx, &job)).To(Succeed())
+
+		result, err := rm.VersionProbe(ctx, log, cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Err).To(MatchError("deadline exceeded"))
+		Expect(result.Pending).To(BeTrue())
+		Expect(result.RetryAfter).To(BeNumerically(">", 5*time.Minute))
 
 		var jobs batchv1.JobList
 		Expect(rm.ctrl.GetClient().List(ctx, &jobs, client.InNamespace("default"))).To(Succeed())


### PR DESCRIPTION
## Why

CRD size grows fast and we need to detect when it grows close to k8s 1mb limit.
E2E test runners have restricted resources which sometimes results in the failed probe jobs, which block the tests as they are not retried.  

## What

- Add CRD size check
- Add version probe job retries with backoff