### PR TITLE
test: enforce NetworkPolicies in e2e and deploy tests

### DIFF
--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -83,6 +83,9 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	By("installing the cert-manager")
 	Expect(testutil.InstallCertManager(ctx)).To(Succeed())
 
+	By("installing the NetworkPolicy controller")
+	Expect(testutil.InstallNetworkPolicyController(ctx)).To(Succeed())
+
 	Expect(testutil.MustRun(ctx, "helm",
 		"upgrade", "--install", "prometheus", "-n", "prometheus", "--create-namespace",
 		"oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack",
@@ -543,6 +546,7 @@ func testDeployment(namespace string) {
 						Tag: version,
 					},
 				},
+				NetworkPolicy: &v1.KeeperNetworkPolicySpec{Policy: v1.NetworkPolicyEnabled},
 			},
 		}
 		Expect(k8sClient.Create(ctx, &keeper)).To(Succeed())
@@ -568,6 +572,7 @@ func testDeployment(namespace string) {
 						Tag: version,
 					},
 				},
+				NetworkPolicy: &v1.ClickHouseNetworkPolicySpec{Policy: v1.NetworkPolicyEnabled},
 			},
 		}
 		Expect(k8sClient.Create(ctx, &ch)).To(Succeed())

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
@@ -1562,6 +1563,17 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			name = fmt.Sprintf("np-test-%d", rand.Uint32()) //nolint:gosec
 		)
 
+		By("denying all ingress in the test namespace by default", func() {
+			denyAll := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "default-deny-ingress"},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+				},
+			}
+			Expect(k8sClient.Create(ctx, denyAll)).To(Succeed())
+		})
+
 		keeper := v1.KeeperCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ns,
@@ -1610,6 +1622,26 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			env.ClickHouseRWChecks(ctx, &cluster, new(0))
 		})
 
+		By("allowing client traffic with a user-defined policy", func() {
+			nativePort := intstr.FromInt32(9000)
+			allowClients := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "allow-clients"},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{controllerutil.LabelAppKey: cluster.SpecificName()},
+					},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+					Ingress: []networkingv1.NetworkPolicyIngressRule{{
+						From: []networkingv1.NetworkPolicyPeer{{
+							PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"role": "allowed"}},
+						}},
+						Ports: []networkingv1.NetworkPolicyPort{{Protocol: new(corev1.ProtocolTCP), Port: &nativePort}},
+					}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, allowClients)).To(Succeed())
+		})
+
 		By("operator creates the NetworkPolicy with the expected shape")
 		Eventually(func(g Gomega) {
 			var np networkingv1.NetworkPolicy
@@ -1634,6 +1666,42 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			g.Expect(clients).To(HaveLen(2)) // operator + referencing cluster
 			g.Expect(clients[1].PodSelector.MatchLabels).To(HaveKeyWithValue(controllerutil.LabelAppKey, cluster.SpecificName()))
 		}).WithTimeout(time.Minute).WithPolling(pollingInterval).Should(Succeed())
+
+		// Probes wearing the cluster pod labels match the managed policies' internal peers exactly.
+		clickhousePodLabels := map[string]string{
+			controllerutil.LabelAppKey:  cluster.SpecificName(),
+			controllerutil.LabelRoleKey: controllerutil.LabelClickHouseValue,
+		}
+		keeperPodLabels := map[string]string{
+			controllerutil.LabelAppKey:  keeper.SpecificName(),
+			controllerutil.LabelRoleKey: controllerutil.LabelKeeperValue,
+		}
+
+		replicaHost := cluster.HostnameByID(v1.ClickHouseReplicaID{})
+		replicaInternalHost := cluster.InternalHostnameByID(v1.ClickHouseReplicaID{})
+		keeperHost := keeper.HostnameByID(0)
+
+		connectivityChecks := []struct {
+			name   string
+			target string
+			port   int
+			labels map[string]string
+		}{
+			{name: "a client matching the user-defined policy can reach the native port", target: replicaHost, port: 9000,
+				labels: map[string]string{"role": "allowed"}},
+			{name: "replica can reach the interserver port", target: replicaInternalHost, port: 9009,
+				labels: clickhousePodLabels},
+			{name: "keeper replica can reach the raft port", target: keeperHost, port: 9234, labels: keeperPodLabels},
+			{name: "clickhouse can reach the keeper client port", target: keeperHost, port: 2181, labels: clickhousePodLabels},
+		}
+
+		for i, tc := range connectivityChecks {
+			By("allowed: " + tc.name)
+
+			probe := env.RunConnectivityProbe(ctx, ns, fmt.Sprintf("probe-%d", i), tc.target, tc.port, tc.labels)
+			Eventually(env.ProbePhase(ctx, probe)).WithTimeout(time.Minute).WithPolling(pollingInterval).
+				Should(Equal(corev1.PodSucceeded))
+		}
 
 		By("disabling cluster networkPolicy removes its policy")
 		Expect(k8sClient.Get(ctx, cluster.NamespacedName(), &cluster)).To(Succeed())

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -198,6 +198,9 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	By("installing the cert-manager")
 	Expect(testutil.InstallCertManager(ctx)).To(Succeed())
 
