### PR TITLE
test(e2e): continuous database invariant checks

### DIFF
--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -623,7 +623,18 @@ func (r *keeperReconciler) evaluateReplicaConditions() {
 	}
 
 	r.SetCondition(chctrl.ReplicaStartupCondition(startupErrors))
-	r.SetCondition(chctrl.HealthyCondition(notReadyIDs))
+
+	if len(r.ReplicaState) < int(r.Cluster.Replicas()) {
+		r.SetCondition(metav1.Condition{
+			Type:    v1.ConditionTypeHealthy,
+			Status:  metav1.ConditionFalse,
+			Reason:  v1.ConditionReasonReplicasNotReady,
+			Message: fmt.Sprintf("Cluster has %d of %d replicas", len(r.ReplicaState), r.Cluster.Replicas()),
+		})
+	} else {
+		r.SetCondition(chctrl.HealthyCondition(notReadyIDs))
+	}
+
 	r.SetCondition(chctrl.ConfigSyncCondition(nil, notUpdatedIDs, nil))
 	r.evaluateVersionConditions(len(notUpdatedIDs) > 0)
 

--- a/test/deploy/deploy_test.go
+++ b/test/deploy/deploy_test.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -102,6 +103,12 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	serverVersion, err := dc.ServerVersion()
 	Expect(err).NotTo(HaveOccurred())
 	By("running on Kubernetes " + serverVersion.GitVersion)
+
+	DeferCleanup(env.StopCache)
+})
+
+var _ = BeforeEach(func() {
+	testutil.StartInvariants(env, metav1.NamespaceAll)
 })
 
 var _ = JustAfterEach(func(ctx context.Context) {
@@ -384,9 +391,9 @@ var _ = Describe("Operator upgrade", Ordered, ContinueOnFailure, Label("upgrade"
 		DeferCleanup(func(ctx context.Context) {
 			Expect(k8sClient.Delete(ctx, &keeperCR)).To(Succeed())
 		})
-		env.WaitClusterReady(ctx, &keeperCR, 5*time.Minute)
+		env.WaitKeeperUpdatedAndReady(ctx, &keeperCR, 5*time.Minute)
 		Expect(k8sClient.Create(ctx, &chCR)).To(Succeed())
-		env.WaitClusterReady(ctx, &chCR, 5*time.Minute)
+		env.WaitClickHouseUpdatedAndReady(ctx, &chCR, 5*time.Minute)
 
 		By("writing test data", func() {
 			// A freshly formed keeper ensemble re-elects for a while, so retry through transient leader loss.
@@ -492,12 +499,12 @@ func testHelmCluster(namespace string) {
 		})
 
 		By("Waiting for KeeperCluster to be ready")
-		env.WaitClusterReady(ctx, &v1.KeeperCluster{
+		env.WaitKeeperUpdatedAndReady(ctx, &v1.KeeperCluster{
 			Namespace: namespace, Name: keeperName,
 		}, 5*time.Minute)
 
 		By("Waiting for ClickHouse to be ready")
-		env.WaitClusterReady(ctx, &v1.ClickHouseCluster{
+		env.WaitClickHouseUpdatedAndReady(ctx, &v1.ClickHouseCluster{
 			Namespace: namespace, Name: chName,
 		}, 5*time.Minute)
 	}
@@ -519,7 +526,7 @@ func testDeployment(namespace string) {
 		})
 
 		By("Waiting for KeeperCluster to be ready")
-		env.WaitClusterReady(ctx, &keeper, 5*time.Minute)
+		env.WaitKeeperUpdatedAndReady(ctx, &keeper, 5*time.Minute)
 
 		ch := testutil.NewClickHouseCluster(namespace, "ch-"+version).
 			WithKeeper(keeper.Name).
@@ -532,7 +539,7 @@ func testDeployment(namespace string) {
 		})
 
 		By("Waiting for ClickHouse to be ready")
-		env.WaitClusterReady(ctx, &ch, 5*time.Minute)
+		env.WaitClickHouseUpdatedAndReady(ctx, &ch, 5*time.Minute)
 	}
 
 	tableArgs := make([]any, 1, len(versionEntries)+1)

--- a/test/e2e/clickhouse_e2e_test.go
+++ b/test/e2e/clickhouse_e2e_test.go
@@ -7,7 +7,6 @@ import (
 	"math/rand/v2"
 	"net"
 	"path"
-	"strconv"
 	"strings"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -57,7 +55,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				Expect(k8sClient.Delete(ctx, &keeper)).To(Succeed())
 			})
 
-			env.WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
+			env.WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute)
 		})
 
 		DescribeTable("standalone ClickHouse updates", func(ctx context.Context, specUpdate v1.ClickHouseClusterSpec) {
@@ -96,7 +94,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			cr.Spec = specUpdate
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute, validateUpdateOrder)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 3*time.Minute)
 			Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
 			Expect(cr.Status.Version).To(HavePrefix(cr.Spec.ContainerTemplate.Image.Tag))
 			env.ClickHouseRWChecks(ctx, &cr, &checks)
@@ -153,7 +151,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			cr.Spec = specUpdate
 			Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 5*time.Minute, validateUpdateOrder)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 5*time.Minute)
 			env.ClickHouseRWChecks(ctx, &cr, &checks)
 		},
 			Entry("update log level", 3, v1.ClickHouseClusterSpec{Settings: v1.ClickHouseSettings{
@@ -266,7 +264,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				By("deleting cluster CR")
 				Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 			})
-			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, validateReadyIsInitialized)
+			env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 
 			survivor, removed := v1.ClickHouseReplicaID{Index: 0}, v1.ClickHouseReplicaID{Index: 1}
 
@@ -318,7 +316,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 				defer chClient.Close()
 
 				Expect(chClient.ExecReplica(ctx, survivor, "SYSTEM START FETCHES default.test")).To(Succeed())
-				env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute, validateUpdateOrder, validateReadyIsInitialized)
+				env.WaitClickHouseUpdatedAndReady(ctx, &cr, 2*time.Minute)
 
 				var survivorRows uint64
 				Expect(chClient.QueryRowReplica(ctx, survivor, "SELECT count() FROM default.test", &survivorRows)).To(Succeed())
@@ -1366,7 +1364,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, keeperCR)).To(Succeed())
 			})
-			env.WaitKeeperUpdatedAndReady(ctx, keeperCR, 2*time.Minute, false)
+			env.WaitKeeperUpdatedAndReady(ctx, keeperCR, 2*time.Minute)
 		})
 
 		cr := baseCr.DeepCopy()
@@ -1392,7 +1390,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			}
 			Expect(k8sClient.Update(ctx, cr)).To(Succeed())
 
-			env.WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute, validateUpdateOrder)
+			env.WaitClickHouseUpdatedAndReady(ctx, cr, 2*time.Minute)
 			env.ClickHouseRWChecks(ctx, cr, &checks)
 		})
 	})
