### PR TITLE
feat: Aggregate helper cluster roles (#324)

### DIFF
--- a/dist/chart/templates/rbac/clickhousecluster-admin-role.yaml
+++ b/dist/chart/templates/rbac/clickhousecluster-admin-role.yaml
@@ -14,6 +14,9 @@ metadata:
     app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.rbac.helpers.aggregateRoles.admin and not (.Values.rbac.namespaced) }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- end }}
   name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "clickhousecluster-admin-role" "context" $) }}
 rules:
 - apiGroups:

--- a/dist/chart/templates/rbac/clickhousecluster-editor-role.yaml
+++ b/dist/chart/templates/rbac/clickhousecluster-editor-role.yaml
@@ -14,6 +14,9 @@ metadata:
     app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.rbac.helpers.aggregateRoles.editor and not (.Values.rbac.namespaced) }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{- end }}
   name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "clickhousecluster-editor-role" "context" $) }}
 rules:
 - apiGroups:

--- a/dist/chart/templates/rbac/clickhousecluster-viewer-role.yaml
+++ b/dist/chart/templates/rbac/clickhousecluster-viewer-role.yaml
@@ -14,6 +14,9 @@ metadata:
     app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.rbac.helpers.aggregateRoles.viewer and not (.Values.rbac.namespaced) }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- end }}
   name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "clickhousecluster-viewer-role" "context" $) }}
 rules:
 - apiGroups:

--- a/dist/chart/templates/rbac/keepercluster-admin-role.yaml
+++ b/dist/chart/templates/rbac/keepercluster-admin-role.yaml
@@ -14,6 +14,9 @@ metadata:
     app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.rbac.helpers.aggregateRoles.admin and not (.Values.rbac.namespaced) }}
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    {{- end }}
   name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "keepercluster-admin-role" "context" $) }}
 rules:
 - apiGroups:

--- a/dist/chart/templates/rbac/keepercluster-editor-role.yaml
+++ b/dist/chart/templates/rbac/keepercluster-editor-role.yaml
@@ -14,6 +14,9 @@ metadata:
     app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.rbac.helpers.aggregateRoles.editor and not (.Values.rbac.namespaced) }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    {{- end }}
   name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "keepercluster-editor-role" "context" $) }}
 rules:
 - apiGroups:

--- a/dist/chart/templates/rbac/keepercluster-viewer-role.yaml
+++ b/dist/chart/templates/rbac/keepercluster-viewer-role.yaml
@@ -14,6 +14,9 @@ metadata:
     app.kubernetes.io/name: {{ include "clickhouse-operator.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.rbac.helpers.aggregateRoles.viewer and not (.Values.rbac.namespaced) }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    {{- end }}
   name: {{ include "clickhouse-operator.resourceName" (dict "suffix" "keepercluster-viewer-role" "context" $) }}
 rules:
 - apiGroups:

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -184,6 +184,10 @@ rbac:
     ## Install convenience admin/editor/viewer roles for CRDs
     ##
     enabled: false
+    aggregateRoles:
+      admin: true
+      editor: true
+      viewer: true
 
 ## ServiceAccount configuration
 ##


### PR DESCRIPTION
## Why

To ease CRD RBAC management in k8s cluster.

## What

Label helper Cluster Roles created by the operator with:

- `rbac.authorization.k8s.io/aggregate-to-view: "true"`
- `rbac.authorization.k8s.io/aggregate-to-edit: "true"`
- `rbac.authorization.k8s.io/aggregate-to-admin: "true"`

## Related Issues

Fixes #324 
Related to #324