+	By("installing the NetworkPolicy controller")
+	Expect(testutil.InstallNetworkPolicyController(ctx)).To(Succeed())
+
 	By("setting up the manager")
 
 	mgr, err := ctrl.NewManager(config, ctrl.Options{

--- a/test/testutil/probes.go
+++ b/test/testutil/probes.go
@@ -1,0 +1,46 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// RunConnectivityProbe starts a pod that checks TCP connectivity to the target once.
+func (e *Env) RunConnectivityProbe(
+	ctx context.Context, ns, name, target string, port int, podLabels map[string]string,
+) *corev1.Pod {
+	GinkgoHelper()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name, Labels: podLabels},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:    "probe",
+				Image:   "busybox:1.36",
+				Command: []string{"sh", "-c", fmt.Sprintf("nc -z -w3 %s %d", target, port)},
+			}},
+		},
+	}
+
+	Expect(e.Client.Create(ctx, pod)).To(Succeed())
+	DeferCleanup(func(ctx context.Context) { _ = e.Client.Delete(ctx, pod) })
+
+	return pod
+}
+
+// ProbePhase polls the probe pod phase for Eventually assertions.
+func (e *Env) ProbePhase(ctx context.Context, pod *corev1.Pod) func(Gomega) corev1.PodPhase {
+	return func(g Gomega) corev1.PodPhase {
+		var p corev1.Pod
+		g.Expect(e.Client.Get(ctx, client.ObjectKeyFromObject(pod), &p)).To(Succeed())
+
+		return p.Status.Phase
+	}
+}

--- a/test/testutil/utils.go
+++ b/test/testutil/utils.go
@@ -27,6 +27,10 @@ const (
 	certmanagerVersion = "v1.19.2"
 	certmanagerURLTmpl = "https://github.com/cert-manager/cert-manager/releases/download/%s/cert-manager.yaml"
 
+	networkPolicyControllerVersion = "v1.1.1"
+	networkPolicyControllerURLTmpl = "https://raw.githubusercontent.com" +
+		"/kubernetes-sigs/kube-network-policies/%s/install.yaml"
+
 	logTailLines  = 10
 	BaseVersion   = "26.3.21.7"
 	UpdateVersion = "26.7.5.10"
@@ -82,6 +86,25 @@ func InstallCRDs(ctx context.Context) error {
 // UninstallCRDs removes the CRDs from the cluster using make uninstall.
 func UninstallCRDs(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "make", "uninstall", "ignore-not-found=true")
+	_, err := Run(cmd)
+
+	return err
+}
+
+// InstallNetworkPolicyController installs kube-network-policies so the default kind CNI enforces NetworkPolicies.
+func InstallNetworkPolicyController(ctx context.Context) error {
+	url := fmt.Sprintf(networkPolicyControllerURLTmpl, networkPolicyControllerVersion)
+
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", url)
+	if _, err := Run(cmd); err != nil {
+		return err
+	}
+
+	cmd = exec.CommandContext(ctx, "kubectl", "rollout", "status", "daemonset/kube-network-policies",
+		"--namespace", "kube-system",
+		"--timeout", "2m",
+	)
+
 	_, err := Run(cmd)
 
 	return err


### PR DESCRIPTION
## Why

Need to check that the created NetworkPolicies are useful and allow the cluster to work as expected.

## What

Install NP controller in e2e tests and verify network connectivity 