@@ -1446,7 +1444,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 		DeferCleanup(func(ctx context.Context) {
 			Expect(k8sClient.Delete(ctx, &keeper)).To(Succeed())
 		})
-		env.WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
+		env.WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute)
 
 		By("checking keeper pod affinity")
 
@@ -1563,7 +1561,7 @@ var _ = Describe("ClickHouse controller", Label("clickhouse"), func() {
 			DeferCleanup(func(ctx context.Context) {
 				Expect(k8sClient.Delete(ctx, &keeper)).To(Succeed())
 			})
-			env.WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute, false)
+			env.WaitKeeperUpdatedAndReady(ctx, &keeper, 2*time.Minute)
 		})
 
 		By("creating ClickHouse cluster with NetworkPolicies", func() {
@@ -1692,68 +1690,4 @@ func podUIDsByName(ctx context.Context, cr *v1.ClickHouseCluster) map[string]typ
 	}
 
 	return out
-}
-
-func validateUpdateOrder(ctx context.Context, cr *v1.ClickHouseCluster) {
-	GinkgoHelper()
-
-	// CheckUpdateOrder returns an error only for update-order invariant violations: fail hard.
-	for shard := range cr.Shards() {
-		Expect(env.CheckUpdateOrder(ctx, &client.ListOptions{
-			Namespace: cr.Namespace,
-			LabelSelector: labels.SelectorFromSet(map[string]string{
-				controllerutil.LabelAppKey:            cr.SpecificName(),
-				controllerutil.LabelClickHouseShardID: strconv.FormatInt(int64(shard), 10),
-			}),
-		}, controllerutil.LabelClickHouseReplicaID, cr.Status.StatefulSetRevision)).To(Succeed())
-	}
-}
-
-func validateReadyIsInitialized(ctx context.Context, cr *v1.ClickHouseCluster) {
-	GinkgoHelper()
-
-	pods := corev1.PodList{}
-	if err := k8sClient.List(ctx, &pods, client.InNamespace(cr.Namespace), client.MatchingLabels{
-		controllerutil.LabelAppKey: cr.SpecificName(),
-	}); err != nil {
-		GinkgoWriter.Printf("validateReadyIsInitialized: skipping tick, list Pods: %s\n", err)
-		return
-	}
-
-	initialized := make([]v1.ClickHouseReplicaID, 0, len(pods.Items))
-
-	for _, pod := range pods.Items {
-		if !ctrl.PodConditionTrue(&pod, v1.ReplicaInitializedCondition) {
-			continue
-		}
-
-		id, err := v1.ClickHouseIDFromLabels(pod.Labels)
-		Expect(err).NotTo(HaveOccurred())
-
-		initialized = append(initialized, id)
-	}
-
-	if len(initialized) == 0 {
-		return
-	}
-
-	// The client pings every replica, which fails while Pods are still being provisioned: skip the tick.
-	chClient, err := testutil.NewClickHouseClient(ctx, podDialer, cr)
-	if err != nil {
-		GinkgoWriter.Printf("validateReadyIsInitialized: skipping tick, connect: %s\n", err)
-		return
-	}
-
-	defer chClient.Close()
-
-	for _, id := range initialized {
-		var isReplicated bool
-		if err := chClient.QueryRowReplica(ctx, id,
-			"SELECT engine='Replicated' FROM system.databases WHERE name='default'", &isReplicated); err != nil {
-			GinkgoWriter.Printf("validateReadyIsInitialized: skipping replica %s: %s\n", id, err)
-			continue
-		}
-
-		Expect(isReplicated).To(BeTrue(), "replica should not be ready until it initialized")
-	}
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -149,8 +149,8 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	mgrDone := make(chan struct{})
 
 	go func() {
-		defer GinkgoRecover()
 		defer close(mgrDone)
+		defer GinkgoRecover()
 
 		Expect(mgr.Start(mgrCtx)).To(Succeed())
 	}()
@@ -167,6 +167,9 @@ var _ = BeforeSuite(func(ctx context.Context) {
 		ctrltestutil.AssertNoLeakedGoroutines()
 	})
 
+	// Registered after the leak assertion so the cache stops before it runs.
+	DeferCleanup(env.StopCache)
+
 	if err = imagePuller.Wait(); err != nil {
 		GinkgoWriter.Printf("failed to pre pull images: %s", err)
 	}
@@ -181,6 +184,10 @@ var _ = BeforeEach(func() {
 	if !enabled {
 		Skip(fmt.Sprintf("not in shard %d/%d", sharding.Index, sharding.Total))
 	}
+})
+
+var _ = BeforeEach(func() {
+	testutil.StartInvariants(env, testutil.TestNamespace())
 })
 
 var _ = JustAfterEach(func(ctx context.Context) {

--- a/test/e2e/keeper_e2e_test.go
+++ b/test/e2e/keeper_e2e_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 			By("deleting cluster CR")
 			Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 		})
-		env.WaitKeeperUpdatedAndReady(ctx, &cr, time.Minute, false)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, time.Minute)
 		env.KeeperRWChecks(ctx, &cr, &checks)
 
 		By("updating cluster CR")
@@ -45,7 +45,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 		cr.Spec = specUpdate
 		Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-		env.WaitKeeperUpdatedAndReady(ctx, &cr, 5*time.Minute, true)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 5*time.Minute)
 		Expect(k8sClient.Get(ctx, cr.NamespacedName(), &cr)).To(Succeed())
 		Expect(cr.Status.Version).To(HavePrefix(cr.Spec.ContainerTemplate.Image.Tag))
 		env.KeeperRWChecks(ctx, &cr, &checks)
@@ -80,7 +80,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 			By("deleting cluster CR")
 			Expect(k8sClient.Delete(ctx, &cr)).To(Succeed())
 		})
-		env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute)
 		env.KeeperRWChecks(ctx, &cr, &checks)
 
 		By("updating cluster CR")
@@ -89,7 +89,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 		cr.Spec = specUpdate
 		Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
 
-		env.WaitKeeperUpdatedAndReady(ctx, &cr, 5*time.Minute, true)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 5*time.Minute)
 		env.KeeperRWChecks(ctx, &cr, &checks)
 	},
 		Entry("update log level", 3, v1.KeeperClusterSpec{Settings: v1.KeeperSettings{
@@ -168,7 +168,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 			By("creating secure keeper cluster CR")
 			Expect(k8sClient.Create(ctx, &cr)).To(Succeed())
 			By("ensuring secure port is working")
-			env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+			env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute)
 			env.KeeperRWChecks(ctx, &cr, new(0))
 		})
 	})
@@ -201,7 +201,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 		})
 
 		By("waiting for diskless keeper to be ready")
-		env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, false)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute)
 
 		By("verifying keeper is functional with basic read/write")
 		env.KeeperRWChecks(ctx, &cr, new(0))
