### PR TITLE
fix(webhook): warn when extraUsersConfig carries server-tree sections

### DIFF
--- a/internal/webhook/v1alpha1/clickhousecluster_webhook.go
+++ b/internal/webhook/v1alpha1/clickhousecluster_webhook.go
@@ -119,6 +119,8 @@ func (w *ClickHouseClusterWebhook) validateImpl(obj *chv1.ClickHouseCluster) (ad
 		errs = append(errs, err)
 	}
 
+	warns = append(warns, warnServerSectionsInUsersConfig(obj.Spec.Settings.ExtraUsersConfig.Raw)...)
+
 	additionalVolumeErrs := validateAdditionalVolumeClaimTemplates(obj.Spec.DataVolumeClaimSpec, obj.Spec.AdditionalVolumeClaimTemplates)
 	errs = append(errs, additionalVolumeErrs...)
 

--- a/internal/webhook/v1alpha1/clickhousecluster_webhook_test.go
+++ b/internal/webhook/v1alpha1/clickhousecluster_webhook_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	chv1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
@@ -179,6 +180,29 @@ var _ = Describe("ClickHouseCluster Webhook", func() {
 			Expect(err).To(Succeed())
 			deferCleanup(cluster)
 			Expect(warnings).To(ContainElement(ContainSubstring("defaultUserPassword is empty")))
+		})
+
+		It("Should warn when extraUsersConfig carries a server-tree section", func(ctx context.Context) {
+			cluster := chCluster.DeepCopy()
+			cluster.Spec.Settings.ExtraUsersConfig = runtime.RawExtension{
+				Raw: []byte(`{"named_collections":{"ctx":{"url":"http://example.internal"}},"profiles":{"default":{}}}`),
+			}
+
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			deferCleanup(cluster)
+			Expect(warnings).To(ContainElement(ContainSubstring("named_collections")))
+			Expect(warnings).To(ContainElement(ContainSubstring("users config parser ignores")))
+		})
+
+		It("Should not warn when extraUsersConfig only carries users-tree sections", func(ctx context.Context) {
+			cluster := chCluster.DeepCopy()
+			cluster.Spec.Settings.ExtraUsersConfig = runtime.RawExtension{
+				Raw: []byte(`{"profiles":{"default":{"max_threads":4}},"quotas":{"default":{}}}`),
+			}
+
+			Expect(k8sClient.Create(ctx, cluster)).To(Succeed())
+			deferCleanup(cluster)
+			Expect(warnings).NotTo(ContainElement(ContainSubstring("users config parser ignores")))
 		})
 
 		It("Should check that all volumes from volume mounts are exists", func(ctx context.Context) {

--- a/internal/webhook/v1alpha1/common.go
+++ b/internal/webhook/v1alpha1/common.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -139,4 +140,57 @@ func validateAdditionalVolumeClaimTemplatesChanges(oldTemplates, newTemplates []
 	}
 
 	return nil
+}
+
+// serverOnlyConfigSections are top-level sections that belong to the server config tree. ClickHouse
+// parses the users config with a different parser, which ignores them: the server starts clean, logs
+// nothing, and the setting silently does not apply. Warn instead of rejecting, so a cluster that
+// already carries one of these keys stays updatable.
+var serverOnlyConfigSections = []string{
+	"dictionaries",
+	"distributed_ddl",
+	"keeper_server",
+	"listen_host",
+	"logger",
+	"macros",
+	"merge_tree",
+	"named_collections",
+	"openSSL",
+	"protocols",
+	"remote_servers",
+	"storage_configuration",
+	"user_directories",
+	"zookeeper",
+}
+
+// warnServerSectionsInUsersConfig reports sections of extraUsersConfig that the users config parser
+// ignores, so they land as a silent no-op rather than an error.
+func warnServerSectionsInUsersConfig(raw []byte) admission.Warnings {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var sections map[string]any
+	if err := json.Unmarshal(raw, &sections); err != nil {
+		// Malformed content is not this check's business; the server surfaces it on start.
+		return nil
+	}
+
+	var found []string
+
+	for _, name := range serverOnlyConfigSections {
+		if _, ok := sections[name]; ok {
+			found = append(found, name)
+		}
+	}
+
+	if len(found) == 0 {
+		return nil
+	}
+
+	return admission.Warnings{fmt.Sprintf(
+		"spec.settings.extraUsersConfig sets %s, which the users config parser ignores. "+
+			"Move these to spec.settings.extraConfig, otherwise they apply nowhere and the server reports no error.",
+		strings.Join(found, ", "),
+	)}
 }


### PR DESCRIPTION
## Why

Putting a server-tree section such as `named_collections` under `spec.settings.extraUsersConfig` fails silently. The content is written to `users.d/`, where ClickHouse parses it with the users config parser, which ignores server-tree sections. The server starts clean, logs nothing, and the setting applies nowhere. @ovidiubuligan hit this and wrote it up as the "misplacement trap" in #308, having verified it against `clickhouse-server:26.7.1.1315-alpine`.

There is no validation on either `extraConfig` or `extraUsersConfig` today, so nothing catches it.

## What

The validating webhook now reports the ignored sections as an admission warning, naming them and pointing at `extraConfig`.

The list covers sections that only exist in the server config tree, most of which the operator itself renders into `config.d`: `named_collections`, `remote_servers`, `zookeeper`, `keeper_server`, `macros`, `storage_configuration`, `logger`, `listen_host`, `protocols`, `distributed_ddl`, `user_directories`, `merge_tree`, `dictionaries` and `openSSL`.

A warning rather than a rejection is deliberate. Rejecting would make a cluster that already carries such a key un-updatable until someone edits it, and the key is inert rather than harmful. If you would rather have a hard error, moving it from `warns` to `errs` is a one line change and I am happy to do it.

Malformed content is left alone here, since the server surfaces that on its own.

This does not touch the reload-versus-restart question that #308 is really about, only the trap the same issue describes.

## Related Issues

Relates to #308
