### PR TITLE
test: enable race detector for e2e, assert no leaked goroutines after suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,15 +154,15 @@ fuzz: fuzz-keeper fuzz-clickhouse ## Run all fuzz tests
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e: ## Run all e2e tests. Honors E2E_SHARD_INDEX / E2E_SHARD_TOTAL for CI sharding.
-	go test ./test/e2e/ -test.timeout 30m -v --ginkgo.v --ginkgo.junit-report=report/junit-report.xml --ginkgo.json-report=report/ginkgo-report.json
+	go test ./test/e2e/ -race -test.timeout 30m -v --ginkgo.v --ginkgo.junit-report=report/junit-report.xml --ginkgo.json-report=report/ginkgo-report.json
 
 .PHONY: test-keeper-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-keeper-e2e: ## Run keeper e2e tests.
-	go test ./test/e2e/ --ginkgo.label-filter keeper -test.timeout 30m -v --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
+	go test ./test/e2e/ -race --ginkgo.label-filter keeper -test.timeout 30m -v --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
 .PHONY: test-clickhouse-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-clickhouse-e2e: ## Run clickhouse e2e tests.
-	go test ./test/e2e/ --ginkgo.label-filter clickhouse -test.timeout 30m -v --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
+	go test ./test/e2e/ -race --ginkgo.label-filter clickhouse -test.timeout 30m -v --ginkgo.v --ginkgo.junit-report=report/junit-report.xml
 
 .PHONY: test-compat-e2e  # Run compatibility smoke tests across ClickHouse versions.
 test-compat-e2e: ## Run compatibility e2e tests (requires CLICKHOUSE_VERSION env var).

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -44,6 +44,8 @@ func TestControllers(t *testing.T) {
 	RunSpecs(t, "ClickHouse Controller Suite")
 }
 
+var _ = AfterSuite(testutil.AssertNoLeakedGoroutines)
+
 var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 	var (
 		suite        testutil.TestSuit

--- a/internal/controller/keeper/controller_test.go
+++ b/internal/controller/keeper/controller_test.go
@@ -37,6 +37,8 @@ func TestControllers(t *testing.T) {
 	RunSpecs(t, "Keeper Controller Suite")
 }
 
+var _ = AfterSuite(testutil.AssertNoLeakedGoroutines)
+
 var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 	var (
 		suite        testutil.TestSuit

--- a/internal/controller/testutil/suite.go
+++ b/internal/controller/testutil/suite.go
@@ -1,12 +1,14 @@
 package testutil
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"strings"
 	"time"
 
@@ -253,6 +255,21 @@ func getFirstFoundEnvTestBinaryDir() string {
 	}
 
 	return ""
+}
+
+// AssertNoLeakedGoroutines fails the suite if the runtime detects goroutines that can never be unblocked.
+func AssertNoLeakedGoroutines() {
+	GinkgoHelper()
+
+	profile := pprof.Lookup("goroutineleak")
+
+	// WriteTo runs the leak-detection GC pass, Count is only valid after it.
+	var leaks bytes.Buffer
+	Expect(profile.WriteTo(&leaks, 1)).To(Succeed())
+
+	if profile.Count() > 0 {
+		Fail(fmt.Sprintf("detected %d leaked goroutines:\n%s", profile.Count(), leaks.String()))
+	}
 }
 
 // EnsureNoEvents ensures that all events are consumed from the events channel.

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	clickhousecomv1alpha1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+	"github.com/ClickHouse/clickhouse-operator/internal/controller/testutil"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -138,6 +139,8 @@ var _ = AfterSuite(func() {
 		err := testEnv.Stop()
 		Expect(err).NotTo(HaveOccurred())
 	}
+
+	testutil.AssertNoLeakedGoroutines()
 })
 
 var _ = BeforeEach(func() {

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -920,6 +920,9 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			db, err := sql.Open("mysql", dsn)
 
 			Expect(err).NotTo(HaveOccurred())
+
+			defer func() { _ = db.Close() }()
+
 			Expect(db.PingContext(ctx)).To(Succeed())
 		})
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-operator/internal/controller/clickhouse"
 	"github.com/ClickHouse/clickhouse-operator/internal/controller/keeper"
+	ctrltestutil "github.com/ClickHouse/clickhouse-operator/internal/controller/testutil"
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
 	"github.com/ClickHouse/clickhouse-operator/internal/upgrade"
 	"github.com/ClickHouse/clickhouse-operator/test/testutil"
@@ -32,6 +33,8 @@ const (
 
 	BaseVersion   = testutil.BaseVersion
 	UpdateVersion = testutil.UpdateVersion
+
+	managerStopTimeout = 30 * time.Second
 )
 
 var releases = map[string][]upgrade.ClickHouseVersion{
@@ -143,15 +146,25 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	// +kubebuilder:scaffold:builder
 
 	mgrCtx, cancel := context.WithCancel(context.Background())
+	mgrDone := make(chan struct{})
 
 	go func() {
 		defer GinkgoRecover()
+		defer close(mgrDone)
 
 		Expect(mgr.Start(mgrCtx)).To(Succeed())
 	}()
 
 	DeferCleanup(func() {
 		cancel()
+
+		select {
+		case <-mgrDone:
+		case <-time.After(managerStopTimeout):
+			Fail("manager did not stop within " + managerStopTimeout.String())
+		}
+
+		ctrltestutil.AssertNoLeakedGoroutines()
 	})
 
 	if err = imagePuller.Wait(); err != nil {


### PR DESCRIPTION
## What

Enable race detection in e2e tests
Uses the Go 1.27 goroutineleak pprof profile: after each suite (envtest clickhouse/keeper/webhook and in-process manager e2e) fail if the runtime proves a goroutine can never be unblocked.