@@ -238,7 +238,7 @@ var _ = Describe("Keeper controller", Label("keeper"), func() {
 			Tag: BaseVersion,
 		}
 		Expect(k8sClient.Update(ctx, &cr)).To(Succeed())
-		env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute, true)
+		env.WaitKeeperUpdatedAndReady(ctx, &cr, 2*time.Minute)
 		env.KeeperRWChecks(ctx, &cr, new(0))
 	})
 })

--- a/test/openshift/openshift_test.go
+++ b/test/openshift/openshift_test.go
@@ -183,13 +183,13 @@ var _ = Describe("OLM deployment on OpenShift", func() {
 		DeferCleanup(func(ctx context.Context) { _ = k8sClient.Delete(ctx, &keeper) })
 
 		By("Waiting for KeeperCluster to be ready")
-		env.WaitClusterReady(ctx, &keeper, 15*time.Minute)
+		env.WaitKeeperUpdatedAndReady(ctx, &keeper, 15*time.Minute)
 
 		ch := testutil.NewClickHouseCluster(namespace, "ch").WithKeeper(keeper.Name).Cluster()
 		Expect(k8sClient.Create(ctx, &ch)).To(Succeed())
 		DeferCleanup(func(ctx context.Context) { _ = k8sClient.Delete(ctx, &ch) })
 
 		By("Waiting for ClickHouse to be ready")
-		env.WaitClusterReady(ctx, &ch, 15*time.Minute)
+		env.WaitClickHouseUpdatedAndReady(ctx, &ch, 15*time.Minute)
 	})
 })

--- a/test/testutil/env.go
+++ b/test/testutil/env.go
@@ -1,20 +1,87 @@
 package testutil
 
 import (
+	"context"
+	"sync"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
 )
 
