### PR TITLE
fix: skip reconcile while the cluster is being deleted

### DIFF
--- a/internal/controller/clickhouse/controller.go
+++ b/internal/controller/clickhouse/controller.go
@@ -88,6 +88,13 @@ func (cc *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	logger := cc.Logger.WithContext(ctx, cluster)
 
+	if !cluster.DeletionTimestamp.IsZero() {
+		logger.Info("clickhouse cluster is being deleted, skipping reconcile")
+		cc.connCache.Evict(req.NamespacedName, cc.Logger)
+
+		return ctrl.Result{}, nil
+	}
+
 	if err := cc.Webhook.Default(ctx, cluster); err != nil {
 		return ctrl.Result{}, fmt.Errorf("fill defaults before reconcile: %w", err)
 	}

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -16,6 +16,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -686,6 +687,60 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 		Expect(suite.Client.Get(ctx, client.ObjectKeyFromObject(&secret), &secret)).To(Succeed())
 		Expect(secret.Data).To(HaveKey(SecretKeyManagementPassword))
 		Expect(secret.Data).To(HaveKey(SecretKeyClusterSecret))
+	})
+
+	It("should not recreate resources while the cluster is being deleted", func(ctx context.Context) {
+		By("creating a cluster to delete")
+
+		deletingCR := &v1.ClickHouseCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deleting",
+				Namespace: "default",
+			},
+			Spec: v1.ClickHouseClusterSpec{
+				Replicas:         new(int32(1)),
+				Shards:           new(int32(1)),
+				KeeperClusterRef: v1.KeeperClusterReference{Name: keeperName},
+			},
+		}
+		Expect(suite.Client.Create(ctx, deletingCR)).To(Succeed())
+
+		_, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: deletingCR.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+
+		testutil.CompleteVersionProbeJob(ctx, suite, deletingCR.Namespace, deletingCR.SpecificName(), "26.1.1.1")
+
+		_, err = controller.Reconcile(ctx, ctrl.Request{NamespacedName: deletingCR.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+
+		testutil.AssertEvents(recorder.Events, map[string]int{
+			"ClusterNotReady": 1,
+		})
+
+		stsKey := types.NamespacedName{
+			Namespace: deletingCR.Namespace,
+			Name:      deletingCR.StatefulSetNameByReplicaID(v1.ClickHouseReplicaID{ShardID: 0, Index: 0}),
+		}
+
+		var sts appsv1.StatefulSet
+		Expect(suite.Client.Get(ctx, stsKey, &sts)).To(Succeed())
+
+		By("foreground-deleting the cluster so it stays pending deletion")
+		Expect(suite.Client.Delete(ctx, deletingCR, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+		Expect(suite.Client.Get(ctx, deletingCR.NamespacedName(), deletingCR)).To(Succeed())
+		Expect(deletingCR.DeletionTimestamp.IsZero()).To(BeFalse())
+
+		By("removing a dependent as foreground garbage collection would")
+		Expect(suite.Client.Delete(ctx, &sts)).To(Succeed())
+
+		By("reconciling the deleting cluster")
+
+		result, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: deletingCR.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeZero())
+
+		By("checking the dependent was not recreated")
+		Expect(k8serrors.IsNotFound(suite.Client.Get(ctx, stsKey, &sts))).To(BeTrue())
 	})
 })
 

--- a/internal/controller/keeper/controller.go
+++ b/internal/controller/keeper/controller.go
@@ -72,6 +72,12 @@ func (cc *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	logger := cc.Logger.WithContext(ctx, cluster)
 
+	if !cluster.DeletionTimestamp.IsZero() {
+		logger.Info("keeper cluster is being deleted, skipping reconcile")
+
+		return ctrl.Result{}, nil
+	}
+
 	if err := cc.Webhook.Default(ctx, cluster); err != nil {
 		return ctrl.Result{}, fmt.Errorf("fill defaults before reconcile: %w", err)
 	}

--- a/internal/controller/keeper/controller_test.go
+++ b/internal/controller/keeper/controller_test.go
@@ -12,6 +12,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,6 +20,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
@@ -298,6 +300,54 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 		listOpts := controllerutil.AppRequirements(cr.Namespace, cr.SpecificName())
 		Expect(suite.Client.List(ctx, &pdbs, listOpts)).To(Succeed())
 		Expect(pdbs.Items).To(BeEmpty())
+	})
+
+	It("should not recreate resources while the cluster is being deleted", func(ctx context.Context) {
+		By("creating a cluster to delete")
+
+		deletingCR := &v1.KeeperCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "deleting",
+				Namespace: "default",
+			},
+			Spec: v1.KeeperClusterSpec{
+				Replicas: new(int32(1)),
+			},
+		}
+		Expect(suite.Client.Create(ctx, deletingCR)).To(Succeed())
+
+		_, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: deletingCR.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+
+		testutil.AssertEvents(recorder.Events, map[string]int{
+			"ReplicaCreated":  1,
+			"ClusterNotReady": 1,
+		})
+
+		stsKey := types.NamespacedName{
+			Namespace: deletingCR.Namespace,
+			Name:      deletingCR.StatefulSetNameByReplicaID(0),
+		}
+
+		var sts appsv1.StatefulSet
+		Expect(suite.Client.Get(ctx, stsKey, &sts)).To(Succeed())
+
+		By("foreground-deleting the cluster so it stays pending deletion")
+		Expect(suite.Client.Delete(ctx, deletingCR, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+		Expect(suite.Client.Get(ctx, deletingCR.NamespacedName(), deletingCR)).To(Succeed())
+		Expect(deletingCR.DeletionTimestamp.IsZero()).To(BeFalse())
+
+		By("removing a dependent as foreground garbage collection would")
+		Expect(suite.Client.Delete(ctx, &sts)).To(Succeed())
+
+		By("reconciling the deleting cluster")
+
+		result, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: deletingCR.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeZero())
+
+		By("checking the dependent was not recreated")
+		Expect(k8serrors.IsNotFound(suite.Client.Get(ctx, stsKey, &sts))).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION
Neither Reconciler checked the CR's deletionTimestamp before syncing. A foreground delete (e.g. an Argo CD prune) therefore livelocks: garbage collection removes a dependent resource, e.g. `statefulset/clickhouse`, the Owns() watch re-enqueues the CR, and the sync recreates the dependent with blockOwnerDeletion set, so the foregroundDeletion finalizer never clears and the cluster churns StatefulSets every few seconds until the operator is scaled down.

Return early from both Reconcilers when the cluster carries a deletionTimestamp, evicting the connection cache the same way the not-found path does.

## Why

Deleting a `ClickHouseCluster` with foreground cascading deletion never completes — the operator and the Kubernetes garbage collector fight each other forever.

Observed on a real cluster: a `ClickHouseCluster` was deleted with `propagationPolicy=Foreground` (this is what an Argo CD prune with the foreground option, or `kubectl delete --cascade=foreground`, issues).

Two hours later the CR (Custom Resource) still existed with the `foregroundDeletion` finalizer, and the namespace showed a StatefulSet and pod that were perpetually 1 second old. The event log showed `SuccessfulCreate` on the StatefulSet every 3–5 seconds, continuously, until the operator was scaled down, or a background deletion was done.

## What

Both Reconcilers (`ClickHouseCluster` and `KeeperCluster`) now return early when the CR carries a `deletionTimestamp`, instead of running the sync pipeline. The ClickHouse Reconciler also evicts the connection cache on this path, the same way its existing not-found branch does.

