### PR TITLE
Reject non-positive version update intervals

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -97,6 +98,10 @@ func run() error {
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if err := validateVersionUpdateInterval(versionUpdateInterval, disableVersionUpdateChecks); err != nil {
+		return err
+	}
 
 	logger := zap.NewRaw(zap.UseFlagOptions(&opts))
 	ctrl.SetLogger(zapr.NewLogger(logger))
@@ -243,4 +248,12 @@ func run() error {
 	}
 
 	return nil
+}
+
+func validateVersionUpdateInterval(interval time.Duration, disableChecks bool) error {
+	if disableChecks || interval > 0 {
+		return nil
+	}
+
+	return errors.New("--version-update-interval must be greater than 0 when version update checks are enabled")
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,12 +99,12 @@ func run() error {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	logger := zap.NewRaw(zap.UseFlagOptions(&opts))
+	ctrl.SetLogger(zapr.NewLogger(logger))
+
 	if err := validateVersionUpdateInterval(versionUpdateInterval, disableVersionUpdateChecks); err != nil {
 		return err
 	}
-
-	logger := zap.NewRaw(zap.UseFlagOptions(&opts))
-	ctrl.SetLogger(zapr.NewLogger(logger))
 
 	disableHTTP2 := func(c *tls.Config) {
 		setupLog.Info("disabling http/2")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Command Suite")
+}
+
+var _ = DescribeTable(
+	"Version update interval validation",
+	func(interval time.Duration, disableChecks, wantError bool) {
+		err := validateVersionUpdateInterval(interval, disableChecks)
+		if wantError {
+			Expect(err).To(MatchError("--version-update-interval must be greater than 0 when version update checks are enabled"))
+		} else {
+			Expect(err).ToNot(HaveOccurred())
+		}
+	},
+	Entry("should reject zero interval if checks are enabled", time.Duration(0), false, true),
+	Entry("should reject negative interval if checks are enabled", -time.Second, false, true),
+	Entry("should accept positive interval if checks are enabled", time.Hour, false, false),
+	Entry("should allow zero interval if checks are disabled", time.Duration(0), true, false),
+	Entry("should allow negative interval if checks are disabled", -time.Second, true, false),
+)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -26,7 +26,7 @@ var _ = DescribeTable(
 	},
 	Entry("should reject zero interval if checks are enabled", time.Duration(0), false, true),
 	Entry("should reject negative interval if checks are enabled", -time.Second, false, true),
-	Entry("should accept positive interval if checks are enabled", time.Hour, false, false),
+	Entry("should accept the smallest positive interval if checks are enabled", time.Nanosecond, false, false),
 	Entry("should allow zero interval if checks are disabled", time.Duration(0), true, false),
 	Entry("should allow negative interval if checks are disabled", -time.Second, true, false),
 )

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -642,7 +642,7 @@ Two flags on the operator manager control the upgrade-check loop globally:
 
 | Flag                              | Default | Effect                                                                                                                                           |
 |-----------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--version-update-interval`       | `24h`   | How often the operator re-fetches the upstream version list                                                                                      |
+| `--version-update-interval`       | `24h`   | How often the operator re-fetches the upstream version list. Must be greater than zero when version update checks are enabled                      |
 | `--disable-version-update-checks` | `false` | Disables the upgrade checker entirely. The `VersionUpgraded` condition is not set, and no outbound HTTP traffic to `clickhouse.com` is generated |
 
 Set `--disable-version-update-checks=true` in air-gapped environments or when egress to `clickhouse.com` is not allowed.


### PR DESCRIPTION
## Summary

- **Reject invalid intervals** when version update checks are enabled.
- **Allow zero or negative values** when version update checks are disabled.
- **Add tests** for zero, negative, positive, and disabled-check cases.

## Why

With `--version-update-interval=0`, every successful version fetch schedules `time.After(0)`. This creates a tight loop of HTTP requests.

## Tests

- `make lint-fix`
- `go test ./cmd ./internal/upgrade -count=1 -v`
- `go test -race ./cmd ./internal/upgrade -count=1`
- Full non-e2e unit suite with integration-labeled specs excluded