-// PollInterval is the default polling interval for Eventually-style waits.
-const PollInterval = 100 * time.Millisecond
+const (
+	// PollInterval is the default polling interval for Eventually-style waits.
+	PollInterval     = 100 * time.Millisecond
+	cacheSyncTimeout = 2 * time.Minute
+)
 
 // Env bundles the suite-level handles shared by the test helpers.
 type Env struct {
 	Client client.Client
 	Config *rest.Config
 	Dialer controllerutil.DialContextFunc
+
+	cacheOnce sync.Once
+	cache     cache.Cache
+	cacheStop context.CancelFunc
+	cacheDone chan struct{}
+}
+
+// Cache lazily starts a suite-lifetime informer cache and returns it.
+// Register StopCache as a suite cleanup after the goroutine-leak assertion.
+func (e *Env) Cache() cache.Cache {
+	GinkgoHelper()
+
+	e.cacheOnce.Do(func() {
+		c, err := cache.New(e.Config, cache.Options{
+			Scheme:                      e.Client.Scheme(),
+			ReaderFailOnMissingInformer: true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, stop := context.WithCancel(context.Background())
+		e.cacheStop = stop
+		e.cacheDone = make(chan struct{})
+
+		go func() {
+			defer close(e.cacheDone)
+			defer GinkgoRecover()
+
+			Expect(c.Start(ctx)).To(Succeed())
+		}()
+
+		syncCtx, cancel := context.WithTimeout(ctx, cacheSyncTimeout)
+		defer cancel()
+
+		Expect(c.WaitForCacheSync(syncCtx)).To(BeTrue())
+
+		e.cache = c
+	})
+
+	// A failed first initialization poisons the Once: fail loudly instead of nil-panicking downstream.
+	Expect(e.cache).NotTo(BeNil(), "informer cache failed to initialize")
+
+	return e.cache
+}
+
+// StopCache stops the informer cache and waits for its goroutines to exit.
+func (e *Env) StopCache() {
+	GinkgoHelper()
+
+	if e.cacheStop == nil {
+		return
+	}
+
+	e.cacheStop()
+
+	select {
+	case <-e.cacheDone:
+	case <-time.After(cacheSyncTimeout):
+		Fail("informer cache did not stop within " + cacheSyncTimeout.String())
+	}
 }

--- a/test/testutil/invariants.go
+++ b/test/testutil/invariants.go
@@ -1,0 +1,797 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	toolscache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
+	chctrl "github.com/ClickHouse/clickhouse-operator/internal/controller"
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+const (
+	invariantPollInterval    = 250 * time.Millisecond
+	invariantPollMinInterval = 50 * time.Millisecond
+
+	operatorPodLabelKey   = "control-plane"
+	operatorPodLabelValue = "controller-manager"
+)
+
+// Violation is a single invariant breach observed during a spec.
+type Violation struct {
+	Time      time.Time
+	Invariant string
+	Object    string
+	Message   string
+	Warning   bool
+}
+
+func (v Violation) String() string {
+	return fmt.Sprintf("%s [%s] %s: %s", v.Time.Format(time.RFC3339Nano), v.Invariant, v.Object, v.Message)
+}
+
+// Invariant represents a single cluster property that should not be violated during the cluster lifetime.
+type Invariant interface {
+	Name() string
+	Check(ctx context.Context, namespace string) []Violation
+}
+
+// InvariantSet enforces invariants in a background goroutine for one spec.
+type InvariantSet struct {
+	cancel  context.CancelFunc
+	detach  []func() error
+	wg      sync.WaitGroup
+	stopped atomic.Bool
+
+	// violations are written by the enforcement goroutine only and read after wg.Wait.
+	violations []Violation
+}
+
+// StartInvariants launches background enforcement of all invariants; absence of violations is asserted in DeferCleanup.
+func StartInvariants(env *Env, namespace string) *InvariantSet {
+	GinkgoHelper()
+
+	reader := env.Cache()
+	invariants := []Invariant{
+		&updateOrderInvariant{reader: reader, armed: map[string]bool{}, groups: map[string]*stsGroup{}},
+		&readyStableInvariant{reader: reader, armed: map[string]clusterSize{}},
+		&readyIsInitializedInvariant{reader: reader, dialer: env.Dialer, checked: map[types.UID]bool{}},
+		&operatorStableInvariant{reader: reader},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	set := &InvariantSet{cancel: cancel}
+	triggers := make(chan struct{}, 1)
+
+	kick := func() {
+		select {
+		case triggers <- struct{}{}:
+		default:
+		}
+	}
+
+	handler := toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    func(any) { kick() },
+		UpdateFunc: func(any, any) { kick() },
+		DeleteFunc: func(any) { kick() },
+	}
+
+	watch := func(ctx context.Context, obj client.Object) error {
+		informer, err := reader.GetInformer(ctx, obj)
+		if err != nil {
+			return fmt.Errorf("get informer: %w", err)
+		}
+
+		registration, err := informer.AddEventHandler(handler)
+		if err != nil {
+			return fmt.Errorf("add event handler: %w", err)
+		}
+
+		set.detach = append(set.detach, func() error {
+			return informer.RemoveEventHandler(registration)
+		})
+
+		return nil
+	}
+
+	set.wg.Add(1)
+
+	go func() {
+		defer set.wg.Done()
+		defer GinkgoRecover()
+
+		// Lazy init informers, so suite can create CRDs
+		for _, obj := range []client.Object{
+			&v1.ClickHouseCluster{},
+			&v1.KeeperCluster{},
+			&appsv1.StatefulSet{},
+			&corev1.Pod{},
+			&appsv1.Deployment{},
+		} {
+			for watch(ctx, obj) != nil {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(invariantPollMinInterval):
+				}
+			}
+		}
+
+		timer := time.NewTimer(invariantPollInterval)
+		defer timer.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-triggers:
+			case <-timer.C:
+			}
+
+			for _, invariant := range invariants {
+				set.record(invariant.Check(ctx, namespace))
+			}
+
+			time.Sleep(invariantPollMinInterval)
+			timer.Reset(invariantPollInterval)
+		}
+	}()
+
+	DeferCleanup(set.StopAndCheck)
+
+	return set
+}
+
+// StopAndCheck stops enforcement and fails the spec on recorded violations; extra calls are no-ops.
+func (s *InvariantSet) StopAndCheck() {
+	GinkgoHelper()
+
+	if !s.stopped.CompareAndSwap(false, true) {
+		return
+	}
+
+	s.cancel()
+	s.wg.Wait()
+
+	for _, detach := range s.detach {
+		Expect(detach()).To(Succeed())
+	}
+
+	messages := make([]string, 0, len(s.violations))
+
+	for _, violation := range s.violations {
+		if violation.Warning {
+			GinkgoWriter.Printf("invariant warning: %s\n", violation.String())
+			continue
+		}
+
+		messages = append(messages, violation.String())
+	}
+
+	Expect(messages).To(BeEmpty(), "invariant violations recorded during the spec")
+}
+
+func (s *InvariantSet) record(violations []Violation) {
+	if len(violations) == 0 {
+		return
+	}
+
+	s.violations = append(s.violations, violations...)
+}
+
+// updateOrderInvariant enforces rolling-update ordering, armed per cluster at first full readiness.
+type updateOrderInvariant struct {
+	reader client.Reader
+	armed  map[string]bool
+	groups map[string]*stsGroup
+}
+
+// stsGroup carries per-StatefulSet-group state across check passes.
+type stsGroup struct {
+	// settledRevision is the last revision observed fully rolled out, separating fresh rollouts from stale CR status.
+	settledRevision string
+	// present remembers desired indexes from the previous pass to catch silent deletions.
+	present map[int]bool
+	// everReady exempts still-provisioning replicas from the unready budget: batch creation is legitimate.
+	everReady map[int]bool
+	// lastReady gates the wrong-order check: error recovery legitimately updates unready replicas first.
+	lastReady map[int]bool
+}
+
+func (u *updateOrderInvariant) Name() string { return "UpdateOrder" }
+
+func (u *updateOrderInvariant) Check(ctx context.Context, namespace string) []Violation {
+	var out []Violation
+
+	var chList v1.ClickHouseClusterList
+	if err := u.reader.List(ctx, &chList, client.InNamespace(namespace)); err != nil {
+		return nil
+	}
+
+	for i := range chList.Items {
+		cr := &chList.Items[i]
+		key := "ClickHouseCluster/" + cr.Namespace + "/" + cr.Name
+
+		if cr.DeletionTimestamp != nil {
+			delete(u.armed, key)
+
+			for shard := range cr.Shards() {
+				delete(u.groups, fmt.Sprintf("%s shard=%d", key, shard))
+			}
+
+			continue
+		}
+
+		if !u.arm(key, cr.Status.ReadyReplicas, cr.Replicas()*cr.Shards(), cr.Status.Conditions) {
+			continue
+		}
+
+		for shard := range cr.Shards() {
+			out = append(out, u.checkStatefulSets(ctx, fmt.Sprintf("%s shard=%d", key, shard), client.MatchingLabels{
+				controllerutil.LabelAppKey:            cr.SpecificName(),
+				controllerutil.LabelClickHouseShardID: strconv.FormatInt(int64(shard), 10),
+			}, cr.Namespace, controllerutil.LabelClickHouseReplicaID,
+				cr.Status.StatefulSetRevision, int(cr.Replicas()), CheckPodReady)...)
+		}
+	}
+
+	var keeperList v1.KeeperClusterList
+	if err := u.reader.List(ctx, &keeperList, client.InNamespace(namespace)); err != nil {
+		return out
+	}
+
+	for i := range keeperList.Items {
+		cr := &keeperList.Items[i]
+		key := "KeeperCluster/" + cr.Namespace + "/" + cr.Name
+
+		if cr.DeletionTimestamp != nil {
+			delete(u.armed, key)
+			delete(u.groups, key)
+
+			continue
+		}
+
+		if !u.arm(key, cr.Status.ReadyReplicas, cr.Replicas(), cr.Status.Conditions) {
+			continue
+		}
+
+		// Keeper probes reflect quorum: elections flip all pods unready, so pod presence is the clock.
+		out = append(out, u.checkStatefulSets(ctx, key, client.MatchingLabels{
+			controllerutil.LabelAppKey: cr.SpecificName(),
+		}, cr.Namespace, controllerutil.LabelKeeperReplicaID,
+			cr.Status.StatefulSetRevision, int(cr.Replicas()), podRunning)...)
+	}
+
+	return out
+}
+
+func podRunning(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodRunning
+}
+
+// arm latches at full readiness: Healthy alone is vacuously true on an empty replica state.
+func (u *updateOrderInvariant) arm(key string, readyReplicas, expected int32, conditions []metav1.Condition) bool {
+	if u.armed[key] {
+		return true
+	}
+
+	if readyReplicas == expected && meta.IsStatusConditionTrue(conditions, v1.ConditionTypeHealthy) {
+		u.armed[key] = true
+	}
+
+	return u.armed[key]
+}
+
+// checkStatefulSets validates one group: no desired-replica deletions, at most one unready, top-first updates.
+func (u *updateOrderInvariant) checkStatefulSets(
+	ctx context.Context, object string,
+	labels client.MatchingLabels, namespace, replicaLabel, stsRev string, desired int,
+	podReady func(*corev1.Pod) bool,
+) []Violation {
+	var stsList appsv1.StatefulSetList
+	if err := u.reader.List(ctx, &stsList, client.InNamespace(namespace), labels); err != nil {
+		return nil
+	}
+
+	var pods corev1.PodList
+	if err := u.reader.List(ctx, &pods, client.InNamespace(namespace), labels); err != nil {
+		return nil
+	}
+
+	// Pod readiness is the rollout clock: StatefulSet status lags it by a kube-controller-manager sync.
+	ready := map[int]bool{}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		index, err := strconv.Atoi(pod.Labels[replicaLabel])
+		if err != nil {
+			continue
+		}
+
+		if pod.DeletionTimestamp == nil && podReady(pod) {
+			ready[index] = true
+		}
+	}
+
+	group, ok := u.groups[object]
+	if !ok {
+		group = &stsGroup{everReady: map[int]bool{}}
+		u.groups[object] = group
+	}
+
+	var out []Violation
+
+	violate := func(message string) {
+		out = append(out, Violation{Time: time.Now(), Invariant: u.Name(), Object: object, Message: message})
+	}
+
+	present := map[int]bool{}
+	items := make([]indexedReplica, 0, len(stsList.Items))
+
+	for i := range stsList.Items {
+		sts := &stsList.Items[i]
+
+		index, err := strconv.Atoi(sts.Labels[replicaLabel])
+		if err != nil || index < 0 {
+			violate(fmt.Sprintf("invalid replica label of %s: %q", sts.Name, sts.Labels[replicaLabel]))
+			return out
+		}
+
+		if index >= desired {
+			continue
+		}
+
+		present[index] = true
+
+		if sts.DeletionTimestamp != nil {
+			violate(fmt.Sprintf("replica %d (%s) is being deleted while still desired", index, sts.Name))
+			continue
+		}
+
+		items = append(items, indexedReplica{sts: sts, index: index})
+	}
+
+	for index := range group.present {
+		if index < desired && !present[index] {
+			violate(fmt.Sprintf("replica %d disappeared", index))
+		}
+	}
+
+	group.present = present
+
+	if message := group.rollingOrderViolation(items, ready, stsRev, desired); message != "" {
+		violate(message)
+	}
+
+	for index := range ready {
+		group.everReady[index] = true
+	}
+
+	group.lastReady = ready
+
+	return out
+}
+
+type indexedReplica struct {
+	sts   *appsv1.StatefulSet
+	index int
+}
+
+// rollingOrderViolation reports an unready-budget or ordering breach, settling the revision on full rollout.
+func (g *stsGroup) rollingOrderViolation(
+	items []indexedReplica, ready map[int]bool, stsRev string, desired int,
+) string {
+	if len(items) < 2 {
+		return ""
+	}
+
+	notReadyCount := 0
+	updated := make([]bool, len(items))
+	states := make([]string, 0, len(items))
+
+	for _, item := range items {
+		if item.index >= len(updated) {
+			return fmt.Sprintf(
+				"replica index %d of %s out of range for %d StatefulSets", item.index, item.sts.Name, len(updated))
+		}
+
+		if !ready[item.index] && g.everReady[item.index] {
+			notReadyCount++
+		}
+
+		updated[item.index] = controllerutil.GetSpecHashFromObject(item.sts) == stsRev
+		states = append(states,
+			fmt.Sprintf("%s(ready=%t,updated=%t)", item.sts.Name, ready[item.index], updated[item.index]))
+	}
+
+	if notReadyCount > 1 {
+		return fmt.Sprintf("%d replicas not ready, expected at most 1: %s", notReadyCount, strings.Join(states, ", "))
+	}
+
+	allUpdated := true
+	for _, isUpdated := range updated {
+		allUpdated = allUpdated && isUpdated
+	}
+
+	// A fully rolled out and ready group settles the target revision.
+	if allUpdated && notReadyCount == 0 && len(items) == desired {
+		g.settledRevision = stsRev
+		return ""
+	}
+
+	switch {
+	case g.settledRevision == "":
+		// Without a settled baseline matches are ambiguous unless the highest replica leads.
+		if !updated[len(updated)-1] {
+			return ""
+		}
+	case stsRev == g.settledRevision:
+		// The CR status lags a starting rollout: matches identify not-yet-updated replicas.
+		return ""
+	case !updated[len(updated)-1]:
+		// Fresh target: the highest replica updates first, its event arrives first on the watch stream.
+		for _, item := range items {
+			if updated[item.index] && g.lastReady[item.index] {
+				return fmt.Sprintf("replica %d updated before the highest replica: %s", item.index, strings.Join(states, ", "))
+			}
+		}
+
+		return ""
+	}
+
+	// find the first updated replica (lowest index that matches target)
+	updatedID := 0
+	for i, isUpdated := range updated {
+		if isUpdated {
+			updatedID = i
+			break
+		}
+	}
+
+	// all replicas above the first updated one must also be updated
+	for i := updatedID + 1; i < len(updated); i++ {
+		if !updated[i] {
+			return fmt.Sprintf("replica %d updated before %d", updatedID, i)
+		}
+	}
+
+	return ""
+}
+
+// readyStableInvariant enforces that an armed cluster stays Ready; single-node (per-shard) clusters are exempt.
+type readyStableInvariant struct {
+	reader client.Reader
+	armed  map[string]clusterSize
+}
+
+type clusterSize struct {
+	replicas int32
+	shards   int32
+}
+
+func (r *readyStableInvariant) Name() string { return "ReadyStable" }
+
+func (r *readyStableInvariant) Check(ctx context.Context, namespace string) []Violation {
+	var out []Violation
+
+	var chList v1.ClickHouseClusterList
+	if err := r.reader.List(ctx, &chList, client.InNamespace(namespace)); err != nil {
+		return nil
+	}
+
+	for i := range chList.Items {
+		cr := &chList.Items[i]
+		key := "ClickHouseCluster/" + cr.Namespace + "/" + cr.Name
+
+		if cr.DeletionTimestamp != nil || cr.Replicas() <= 1 {
+			delete(r.armed, key)
+			continue
+		}
+
+		size := clusterSize{replicas: cr.Replicas(), shards: cr.Shards()}
+		out = append(out, r.check(key, size, cr.Status.ReadyReplicas,
+			cr.Generation, cr.Status.ObservedGeneration, cr.Status.Conditions, "")...)
+	}
+
+	var keeperList v1.KeeperClusterList
+	if err := r.reader.List(ctx, &keeperList, client.InNamespace(namespace)); err != nil {
+		return out
+	}
+
+	for i := range keeperList.Items {
+		cr := &keeperList.Items[i]
+		keeperKey := "KeeperCluster/" + cr.Namespace + "/" + cr.Name
+
+		if cr.DeletionTimestamp != nil || cr.Replicas() <= 1 {
+			delete(r.armed, keeperKey)
+			continue
+		}
+
+		// Leader restarts (no handoff today) elect through a NoLeader window: warn instead of fail.
+		key := "KeeperCluster/" + cr.Namespace + "/" + cr.Name
+		size := clusterSize{replicas: cr.Replicas(), shards: 1}
+		out = append(out, r.check(key, size, cr.Status.ReadyReplicas,
+			cr.Generation, cr.Status.ObservedGeneration, cr.Status.Conditions,
+			v1.KeeperConditionReasonNoLeader)...)
+	}
+
+	return out
+}
+
+func (r *readyStableInvariant) check(
+	key string, size clusterSize, readyReplicas int32,
+	generation, observedGeneration int64, conditions []metav1.Condition, warnReason string,
+) []Violation {
+	armed, wasArmed := r.armed[key]
+
+	if wasArmed && armed != size {
+		// Enforce through replica-count changes; re-arm when leaving a single node or changing shards.
+		if armed.replicas > 1 && armed.shards == size.shards {
+			r.armed[key] = size
+		} else {
+			delete(r.armed, key)
+
+			wasArmed = false
+		}
+	}
+
+	if !wasArmed {
+		// ReadyReplicas guards against vacuously-true conditions written from an empty replica state.
+		if readyReplicas == size.replicas*size.shards &&
+			generation == observedGeneration &&
+			meta.IsStatusConditionTrue(conditions, v1.ConditionTypeHealthy) &&
+			meta.IsStatusConditionTrue(conditions, v1.ConditionTypeClusterSizeAligned) {
+			r.armed[key] = size
+		}
+
+		return nil
+	}
+
+	cond := meta.FindStatusCondition(conditions, v1.ConditionTypeReady)
+	if cond != nil && cond.Status == metav1.ConditionFalse {
+		return []Violation{{Time: time.Now(), Invariant: r.Name(), Object: key,
+			Message: "cluster became unready: " + cond.Message, Warning: cond.Reason == warnReason}}
+	}
+
+	return nil
+}
+
+// readyIsInitializedInvariant: a gate-passing replica must already have a Replicated default database.
+type readyIsInitializedInvariant struct {
+	reader  client.Reader
+	dialer  controllerutil.DialContextFunc
+	checked map[types.UID]bool
+}
+
+func (r *readyIsInitializedInvariant) Name() string { return "ReadyIsInitialized" }
+
+func (r *readyIsInitializedInvariant) Check(ctx context.Context, namespace string) []Violation {
+	var chList v1.ClickHouseClusterList
+	if err := r.reader.List(ctx, &chList, client.InNamespace(namespace)); err != nil {
+		return nil
+	}
+
+	var out []Violation
+
+	for i := range chList.Items {
+		out = append(out, r.checkCluster(ctx, &chList.Items[i])...)
+	}
+
+	return out
+}
+
+func (r *readyIsInitializedInvariant) checkCluster(
+	ctx context.Context, cr *v1.ClickHouseCluster,
+) []Violation {
+	if cr.DeletionTimestamp != nil {
+		return nil
+	}
+
+	var pods corev1.PodList
+	if err := r.reader.List(ctx, &pods, client.InNamespace(cr.Namespace), client.MatchingLabels{
+		controllerutil.LabelAppKey: cr.SpecificName(),
+	}); err != nil {
+		return nil
+	}
+
+	object := "ClickHouseCluster/" + cr.Namespace + "/" + cr.Name
+	initialized := map[types.UID]v1.ClickHouseReplicaID{}
+
+	var out []Violation
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if r.checked[pod.UID] || !chctrl.PodConditionTrue(pod, v1.ReplicaInitializedCondition) {
+			continue
+		}
+
+		id, err := v1.ClickHouseIDFromLabels(pod.Labels)
+		if err != nil {
+			r.checked[pod.UID] = true
+
+			out = append(out, Violation{Time: time.Now(), Invariant: r.Name(), Object: object,
+				Message: fmt.Sprintf("gated pod %s has invalid replica labels: %s", pod.Name, err)})
+
+			continue
+		}
+
+		initialized[pod.UID] = id
+	}
+
+	if len(initialized) == 0 {
+		return out
+	}
+
+	// Client construction pings every replica: skip the pass while Pods are provisioning.
+	chClient, err := NewClickHouseClient(ctx, r.dialer, cr)
+	if err != nil {
+		return out
+	}
+
+	defer chClient.Close()
+
+	for uid, id := range initialized {
+		var isReplicated bool
+		if err := chClient.QueryRowReplica(ctx, id,
+			"SELECT engine='Replicated' FROM system.databases WHERE name='default'", &isReplicated); err != nil {
+			continue
+		}
+
+		r.checked[uid] = true
+
+		if !isReplicated {
+			out = append(out, Violation{Time: time.Now(), Invariant: r.Name(), Object: object,
+				Message: fmt.Sprintf("replica %s passed the readiness gate before initialization", id)})
+		}
+	}
+
+	return out
+}
+
+// operatorStableInvariant: operator pods must not restart or get replaced; Deployment changes re-baseline.
+type operatorStableInvariant struct {
+	reader      client.Reader
+	deployments map[string]deploymentIdentity
+	pods        map[string]podIdentity
+}
+
+type deploymentIdentity struct {
+	uid        string
+	generation int64
+}
+
+type podIdentity struct {
+	uid      string
+	restarts int32
+}
+
+func (o *operatorStableInvariant) Name() string { return "OperatorStable" }
+
+func (o *operatorStableInvariant) Check(ctx context.Context, _ string) []Violation {
+	var deployList appsv1.DeploymentList
+
+	err := o.reader.List(ctx, &deployList, client.MatchingLabels{operatorPodLabelKey: operatorPodLabelValue})
+	if err != nil {
+		return nil
+	}
+
+	deployments := make(map[string]deploymentIdentity, len(deployList.Items))
+	settled := true
+
+	for i := range deployList.Items {
+		deploy := &deployList.Items[i]
+		deployments[deploy.Namespace+"/"+deploy.Name] = deploymentIdentity{
+			uid:        string(deploy.UID),
+			generation: deploy.Generation,
+		}
+
+		replicas := int32(1)
+		if deploy.Spec.Replicas != nil {
+			replicas = *deploy.Spec.Replicas
+		}
+
+		if deploy.Status.ObservedGeneration < deploy.Generation ||
+			deploy.Status.Replicas != replicas ||
+			deploy.Status.UpdatedReplicas != replicas ||
+			deploy.Status.AvailableReplicas != replicas {
+			settled = false
+		}
+	}
+
+	if !maps.Equal(o.deployments, deployments) {
+		o.deployments = deployments
+		o.pods = nil
+
+		return nil
+	}
+
+	if !settled || len(deployments) == 0 {
+		o.pods = nil
+
+		return nil
+	}
+
+	current := o.listPods(ctx)
+	if current == nil {
+		return nil
+	}
+
+	if o.pods == nil {
+		if len(current) > 0 {
+			o.pods = current
+		}
+
+		return nil
+	}
+
+	var out []Violation
+
+	violate := func(object, message string) {
+		out = append(out, Violation{Time: time.Now(), Invariant: o.Name(), Object: object, Message: message})
+	}
+
+	for name, was := range o.pods {
+		now, ok := current[name]
+
+		switch {
+		case !ok:
+			violate(name, "operator pod disappeared")
+		case now.uid != was.uid:
+			violate(name, "operator pod was replaced")
+		case now.restarts > was.restarts:
+			violate(name, fmt.Sprintf("operator pod restarted %d time(s)", now.restarts-was.restarts))
+		}
+	}
+
+	for name := range current {
+		if _, ok := o.pods[name]; !ok {
+			violate(name, "unexpected new operator pod")
+		}
+	}
+
+	return out
+}
+
+func (o *operatorStableInvariant) listPods(ctx context.Context) map[string]podIdentity {
+	var pods corev1.PodList
+	if err := o.reader.List(ctx, &pods, client.MatchingLabels{operatorPodLabelKey: operatorPodLabelValue}); err != nil {
+		return nil
+	}
+
+	current := make(map[string]podIdentity, len(pods.Items))
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+
+		// Terminating leftovers from a previous deployment are not a stability signal.
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+
+		var restarts int32
+		for _, cs := range pod.Status.ContainerStatuses {
+			restarts += cs.RestartCount
+		}
+
+		current[pod.Namespace+"/"+pod.Name] = podIdentity{uid: string(pod.UID), restarts: restarts}
+	}
+
+	return current
+}

