### PR TITLE
feat: add periodic resync, bound ClickHouse calls, fix reconcile flow

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,8 @@ import (
 
 const (
 	defaultVersionUpdateInterval = 24 * time.Hour
+	// Below the deployment's terminationGracePeriodSeconds so the post-drain lease release still happens before SIGKILL.
+	defaultShutdownTimeout = 8 * time.Second
 )
 
 var (
@@ -158,13 +160,16 @@ func run() error {
 
 	config.UserAgent = version.BuildUserAgent()
 
+	shutdownTimeout := defaultShutdownTimeout
 	mgrOptions := ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                metricsServerOptions,
-		WebhookServer:          webhookServer,
-		HealthProbeBindAddress: probeAddr,
-		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "d4ceba06.clickhouse.com",
+		Scheme:                        scheme,
+		Metrics:                       metricsServerOptions,
+		WebhookServer:                 webhookServer,
+		HealthProbeBindAddress:        probeAddr,
+		LeaderElection:                enableLeaderElection,
+		LeaderElectionID:              "d4ceba06.clickhouse.com",
+		LeaderElectionReleaseOnCancel: true,
+		GracefulShutdownTimeout:       &shutdownTimeout,
 	}
 
 	env, err := environment.GetEnvironment(context.Background())
@@ -206,12 +211,14 @@ func run() error {
 		upgradeChecker = upgrade.NewChecker(updater)
 	}
 
-	err = keeper.SetupWithManager(mgr, zapLogger, upgradeChecker, nil, env.EnablePDB, env.EnableNetworkPolicy)
+	err = keeper.SetupWithManager(
+		mgr, zapLogger, upgradeChecker, nil, env.EnablePDB, env.EnableNetworkPolicy, env.ResyncPeriod)
 	if err != nil {
 		return fmt.Errorf("unable to setup KeeperCluster controller: %w", err)
 	}
 
-	err = clickhouse.SetupWithManager(mgr, zapLogger, upgradeChecker, nil, env.EnablePDB, env.EnableNetworkPolicy)
+	err = clickhouse.SetupWithManager(
+		mgr, zapLogger, upgradeChecker, nil, env.EnablePDB, env.EnableNetworkPolicy, env.ResyncPeriod)
 	if err != nil {
 		return fmt.Errorf("unable to setup ClickHouseCluster controller: %w", err)
 	}

--- a/docs/guides/configuration.mdx
+++ b/docs/guides/configuration.mdx
@@ -977,3 +977,16 @@ spec:
         key: password
         name: default-password
 ```
+
+## Periodic resync {#periodic-resync}
+
+Besides reacting to Kubernetes events, the operator re-reconciles every cluster on a fixed interval. This keeps status conditions fresh for state that no watch can observe — ClickHouse replica health, Keeper quorum — and retries remediation such as stuck-pod cleanup.
+
+The interval is controlled by the operator's `RESYNC_PERIOD` environment variable (default `30s`). It applies to `KeeperCluster` resources, where `0` disables the periodic resync. `ClickHouseCluster` resources poll ClickHouse `system.warnings` every 30 seconds, which already re-triggers reconciliation, so `RESYNC_PERIOD` currently has no effect on them.
+
+```yaml
+# in the operator Deployment spec
+env:
+- name: RESYNC_PERIOD
+  value: "1m"
+```

--- a/docs/styles/config/vocabularies/ClickHouse/accept.txt
+++ b/docs/styles/config/vocabularies/ClickHouse/accept.txt
@@ -39,3 +39,4 @@ Cilium
 Calico
 CNI
 maxSkew
+[Rr]esyncs?

--- a/internal/controller/clickhouse/commands.go
+++ b/internal/controller/clickhouse/commands.go
@@ -501,6 +501,7 @@ func (cmd *commander) getConn(id v1.ClickHouseReplicaID) (clickhouse.Conn, error
 			Addr:        []string{net.JoinHostPort(cmd.cluster.InternalHostnameByID(id), strconv.FormatInt(int64(PortManagement), 10))},
 			Auth:        cmd.auth,
 			DialContext: cmd.dialer,
+			DialTimeout: dialTimeout,
 		})
 		if err != nil {
 			cmd.log.Error(err, "failed to open ClickHouse connection", "replica_id", id)

--- a/internal/controller/clickhouse/commands_test.go
+++ b/internal/controller/clickhouse/commands_test.go
@@ -98,6 +98,7 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 		chContainers []testcontainers.Container
 		testNetwork  *testcontainers.DockerNetwork
 		cmd          *commander
+		cache        *connCache
 	)
 
 	BeforeAll(func(ctx context.Context) {
@@ -217,7 +218,7 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 		}
 
 		secret := &corev1.Secret{Data: map[string][]byte{SecretKeyManagementPassword: []byte(testPassword)}}
-		cache := newConnCache()
+		cache = newConnCache()
 		cmd = newCommander(logger, &cluster, secret, dialer, cache)
 
 		DeferCleanup(func() {
@@ -348,6 +349,17 @@ var _ = Describe("commander", Ordered, Label("integration"), func() {
 			Expect(row.Scan(&count)).To(Succeed())
 			Expect(count).To(Equal(uint64(10)))
 		}
+	})
+
+	It("should evict a single replica connection from the cache", func(_ context.Context) {
+		id := v1.ClickHouseReplicaID{ShardID: 0, Index: 0}
+
+		_, err := cmd.getConn(id)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cmd.entry.conns).To(HaveKey(id))
+
+		cache.EvictReplica(cmd.cluster.NamespacedName(), id, cmd.log)
+		Expect(cmd.entry.conns).NotTo(HaveKey(id))
 	})
 
 	Describe("CleanupDatabaseReplicas", Ordered, func() {

--- a/internal/controller/clickhouse/conncache.go
+++ b/internal/controller/clickhouse/conncache.go
@@ -69,6 +69,31 @@ func (c *connCache) Evict(key types.NamespacedName, log controllerutil.Logger) {
 	}
 }
 
+func (c *connCache) EvictReplica(key types.NamespacedName, id v1.ClickHouseReplicaID, log controllerutil.Logger) {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	e, ok := c.entries[key]
+	c.mu.Unlock()
+
+	if !ok {
+		return
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if conn, ok := e.conns[id]; ok {
+		if err := conn.Close(); err != nil {
+			log.Warn("error closing pooled connection", "error", err, "replica_id", id)
+		}
+
+		delete(e.conns, id)
+	}
+}
+
 func (c *connCache) Close(log controllerutil.Logger) {
 	if c == nil {
 		return

--- a/internal/controller/clickhouse/constants.go
+++ b/internal/controller/clickhouse/constants.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/blang/semver/v4"
 
@@ -78,6 +79,11 @@ const (
 	// NamedCollectionsKeyByteLen and DiskEncryptionKeyByteLen are AES-128 key sizes in bytes (16 bytes = 32 hex chars).
 	NamedCollectionsKeyByteLen = 16
 	DiskEncryptionKeyByteLen   = 16
+
+	dialTimeout         = 10 * time.Second
+	databaseOpsTimeout  = time.Minute
+	databaseSyncTimeout = 10 * time.Minute
+	shardSyncTimeout    = 10 * time.Minute
 )
 
 type secretSpec struct {

--- a/internal/controller/clickhouse/controller.go
+++ b/internal/controller/clickhouse/controller.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -40,6 +41,7 @@ type ClusterController struct {
 	Dialer              controllerutil.DialContextFunc
 	EnablePDB           bool
 	EnableNetworkPolicy bool
+	ResyncPeriod        time.Duration
 	connCache           *connCache
 }
 
@@ -130,6 +132,7 @@ func (cc *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (c
 		Checker:             cc.Checker,
 		EnablePDB:           cc.EnablePDB,
 		EnableNetworkPolicy: cc.EnableNetworkPolicy,
+		ResyncPeriod:        cc.ResyncPeriod,
 		connCache:           cc.connCache,
 
 		Cluster:      cluster,
@@ -167,7 +170,7 @@ func (cc *ClusterController) GetDialer() controllerutil.DialContextFunc {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker, dialer controllerutil.DialContextFunc, enablePDB, enableNetworkPolicy bool) error {
+func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker, dialer controllerutil.DialContextFunc, enablePDB, enableNetworkPolicy bool, resyncPeriod time.Duration) error {
 	namedLogger := log.Named("clickhouse")
 
 	clickhouseController := &ClusterController{
@@ -180,6 +183,7 @@ func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgr
 		Dialer:              dialer,
 		EnablePDB:           enablePDB,
 		EnableNetworkPolicy: enableNetworkPolicy,
+		ResyncPeriod:        resyncPeriod,
 		connCache:           newConnCache(),
 	}
 

--- a/internal/controller/clickhouse/controller_test.go
+++ b/internal/controller/clickhouse/controller_test.go
@@ -479,6 +479,60 @@ var _ = When("reconciling ClickHouseCluster", Ordered, func() {
 		Expect(secret.Data[SecretKeyManagementPassword]).NotTo(BeEmpty())
 	})
 
+	It("should restore a removed cluster secret controller reference", func(ctx context.Context) {
+		secret := secrets.Items[0]
+		secretKey := types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}
+		Expect(suite.Client.Get(ctx, secretKey, &secret)).To(Succeed())
+
+		By("stripping the owner references")
+
+		secret.OwnerReferences = nil
+		Expect(suite.Client.Update(ctx, &secret)).To(Succeed())
+
+		_, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: cr.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(suite.Client.Get(ctx, secretKey, &secret)).To(Succeed())
+		owner := metav1.GetControllerOf(&secret)
+		Expect(owner).NotTo(BeNil())
+		Expect(owner.UID).To(Equal(cr.UID))
+	})
+
+	It("should tolerate a foreign controller owner on the cluster secret", func(ctx context.Context) {
+		secret := secrets.Items[0]
+		secretKey := types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}
+		Expect(suite.Client.Get(ctx, secretKey, &secret)).To(Succeed())
+
+		By("replacing the controller reference with a foreign owner")
+
+		secret.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion:         "v1",
+			Kind:               "ConfigMap",
+			Name:               "foreign-owner",
+			UID:                "11111111-1111-1111-1111-111111111111",
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}}
+		Expect(suite.Client.Update(ctx, &secret)).To(Succeed())
+
+		By("reconciling without error and without adoption")
+
+		_, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: cr.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(suite.Client.Get(ctx, secretKey, &secret)).To(Succeed())
+		owner := metav1.GetControllerOf(&secret)
+		Expect(owner).NotTo(BeNil())
+		Expect(owner.Name).To(Equal("foreign-owner"))
+
+		By("restoring operator ownership for subsequent specs")
+
+		secret.OwnerReferences = nil
+		Expect(suite.Client.Update(ctx, &secret)).To(Succeed())
+		_, err = controller.Reconcile(ctx, ctrl.Request{NamespacedName: cr.NamespacedName()})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("should reflect configuration changes in revisions", func(ctx context.Context) {
 		updatedCR := cr.DeepCopy()
 		Expect(suite.Client.Get(ctx, cr.NamespacedName(), updatedCR)).To(Succeed())

--- a/internal/controller/clickhouse/sync.go
+++ b/internal/controller/clickhouse/sync.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	runtimeutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1 "github.com/ClickHouse/clickhouse-operator/api/v1alpha1"
 	chctrl "github.com/ClickHouse/clickhouse-operator/internal/controller"
@@ -106,6 +107,7 @@ type clickhouseReconciler struct {
 	Checker             *upgrade.Checker
 	EnablePDB           bool
 	EnableNetworkPolicy bool
+	ResyncPeriod        time.Duration
 	connCache           *connCache
 
 	Cluster      *v1.ClickHouseCluster
@@ -167,16 +169,6 @@ func (r *clickhouseReconciler) sync(ctx context.Context, log ctrlutil.Logger) (c
 
 	result, err := chctrl.RunSteps(ctx, log, steps)
 	if err != nil {
-		if k8serrors.IsConflict(err) {
-			log.Error(err, "update conflict for resource, reschedule to retry")
-			return ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
-		}
-
-		if k8serrors.IsAlreadyExists(err) {
-			log.Error(err, "create already existed resource, reschedule to retry")
-			return ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
-		}
-
 		log.Error(err, "unexpected error, setting conditions to unknown and rescheduling reconciliation to try again")
 
 		r.SetCondition(metav1.Condition{
@@ -193,6 +185,8 @@ func (r *clickhouseReconciler) sync(ctx context.Context, log ctrlutil.Logger) (c
 		return ctrl.Result{}, fmt.Errorf("reconcile steps: %w", err)
 	}
 
+	r.Cluster.Status.ObservedGeneration = r.Cluster.Generation
+
 	r.SetCondition(metav1.Condition{
 		Type:    v1.ConditionTypeReconcileSucceeded,
 		Status:  metav1.ConditionTrue,
@@ -203,6 +197,10 @@ func (r *clickhouseReconciler) sync(ctx context.Context, log ctrlutil.Logger) (c
 
 	if err := r.UpsertStatus(ctx, log); err != nil {
 		return ctrl.Result{}, fmt.Errorf("update status after reconciliation: %w", err)
+	}
+
+	if result.IsZero() {
+		result.RequeueAfter = r.ResyncPeriod
 	}
 
 	return result, nil
@@ -288,16 +286,26 @@ func (r *clickhouseReconciler) reconcileClusterSecret(ctx context.Context, log c
 		return chctrl.StepBlocked(chctrl.RequeueProbePoll), nil
 	}
 
-	var isSecretUpdated bool
+	var hasUpdates bool
 
-	r.secret, isSecretUpdated = templateClusterSecrets(r.Cluster, r.secret)
-	if !isSecretUpdated {
+	r.secret, hasUpdates = templateClusterSecrets(r.Cluster, r.secret)
+	if !hasUpdates && metav1.IsControlledBy(&r.secret, r.Cluster) {
 		log.Debug("cluster secret is up to date")
 		return chctrl.StepContinue(), nil
 	}
 
 	if err := ctrl.SetControllerReference(r.Cluster, &r.secret, r.GetScheme()); err != nil {
-		return chctrl.StepResult{}, fmt.Errorf("set controller reference for cluster secret %q: %w", r.Cluster.SecretName(), err)
+		var alreadyOwned *runtimeutil.AlreadyOwnedError
+		if !errors.As(err, &alreadyOwned) {
+			return chctrl.StepResult{}, fmt.Errorf("set controller reference for cluster secret %q: %w", r.Cluster.SecretName(), err)
+		}
+
+		if !hasUpdates {
+			return chctrl.StepContinue(), nil
+		}
+
+		log.Warn("cluster secret has a foreign controller owner, updating content without adoption",
+			"owner", alreadyOwned.Owner.Kind+"/"+alreadyOwned.Owner.Name)
 	}
 
 	// Create or recreate commander with new credentials
@@ -604,11 +612,6 @@ func (r *clickhouseReconciler) reconcileWarnings(ctx context.Context, log ctrlut
 }
 
 func (r *clickhouseReconciler) reconcileClusterRevisions(ctx context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	if r.Cluster.Status.ObservedGeneration != r.Cluster.Generation {
-		r.Cluster.Status.ObservedGeneration = r.Cluster.Generation
-		log.Debug(fmt.Sprintf("observed new CR generation %d", r.Cluster.Generation))
-	}
-
 	updateRevision, err := ctrlutil.DeepHashObject(r.Cluster.Spec)
 	if err != nil {
 		return chctrl.StepResult{}, fmt.Errorf("get current spec revision: %w", err)
@@ -843,7 +846,10 @@ func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ct
 			return id, true, nil
 		}
 
-		replicated, err := r.commander.EnsureReplicaDefaultDatabaseEngine(ctx, log, id)
+		opCtx, cancel := context.WithTimeout(ctx, databaseOpsTimeout)
+		defer cancel()
+
+		replicated, err := r.commander.EnsureReplicaDefaultDatabaseEngine(opCtx, log, id)
 
 		return id, replicated, err
 	})
@@ -866,10 +872,13 @@ func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ct
 	schemaSynced := true
 
 	if len(r.reachableReplicas) >= 2 {
-		if !r.commander.SyncDatabases(ctx, log, r.reachableReplicas) {
+		syncCtx, cancel := context.WithTimeout(ctx, databaseSyncTimeout)
+		if !r.commander.SyncDatabases(syncCtx, log, r.reachableReplicas) {
 			schemaSynced = false
 			allDatabasesSynced = false
 		}
+
+		cancel()
 	} else {
 		log.Info("no replicas to replicate schema, skipping")
 	}
@@ -882,11 +891,14 @@ func (r *clickhouseReconciler) reconcileDatabaseSync(ctx context.Context, log ct
 	runningReplicas := r.syncShardsPendingRemoval(ctx, log, drainingShards)
 
 	if len(r.reachableReplicas) > 0 {
-		if err := r.commander.CleanupDatabaseReplicas(ctx, log, runningReplicas); err != nil {
+		cleanupCtx, cancel := context.WithTimeout(ctx, databaseOpsTimeout)
+		if err := r.commander.CleanupDatabaseReplicas(cleanupCtx, log, runningReplicas); err != nil {
 			log.Warn("failed to cleanup database replicas", "error", err)
 
 			staleReplicasCleanedUp = false
 		}
+
+		cancel()
 	}
 
 	switch {
@@ -1061,7 +1073,11 @@ func (r *clickhouseReconciler) syncShardsPendingRemoval(ctx context.Context, log
 
 	syncRes := ctrlutil.ExecuteParallel(slices.Collect(maps.Keys(shardsToSyncSet)), func(shardID int32) (int32, struct{}, error) {
 		log.Info("pre scale-down shard sync", "shard_id", shardID)
-		return shardID, struct{}{}, r.commander.SyncShard(ctx, log, shardID)
+
+		syncCtx, cancel := context.WithTimeout(ctx, shardSyncTimeout)
+		defer cancel()
+
+		return shardID, struct{}{}, r.commander.SyncShard(syncCtx, log, shardID)
 	})
 
 	for id, res := range syncRes {
@@ -1165,6 +1181,8 @@ func (r *clickhouseReconciler) reconcileCleanUp(ctx context.Context, log ctrluti
 				log.Error(err, "failed to delete replica service", "replica_id", id, "service", res.Service.Name)
 			}
 		}
+
+		r.connCache.EvictReplica(r.Cluster.NamespacedName(), id, log)
 	}
 
 	return chctrl.StepContinue(), nil

--- a/internal/controller/keeper/controller.go
+++ b/internal/controller/keeper/controller.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +39,7 @@ type ClusterController struct {
 	Dialer              controllerutil.DialContextFunc
 	EnablePDB           bool
 	EnableNetworkPolicy bool
+	ResyncPeriod        time.Duration
 }
 
 // +kubebuilder:rbac:groups=clickhouse.com,resources=keeperclusters,verbs=get;list;watch;create;update;patch;delete
@@ -114,6 +116,7 @@ func (cc *ClusterController) Reconcile(ctx context.Context, req ctrl.Request) (c
 		Checker:             cc.Checker,
 		EnablePDB:           cc.EnablePDB,
 		EnableNetworkPolicy: cc.EnableNetworkPolicy,
+		ResyncPeriod:        cc.ResyncPeriod,
 
 		Cluster:      cluster,
 		ReplicaState: map[v1.KeeperReplicaID]replicaState{},
@@ -162,7 +165,7 @@ func keeperClustersForClickHouse(_ context.Context, obj client.Object) []reconci
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker, dialer controllerutil.DialContextFunc, enablePDB, enableNetworkPolicy bool) error {
+func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgrade.Checker, dialer controllerutil.DialContextFunc, enablePDB, enableNetworkPolicy bool, resyncPeriod time.Duration) error {
 	namedLogger := log.Named("keeper")
 
 	keeperController := &ClusterController{
@@ -175,14 +178,14 @@ func SetupWithManager(mgr ctrl.Manager, log controllerutil.Logger, checker *upgr
 		Dialer:              dialer,
 		EnablePDB:           enablePDB,
 		EnableNetworkPolicy: enableNetworkPolicy,
+		ResyncPeriod:        resyncPeriod,
 	}
 
 	controllerBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1.KeeperCluster{}, builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}, predicate.AnnotationChangedPredicate{}))).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
-		Owns(&corev1.Service{}).
-		Owns(&corev1.Pod{})
+		Owns(&corev1.Service{})
 
 	if enableNetworkPolicy {
 		controllerBuilder = controllerBuilder.

--- a/internal/controller/keeper/controller_test.go
+++ b/internal/controller/keeper/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -77,7 +78,8 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 			Dialer: func(context.Context, string) (net.Conn, error) {
 				return nil, errors.New("disabled")
 			},
-			EnablePDB: true,
+			EnablePDB:    true,
+			ResyncPeriod: 30 * time.Second,
 		}
 	})
 
@@ -176,8 +178,9 @@ var _ = When("reconciling standalone KeeperCluster resource", Ordered, func() {
 		By("reconciling the unchanged cluster repeatedly")
 
 		for range 5 {
-			_, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: cr.NamespacedName()})
+			result, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: cr.NamespacedName()})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0), "with a resync period set, every reconcile must schedule a wake-up")
 		}
 
 		Expect(collect()).To(Equal(before), "repeated reconciles must not update any resource")

--- a/internal/controller/keeper/sync.go
+++ b/internal/controller/keeper/sync.go
@@ -86,6 +86,7 @@ type keeperReconciler struct {
 	Checker             *upgrade.Checker
 	EnablePDB           bool
 	EnableNetworkPolicy bool
+	ResyncPeriod        time.Duration
 
 	Cluster      *v1.KeeperCluster
 	ReplicaState map[v1.KeeperReplicaID]replicaState
@@ -131,16 +132,6 @@ func (r *keeperReconciler) sync(ctx context.Context, log ctrlutil.Logger) (ctrl.
 
 	result, err := chctrl.RunSteps(ctx, log, steps)
 	if err != nil {
-		if k8serrors.IsConflict(err) {
-			log.Error(err, "update conflict for resource, reschedule to retry")
-			return ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
-		}
-
-		if k8serrors.IsAlreadyExists(err) {
-			log.Error(err, "create already existed resource, reschedule to retry")
-			return ctrl.Result{RequeueAfter: chctrl.RequeueOnRefreshTimeout}, nil
-		}
-
 		log.Error(err, "unexpected error, setting conditions to unknown and rescheduling reconciliation to try again")
 
 		r.SetCondition(metav1.Condition{Type: v1.ConditionTypeReconcileSucceeded, Status: metav1.ConditionFalse, Reason: v1.ConditionReasonStepFailed, Message: "Reconcile returned error"})
@@ -152,6 +143,8 @@ func (r *keeperReconciler) sync(ctx context.Context, log ctrlutil.Logger) (ctrl.
 		return ctrl.Result{}, fmt.Errorf("reconcile steps: %w", err)
 	}
 
+	r.Cluster.Status.ObservedGeneration = r.Cluster.Generation
+
 	r.SetCondition(metav1.Condition{Type: v1.ConditionTypeReconcileSucceeded, Status: metav1.ConditionTrue, Reason: v1.ConditionReasonReconcileFinished, Message: "Reconcile succeeded"})
 	log.Info("reconciliation loop end", "result", result)
 
@@ -159,15 +152,14 @@ func (r *keeperReconciler) sync(ctx context.Context, log ctrlutil.Logger) (ctrl.
 		return ctrl.Result{}, fmt.Errorf("update status after reconciliation: %w", err)
 	}
 
+	if result.IsZero() {
+		result.RequeueAfter = r.ResyncPeriod
+	}
+
 	return result, nil
 }
 
 func (r *keeperReconciler) reconcileClusterRevisions(_ context.Context, log ctrlutil.Logger) (chctrl.StepResult, error) {
-	if r.Cluster.Status.ObservedGeneration != r.Cluster.Generation {
-		r.Cluster.Status.ObservedGeneration = r.Cluster.Generation
-		log.Debug(fmt.Sprintf("observed new CR generation %d", r.Cluster.Generation))
-	}
-
 	updateRevision, err := ctrlutil.DeepHashObject(r.Cluster.Spec)
 	if err != nil {
 		return chctrl.StepResult{}, fmt.Errorf("get current spec revision: %w", err)

--- a/internal/controller/resourcemanager.go
+++ b/internal/controller/resourcemanager.go
@@ -99,8 +99,8 @@ func (rm *ResourceManager) ReconcileResource(
 
 	log.Debug("resource changed, diff: " + gcmp.Diff(foundResource, resource, diffFilter(specFields)))
 
-	foundResource.SetAnnotations(resource.GetAnnotations())
-	foundResource.SetLabels(resource.GetLabels())
+	foundResource.SetAnnotations(util.MergeMaps(foundResource.GetAnnotations(), resource.GetAnnotations()))
+	foundResource.SetLabels(util.MergeMaps(foundResource.GetLabels(), resource.GetLabels()))
 
 	for _, fieldName := range specFields {
 		field := reflect.ValueOf(foundResource).Elem().FieldByName(fieldName)

--- a/internal/controller/step.go
+++ b/internal/controller/step.go
@@ -69,6 +69,10 @@ func RunSteps(ctx context.Context, log controllerutil.Logger, steps []ReconcileS
 
 		if sr.Blocked {
 			blocked = true
+
+			if sr.RequeueAfter == 0 {
+				sr.RequeueAfter = RequeueProbePoll
+			}
 		}
 
 		if sr.RequeueAfter > 0 {

--- a/internal/controller/step_test.go
+++ b/internal/controller/step_test.go
@@ -1,0 +1,89 @@
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/ClickHouse/clickhouse-operator/internal/controllerutil"
+)
+
+var _ = Describe("RunSteps", func() {
+	log := controllerutil.NewLogger(zap.NewRaw(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	step := func(name string, sr StepResult) ReconcileStep {
+		return ReconcileStep{
+			Name: name,
+			Fn:   func(context.Context, controllerutil.Logger) (StepResult, error) { return sr, nil },
+		}
+	}
+
+	It("should return the minimum RequeueAfter across steps", func(ctx context.Context) {
+		result, err := RunSteps(ctx, log, []ReconcileStep{
+			step("a", StepRequeue(30*time.Second)),
+			step("b", StepRequeue(5*time.Second)),
+			step("c", StepContinue()),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+	})
+
+	It("should skip non-Always steps after a blocked step", func(ctx context.Context) {
+		var ran []string
+
+		record := func(name string, sr StepResult, always bool) ReconcileStep {
+			return ReconcileStep{
+				Name: name,
+				Fn: func(context.Context, controllerutil.Logger) (StepResult, error) {
+					ran = append(ran, name)
+					return sr, nil
+				},
+				Always: always,
+			}
+		}
+
+		result, err := RunSteps(ctx, log, []ReconcileStep{
+			record("blocking", StepBlocked(RequeueProbePoll), false),
+			record("skipped", StepContinue(), false),
+			record("always", StepContinue(), true),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ran).To(Equal([]string{"blocking", "always"}))
+		Expect(result.RequeueAfter).To(Equal(RequeueProbePoll))
+	})
+
+	It("should guarantee a wake-up for a blocked step without RequeueAfter", func(ctx context.Context) {
+		result, err := RunSteps(ctx, log, []ReconcileStep{
+			step("blocking", StepResult{Blocked: true}),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(Equal(RequeueProbePoll))
+	})
+
+	It("should stop on the first error", func(ctx context.Context) {
+		var ran []string
+
+		_, err := RunSteps(ctx, log, []ReconcileStep{
+			step("ok", StepContinue()),
+			{
+				Name: "failing",
+				Fn: func(context.Context, controllerutil.Logger) (StepResult, error) {
+					ran = append(ran, "failing")
+					return StepResult{}, context.DeadlineExceeded
+				},
+			},
+			{
+				Name: "unreached",
+				Fn: func(context.Context, controllerutil.Logger) (StepResult, error) {
+					ran = append(ran, "unreached")
+					return StepContinue(), nil
+				},
+			},
+		})
+		Expect(err).To(MatchError(context.DeadlineExceeded))
+		Expect(ran).To(Equal([]string{"failing"}))
+	})
+})

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -3,16 +3,18 @@ package environment
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/sethvargo/go-envconfig"
 )
 
 // Environment holds all environment variables for the application.
 type Environment struct {
-	EnableWebhooks      bool     `env:"ENABLE_WEBHOOKS, default=true"`
-	EnablePDB           bool     `env:"ENABLE_PDB, default=true"`
-	EnableNetworkPolicy bool     `env:"ENABLE_NETWORK_POLICY, default=true"`
-	WatchNamespace      []string `env:"WATCH_NAMESPACE"`
+	EnableWebhooks      bool          `env:"ENABLE_WEBHOOKS, default=true"`
+	EnablePDB           bool          `env:"ENABLE_PDB, default=true"`
+	EnableNetworkPolicy bool          `env:"ENABLE_NETWORK_POLICY, default=true"`
+	WatchNamespace      []string      `env:"WATCH_NAMESPACE"`
+	ResyncPeriod        time.Duration `env:"RESYNC_PERIOD, default=30s"`
 }
 
 // GetEnvironment processes environment variables and returns an Environment struct.

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,6 +30,7 @@ var _ = DescribeTable("Environment variables parsing",
 		EnablePDB:           true,
 		EnableNetworkPolicy: true,
 		WatchNamespace:      nil,
+		ResyncPeriod:        30 * time.Second,
 	}),
 	Entry("explicit enabled webhook", map[string]string{
 		"ENABLE_WEBHOOKS": "true",
@@ -36,6 +38,7 @@ var _ = DescribeTable("Environment variables parsing",
 		EnableWebhooks:      true,
 		EnablePDB:           true,
 		EnableNetworkPolicy: true,
+		ResyncPeriod:        30 * time.Second,
 	}),
 	Entry("explicit disabled webhook", map[string]string{
 		"ENABLE_WEBHOOKS": "false",
@@ -43,6 +46,7 @@ var _ = DescribeTable("Environment variables parsing",
 		EnableWebhooks:      false,
 		EnablePDB:           true,
 		EnableNetworkPolicy: true,
+		ResyncPeriod:        30 * time.Second,
 	}),
 	Entry("explicit disabled PDB management", map[string]string{
 		"ENABLE_PDB": "false",
@@ -50,6 +54,7 @@ var _ = DescribeTable("Environment variables parsing",
 		EnableWebhooks:      true,
 		EnablePDB:           false,
 		EnableNetworkPolicy: true,
+		ResyncPeriod:        30 * time.Second,
 	}),
 	Entry("parse single namespace", map[string]string{
 		"WATCH_NAMESPACE": "target_namespace",
@@ -58,6 +63,7 @@ var _ = DescribeTable("Environment variables parsing",
 		EnablePDB:           true,
 		EnableNetworkPolicy: true,
 		WatchNamespace:      []string{"target_namespace"},
+		ResyncPeriod:        30 * time.Second,
 	}),
 	Entry("parse multiple namespace", map[string]string{
 		"WATCH_NAMESPACE": "target,namespace",
@@ -66,9 +72,26 @@ var _ = DescribeTable("Environment variables parsing",
 		EnablePDB:           true,
 		EnableNetworkPolicy: true,
 		WatchNamespace:      []string{"target", "namespace"},
+		ResyncPeriod:        30 * time.Second,
 	}),
 	Entry("empty namespace behaves as not set", map[string]string{
 		"WATCH_NAMESPACE": "",
+	}, Environment{
+		EnableWebhooks:      true,
+		EnablePDB:           true,
+		EnableNetworkPolicy: true,
+		ResyncPeriod:        30 * time.Second,
+	}),
+	Entry("explicit resync period", map[string]string{
+		"RESYNC_PERIOD": "5m",
+	}, Environment{
+		EnableWebhooks:      true,
+		EnablePDB:           true,
+		EnableNetworkPolicy: true,
+		ResyncPeriod:        5 * time.Minute,
+	}),
+	Entry("zero resync period disables periodic reconciliation", map[string]string{
+		"RESYNC_PERIOD": "0",
 	}, Environment{
 		EnableWebhooks:      true,
 		EnablePDB:           true,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -141,8 +141,9 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	Expect(mgr.Add(updater)).To(Succeed())
 
 	upgradeChecker := upgrade.NewChecker(updater)
-	Expect(keeper.SetupWithManager(mgr, zapLogger, upgradeChecker, podDialer, true, true)).To(Succeed())
-	Expect(clickhouse.SetupWithManager(mgr, zapLogger, upgradeChecker, podDialer, true, true)).To(Succeed())
+	Expect(keeper.SetupWithManager(mgr, zapLogger, upgradeChecker, podDialer, true, true, 30*time.Second)).To(Succeed())
+	Expect(clickhouse.SetupWithManager(
+		mgr, zapLogger, upgradeChecker, podDialer, true, true, 30*time.Second)).To(Succeed())
 	// +kubebuilder:scaffold:builder
 
 	mgrCtx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Why

The reconcile loop misses a few basic patterns. Keeper never re-checks quorum without a Kubernetes event, observedGeneration advances even on failing passes, update conflicts bypass the workqueue backoff, and ClickHouse calls run unbounded on the single reconcile worker.

## What

New `RESYNC_PERIOD` env (default 30s, 0 disables)
Blocked steps without a RequeueAfter default to the probe poll. observedGeneration is set only after an error-free pass. 
ClickHouse connections get timeouts, and the deleted replica connection is evicted from the cache.
Reoncile cluster-secret owner.
Fix keeper controller triggers
Configure graceful shutdown of the controller