### PR TITLE
fix: Use the correct `grants.query[]` form over `grants[].query`

### DIFF
--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -763,7 +763,8 @@ data:
           - '@from_env': READER_PASSWORD
         profile: default
         grants:
-          - query: "GRANT SELECT ON *.*"
+          query:
+            - "GRANT SELECT ON *.*"
 ---
 apiVersion: v1
 kind: Secret

--- a/examples/custom_configuration.yaml
+++ b/examples/custom_configuration.yaml
@@ -29,4 +29,5 @@ spec:
           password_sha256_hex: "8e67dd1355714239acde098b6f1cf906bde45be6db826dc2caca7536e07ae844"
           profile: default
           grants:
-            - query: "GRANT SELECT ON *.*"
+            query:
+              - "GRANT SELECT ON *.*"

--- a/internal/controller/clickhouse/templates/users.yaml.tmpl
+++ b/internal/controller/clickhouse/templates/users.yaml.tmpl
@@ -10,7 +10,8 @@ users:
     no_password:
     {{ end}}
     grants:
-      - query: "GRANT ALL ON *.* WITH GRANT OPTION"
+      query:
+        - "GRANT ALL ON *.* WITH GRANT OPTION"
   {{ .OperatorUserName }}:
     profile: {{ .OperatorProfileName }}
     quota: default
@@ -18,7 +19,8 @@ users:
       '@hide_in_preprocessed': true
       '#text': {{ .OperatorUserPasswordHash }}
     grants: {{/* TODO restrict */}}
-      - query: "GRANT ALL ON *.*"
+      query:
+        - "GRANT ALL ON *.*"
 profiles:
   {{ .DefaultProfileName }}:
     log_queries: 1

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -749,7 +749,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Data: map[string]string{
 					"user.yaml": fmt.Sprintf(`{"users": {"%s": {
 					"password_sha256_hex": "%s",
-					"grants": [{"query": "GRANT ALL ON *.*"}]
+					"grants": {"query": ["GRANT ALL ON *.*"]}
 				}}}`, auth.Username, controllerutil.Sha256Hash([]byte(auth.Password))),
 					"config.yaml": `{"max_table_size_to_drop": 7}`,
 				},
@@ -1199,7 +1199,8 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
 
 				cr.Spec.Settings.ExtraUsersConfig.Raw = []byte(fmt.Sprintf(`{"users": {"e2e_test_user": {
-					"password_sha256_hex": "%s", "grants": [{"query": "GRANT ALL ON *.* WITH GRANT OPTION"}]}}}`,
+					"password_sha256_hex": "%s",
+					"grants": {"query": ["GRANT ALL ON *.* WITH GRANT OPTION"]}}}}`,
 					controllerutil.Sha256Hash([]byte(password)),
 				))
 				Expect(k8sClient.Update(ctx, &cr)).To(Succeed())


### PR DESCRIPTION
## Why

`grants[].query` creates sibling grants that wont be applied if multiple are applied while `grants.query[]` correctly creates multiple queries in one grant

## What

Use the correct form for raw config, so that if someone looks at the examples and extrapolates they use the correct form, and fix tests that use the incorrect form that happen to work because they only specify one grants