--- a/test/testutil/wait.go
+++ b/test/testutil/wait.go
@@ -3,7 +3,6 @@ package testutil
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -12,121 +11,108 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
-	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
 )
 
-// ClickHouseValidator checks invariants on every polling tick of WaitClickHouseUpdatedAndReady:
-// violations fail hard (Expect). Non-informative errors are skipped.
-type ClickHouseValidator func(ctx context.Context, cr *v1.ClickHouseCluster)
+// clusterStatus is a snapshot of the status fields shared by both cluster kinds.
+type clusterStatus struct {
+	observedGeneration int64
+	currentRevision    string
+	updateRevision     string
+	readyReplicas      int32
+	conditions         []metav1.Condition
+}
+
+func statusOf(cluster client.Object) clusterStatus {
+	switch cr := cluster.(type) {
+	case *v1.ClickHouseCluster:
+		return clusterStatus{
+			observedGeneration: cr.Status.ObservedGeneration,
+			currentRevision:    cr.Status.CurrentRevision,
+			updateRevision:     cr.Status.UpdateRevision,
+			readyReplicas:      cr.Status.ReadyReplicas,
+			conditions:         cr.Status.Conditions,
+		}
+
+	case *v1.KeeperCluster:
+		return clusterStatus{
+			observedGeneration: cr.Status.ObservedGeneration,
+			currentRevision:    cr.Status.CurrentRevision,
+			updateRevision:     cr.Status.UpdateRevision,
+			readyReplicas:      cr.Status.ReadyReplicas,
+			conditions:         cr.Status.Conditions,
+		}
+
+	default:
+		Fail(fmt.Sprintf("unsupported cluster type %T", cluster))
+		return clusterStatus{}
+	}
+}
+
+// expectedReplicas derives the expected replica count from the cluster's current spec.
+func expectedReplicas(cluster client.Object) int {
+	switch cr := cluster.(type) {
+	case *v1.ClickHouseCluster:
+		return int(cr.Replicas() * cr.Shards())
+	case *v1.KeeperCluster:
+		return int(cr.Replicas())
+	default:
+		Fail(fmt.Sprintf("unsupported cluster type %T", cluster))
+		return 0
+	}
+}
 
 // WaitClickHouseUpdatedAndReady waits until the cluster rollout completes and all replicas are ready.
-func (e *Env) WaitClickHouseUpdatedAndReady(
-	ctx context.Context,
-	cr *v1.ClickHouseCluster,
-	timeout time.Duration,
-	validators ...ClickHouseValidator,
-) {
+func (e *Env) WaitClickHouseUpdatedAndReady(ctx context.Context, cr *v1.ClickHouseCluster, timeout time.Duration) {
 	GinkgoHelper()
 
-	By(fmt.Sprintf("waiting for cluster %s to be ready", cr.Name))
-	Eventually(func(g Gomega) {
-		var cluster v1.ClickHouseCluster
-		g.Expect(e.Client.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
-		g.Expect(cluster.Generation).To(Equal(cluster.Status.ObservedGeneration))
-
-		for _, val := range validators {
-			val(ctx, &cluster)
-		}
-
-		count := int(cr.Replicas() * cr.Shards())
-
-		g.Expect(cluster.Status.CurrentRevision).
-			To(Equal(cluster.Status.UpdateRevision), "rollout should eventually complete")
-		g.Expect(cluster.Status.ReadyReplicas).
-			To(BeEquivalentTo(count), "all replicas should be ready")
-
-		var pods corev1.PodList
-		g.Expect(e.Client.List(ctx, &pods, client.InNamespace(cr.Namespace), client.MatchingLabels{
-			controllerutil.LabelAppKey: cr.SpecificName(),
-		})).To(Succeed())
-		g.Expect(pods.Items).To(HaveLen(count))
-
-		expectConditionsTrue(g, cluster.Status.Conditions,
-			v1.ConditionTypeReady,
-			v1.ConditionTypeHealthy,
-			v1.ConditionTypeClusterSizeAligned,
-			v1.ConditionTypeConfigurationInSync,
-			v1.ClickHouseConditionTypeSchemaInSync,
-		)
-
-		for _, pod := range pods.Items {
-			g.Expect(CheckPodReady(&pod)).To(BeTrue(), fmt.Sprintf("pod %s is not ready", pod.Name))
-		}
-	}, timeout).WithPolling(PollInterval).Should(Succeed())
+	e.waitUpdatedAndReady(ctx, cr, timeout,
+		v1.ConditionTypeReady,
+		v1.ConditionTypeHealthy,
+		v1.ConditionTypeClusterSizeAligned,
+		v1.ConditionTypeConfigurationInSync,
+		v1.ClickHouseConditionTypeSchemaInSync,
+	)
 }
 
 // WaitKeeperUpdatedAndReady waits until the keeper rollout completes and all replicas are ready.
-func (e *Env) WaitKeeperUpdatedAndReady(
-	ctx context.Context, cr *v1.KeeperCluster, timeout time.Duration, isUpdate bool,
+func (e *Env) WaitKeeperUpdatedAndReady(ctx context.Context, cr *v1.KeeperCluster, timeout time.Duration) {
+	GinkgoHelper()
+
+	e.waitUpdatedAndReady(ctx, cr, timeout,
+		v1.ConditionTypeReady,
+		v1.ConditionTypeHealthy,
+		v1.ConditionTypeClusterSizeAligned,
+		v1.ConditionTypeConfigurationInSync,
+	)
+}
+
+func (e *Env) waitUpdatedAndReady(
+	ctx context.Context, cr client.Object, timeout time.Duration, conditions ...v1.ConditionType,
 ) {
 	GinkgoHelper()
 
-	By(fmt.Sprintf("waiting for cluster %s to be ready", cr.Name))
+	By(fmt.Sprintf("waiting for cluster %s to be ready", cr.GetName()))
 	Eventually(func(g Gomega) {
-		var cluster v1.KeeperCluster
-		g.Expect(e.Client.Get(ctx, cr.NamespacedName(), &cluster)).To(Succeed())
-		g.Expect(cluster.Generation).To(Equal(cluster.Status.ObservedGeneration))
+		cluster, ok := cr.DeepCopyObject().(client.Object)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(e.Client.Get(ctx, client.ObjectKeyFromObject(cr), cluster)).To(Succeed())
 
-		if isUpdate {
-			// Intentional global assertion to fail suite if update order is wrong.
-			Expect(e.CheckUpdateOrder(ctx, &client.ListOptions{
-				Namespace: cluster.Namespace,
-				LabelSelector: labels.SelectorFromSet(map[string]string{
-					controllerutil.LabelAppKey: cluster.SpecificName(),
-				}),
-			}, controllerutil.LabelKeeperReplicaID, cluster.Status.StatefulSetRevision)).To(Succeed())
-		}
+		status := statusOf(cluster)
+		replicas := expectedReplicas(cluster)
 
-		g.Expect(cluster.Status.CurrentRevision).To(Equal(cluster.Status.UpdateRevision))
-		g.Expect(cluster.Status.ReadyReplicas).To(Equal(cluster.Replicas()))
+		g.Expect(cluster.GetGeneration()).To(Equal(status.observedGeneration))
+		g.Expect(status.currentRevision).
+			To(Equal(status.updateRevision), "rollout should eventually complete")
+		g.Expect(status.readyReplicas).
+			To(BeEquivalentTo(replicas), "all replicas should be ready")
 
-		expectConditionsTrue(g, cluster.Status.Conditions,
-			v1.ConditionTypeReady,
-			v1.ConditionTypeHealthy,
-			v1.ConditionTypeClusterSizeAligned,
-			v1.ConditionTypeConfigurationInSync,
-		)
+		// Conditions and status are the operator's contract with the user: trust
+		// them here so the RW checks that follow validate they are not lying.
+		expectConditionsTrue(g, status.conditions, conditions...)
 	}, timeout).WithPolling(PollInterval).Should(Succeed())
-	// Needed for replica deletion to not forward deleting pods.
-	By(fmt.Sprintf("waiting for cluster %s replicas count match", cr.Name))
-	e.WaitReplicaCount(ctx, cr.Namespace, cr.SpecificName(), int(cr.Replicas()))
-}
-
-// WaitClusterReady waits for the Ready and Healthy conditions, reporting all conditions on failure.
-func (e *Env) WaitClusterReady(ctx context.Context, cluster client.Object, timeout time.Duration) {
-	GinkgoHelper()
-
-	Eventually(func(g Gomega) {
-		g.Expect(e.Client.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
-
-		var conditions []metav1.Condition
-
-		switch cr := cluster.(type) {
-		case *v1.ClickHouseCluster:
-			conditions = cr.Status.Conditions
-		case *v1.KeeperCluster:
-			conditions = cr.Status.Conditions
-		}
-
-		for _, conditionType := range []v1.ConditionType{v1.ConditionTypeReady, v1.ConditionTypeHealthy} {
-			g.Expect(meta.IsStatusConditionTrue(conditions, conditionType)).
-				To(BeTrue(), "%T %s %s not true: %s", cluster, cluster.GetName(), conditionType, formatConditions(conditions))
-		}
-	}, timeout, "5s").Should(Succeed())
 }
 
 // WaitDeploymentAvailable waits until the deployment rollout completes and it reports Available.
@@ -149,20 +135,6 @@ func (e *Env) WaitDeploymentAvailable(ctx context.Context, namespace, name strin
 	}, timeout, PollInterval).Should(Succeed())
 }
 
-// WaitReplicaCount waits until the pod count for the app label matches replicas.
-func (e *Env) WaitReplicaCount(ctx context.Context, namespace, app string, replicas int) {
-	GinkgoHelper()
-
-	Eventually(func(g Gomega) int {
-		var pods corev1.PodList
-		g.Expect(e.Client.List(ctx, &pods, client.InNamespace(namespace), client.MatchingLabels{
-			controllerutil.LabelAppKey: app,
-		})).To(Succeed())
-
-		return len(pods.Items)
-	}).WithTimeout(time.Minute).WithPolling(PollInterval).Should(Equal(replicas))
-}
-
 // CheckPodReady returns true when the pod's Ready condition is true.
 func CheckPodReady(pod *corev1.Pod) bool {
 	for _, cond := range pod.Status.Conditions {
@@ -172,63 +144,6 @@ func CheckPodReady(pod *corev1.Pod) bool {
 	}
 
 	return false
-}
-
-// CheckUpdateOrder lists StatefulSets for the given app and validates rolling update invariants:
-// 1. Updated StatefulSets form a contiguous group from the highest replica ID
-// 2. At most one StatefulSet has zero ready replicas (the one currently being updated).
-func (e *Env) CheckUpdateOrder(ctx context.Context, selector *client.ListOptions, replicaLabel, stsRev string) error {
-	GinkgoHelper()
-
-	var stsList appsv1.StatefulSetList
-	Expect(e.Client.List(ctx, &stsList, selector)).To(Succeed())
-
-	if len(stsList.Items) < 2 {
-		return nil
-	}
-
-	notReadyCount := 0
-	updated := make([]bool, len(stsList.Items))
-
-	for _, sts := range stsList.Items {
-		index, err := strconv.Atoi(sts.Labels[replicaLabel])
-		Expect(err).NotTo(HaveOccurred())
-
-		if sts.Status.ReadyReplicas != 1 {
-			notReadyCount++
-		}
-
-		updated[index] = controllerutil.GetSpecHashFromObject(&sts) == stsRev
-	}
-
-	if notReadyCount > 1 {
-		return fmt.Errorf("%d replicas not ready, expected at most 1", notReadyCount)
-	}
-
-	// The controller updates the highest-index replica first.
-	// If it doesn't match the target revisions, either the rollout hasn't started
-	// or the revisions are stale (cluster status read before the STS list) — skip.
-	if !updated[len(updated)-1] {
-		return nil
-	}
-
-	// find the first updated replica (lowest index that matches target)
-	updatedID := 0
-	for i, isUpdated := range updated {
-		if isUpdated {
-			updatedID = i
-			break
-		}
-	}
-
-	// all replicas above the first updated one must also be updated
-	for i := updatedID + 1; i < len(updated); i++ {
-		if !updated[i] {
-			return fmt.Errorf("replica %d updated before %d", updatedID, i)
-		}
-	}
-
-	return nil
 }
 
 func expectConditionsTrue(g Gomega, conditions []metav1.Condition, types ...v1.ConditionType) {


### PR DESCRIPTION
## Why

Currently, operator behavior invariants are validated as a polling loop while waiting for reconciles to converge. 
This change rewrites these checks as a background routine that does it continuously in the every test.

## What

This implements the following checks
- Cluster remains Ready after initial creation(except 1 node)
- Operator upgrades replicas in the correct order
- Operator admits client traffic only for ready replicas
- (Deploy tests) Operator never restarted
